### PR TITLE
Re-consider graceful shutdown

### DIFF
--- a/access/slackbot/slackbot_test.go
+++ b/access/slackbot/slackbot_test.go
@@ -96,6 +96,7 @@ func (s *SlackbotSuite) SetUpTest(c *C) {
 
 func (s *SlackbotSuite) TearDownTest(c *C) {
 	s.app.Stop()
+	s.app.Wait()
 	s.slackServer.Stop()
 }
 
@@ -126,9 +127,10 @@ func (s *SlackbotSuite) startApp(c *C) {
 	conf.Slack.APIURL = "http://" + s.slackServer.ServerAddr + "/"
 	conf.Slack.Listen = ":" + s.appPort
 
-	s.app, err = NewAppWithTLSConfig(context.TODO(), &tc, conf)
+	s.app, err = NewAppWithTLSConfig(conf, &tc)
 	c.Assert(err, IsNil)
-	s.app.Start()
+	err = s.app.Start(context.TODO())
+	c.Assert(err, IsNil)
 }
 
 func (s *SlackbotSuite) createAccessRequest(c *C) services.AccessRequest {


### PR DESCRIPTION
- Dispatch OS signals to do graceful/fast shutdown.
- `App.Wait()` now really waits for everything to finish using WaitGroup/Cond.
- `App.Close()` does the force shutdown.
- `ctx` is removed as a struct member. Passing it as a parameter instead.

Don't know good it or not but App is now fully re-startable so we can do `Start()`/`Wait()` with something like exponential backoff.
@fspmarshall what do you think?