### PR TITLE
Reconnect watcher when the stream closes or server shuts down

### DIFF
--- a/access/slackbot/slackbot_test.go
+++ b/access/slackbot/slackbot_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	Loopback    = "127.0.0.1"
 	Host        = "localhost"
 	HostID      = "00000000-0000-0000-0000-000000000000"
 	Site        = "local-site"
@@ -50,6 +49,7 @@ var _ = Suite(&SlackbotSuite{})
 func TestSlackbot(t *testing.T) { TestingT(t) }
 
 func (s *SlackbotSuite) SetUpSuite(c *C) {
+	var err error
 	log.SetLevel(log.DebugLevel)
 	priv, pub, err := testauthority.New().GenerateKeyPair("")
 	c.Assert(err, IsNil)
@@ -80,7 +80,8 @@ func (s *SlackbotSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	t.AddUserWithRole("plugin", accessPluginRole)
 
-	t.Create(nil, true, nil)
+	err = t.Create(nil, true, nil)
+	c.Assert(err, IsNil)
 	if err := t.Start(); err != nil {
 		c.Fatalf("Unexpected response from Start: %v", err)
 	}


### PR DESCRIPTION
Closes #2.

There're two cases when watcher stream could be closed:

- When the cached enabled for Auth Server. It initiates stream closing every 600 seconds. We check this case using `IsEOF(err)`.
- When Auth Server goes offline. Then we should start another watcher. We check this case using `IsConnectionProblem(err)`.

Further, we should consider doing `GetRequests(PENDING)` after every successful reconnection not to miss any requests created between disconnection and reconnection. Not sure how to do this using the current API though. Must we fetch all the pending requests and match them against their presence in the cache? How we can be sure that there's not so large amount of records?

Another thing I want to discuss is that I've set `grpc.WaitForReady(true)` as a default call option for all the grpc calls. It's disabled by default in the grpc library, and as a library's default it's totally sane, but since the `access` package is a wrapper, it could be convenient to not have disconnection errors on every call. With this setting, if server goes offline the call like `GetRequest()` would block, but it's a caller's responsibility to control it using a `ctx` with timeout. You can see how I do this for the entire incoming http request and return 503 code in the case when timeout is exceeded. Perhaps, we should even change 503 to 200 and answer to the user with a slack *ephemeral* message saying "I'm sorry, Teleport is offline, cannot process your request". Please let me know what do you think about setting `WaitForReady(true)` as a default option for the `access` package!