### PR TITLE
Refactor App & add some documentation

### DIFF
--- a/access/slackbot/callback_server.go
+++ b/access/slackbot/callback_server.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/gravitational/teleport-plugins/access"
+	"github.com/nlopes/slack"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// ActionApprove uniquely identifies the approve button in events.
+	ActionApprove = "approve_request"
+	// ActionDeny uniquely identifies the deny button in events.
+	ActionDeny = "deny_request"
+)
+
+type CallbackFunc func(ctx context.Context, reqID, actionID, responseURL string) error
+
+// CallbackServer is a wrapper around http.Server that processes Slack interaction events.
+// It verifies incoming requests and calls onCallback for valid ones
+type CallbackServer struct {
+	secret     string
+	onCallback CallbackFunc
+	httpServer *http.Server
+}
+
+func NewCallbackServer(ctx context.Context, conf *Config, onCallback CallbackFunc) *CallbackServer {
+	s := CallbackServer{
+		secret:     conf.Slack.Secret,
+		onCallback: onCallback,
+	}
+
+	s.httpServer = &http.Server{
+		Addr: conf.Slack.Listen,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			s.processCallback(ctx, rw, r)
+		}),
+	}
+
+	go func() {
+		<-ctx.Done()
+		s.httpServer.Close()
+	}()
+
+	return &s
+}
+
+func (s *CallbackServer) ListenAndServe() error {
+	err := s.httpServer.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+func (s *CallbackServer) Shutdown(ctx context.Context) error {
+	sctx, scancel := context.WithTimeout(ctx, time.Second*20)
+	defer scancel()
+
+	return s.httpServer.Shutdown(sctx)
+}
+
+func (s *CallbackServer) processCallback(ctx context.Context, rw http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(ctx, time.Millisecond*2500) // Slack requires to respond within 3000 milliseconds
+	defer cancel()
+
+	sv, err := slack.NewSecretsVerifier(r.Header, s.secret)
+	if err != nil {
+		log.Errorf("Failed to initialize secrets verifier: %s", err)
+		http.Error(rw, "verification failed", 500)
+		return
+	}
+	// tee body into verifier as it is read.
+	r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &sv))
+	payload := []byte(r.FormValue("payload"))
+
+	// the FormValue method exhausts the reader, so signature
+	// verification can now proceed.
+	if err := sv.Ensure(); err != nil {
+		log.Errorf("Secret verification failed: %s", err)
+		http.Error(rw, "verification failed", 500)
+		return
+	}
+
+	var cb slack.InteractionCallback
+	if err := json.Unmarshal(payload, &cb); err != nil {
+		log.Errorf("Failed to parse json response: %s", err)
+		http.Error(rw, "failed to parse response", 500)
+		return
+	}
+
+	if len(cb.ActionCallback.BlockActions) != 1 {
+		log.Warnf("Received more than one Slack action: %+v", cb.ActionCallback.BlockActions)
+		http.Error(rw, "expected exactly one block action", 500)
+		return
+	}
+
+	action := cb.ActionCallback.BlockActions[0]
+
+	if err := s.onCallback(ctx, action.Value, action.ActionID, cb.ResponseURL); err != nil {
+		log.Errorf("Failed to process callback: %s", err)
+		var code int
+		switch {
+		case access.IsCanceled(err) || access.IsDeadline(err):
+			code = 503
+		default:
+			code = 500
+		}
+		http.Error(rw, "failed to process callback", code)
+	} else {
+		rw.WriteHeader(http.StatusOK)
+	}
+}

--- a/access/slackbot/config.go
+++ b/access/slackbot/config.go
@@ -30,7 +30,7 @@ const exampleConfig = `# example slackbot configuration file
 [teleport]
 auth-server = "example.com:3025"  # Auth GRPC API address
 client-key = "path/to/client.key" # Teleport GRPC client secret key
-client-crt = "path/to/client.crt" # Teleport GRPC client certificate 
+client-crt = "path/to/client.crt" # Teleport GRPC client certificate
 root-cas = "path/to/root.cas"     # Teleport cluster CA certs
 
 [slack]

--- a/access/slackbot/slack_client.go
+++ b/access/slackbot/slack_client.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gravitational/teleport-plugins/access"
+	"github.com/nlopes/slack"
+	log "github.com/sirupsen/logrus"
+)
+
+// SlackClient is a wrapper around slack.Client that works with access.Request
+type SlackClient struct {
+	client  *slack.Client
+	channel string
+}
+
+func NewSlackClient(conf *Config) *SlackClient {
+	slackOptions := []slack.Option{}
+	if conf.Slack.APIURL != "" {
+		slackOptions = append(slackOptions, slack.OptionAPIURL(conf.Slack.APIURL))
+	}
+
+	return &SlackClient{
+		client:  slack.New(conf.Slack.Token, slackOptions...),
+		channel: conf.Slack.Channel,
+	}
+}
+
+// Post posts request info to Slack with action buttons
+func (c *SlackClient) Post(req access.Request) (channelID, timestamp string, err error) {
+	channelID, timestamp, err = c.client.PostMessage(
+		c.channel,
+		slack.MsgOptionBlocks(
+			msgSection(msgText(req, "PENDING")),
+			actionBlock(req.ID),
+		),
+	)
+
+	return
+}
+
+// Expire updates request's Slack post with EXPIRED status and removes action buttons.
+// TODO: Use ext-data when it's integrated
+func (c *SlackClient) Expire(req access.Request, channelID, timestamp string) error {
+	if len(channelID) == 0 || len(timestamp) == 0 {
+		log.Warningf("can't expire slack message without channel ID or timestamp")
+		return nil
+	}
+
+	_, _, _, err := c.client.UpdateMessage(
+		channelID,
+		timestamp,
+		slack.MsgOptionBlocks(
+			msgSection(msgText(req, "EXPIRED")),
+		),
+	)
+
+	return err
+}
+
+// Respond updates Slack post with the new request info and the new status, and removes action buttons
+func (c *SlackClient) Respond(req access.Request, status string, responseURL string) error {
+	var message slack.Message
+	message.Blocks.BlockSet = []slack.Block{msgSection(msgText(req, status))}
+	message.ReplaceOriginal = true
+
+	body, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("Failed to serialize msg block: %s", err)
+	}
+
+	rsp, err := http.Post(responseURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("Failed to send update: %s", err)
+	}
+
+	rbody, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read update response: %s", err)
+	}
+
+	var ursp struct {
+		Ok bool `json:"ok"`
+	}
+	if err := json.Unmarshal(rbody, &ursp); err != nil {
+		return fmt.Errorf("Failed to parse response body: %s", err)
+	}
+
+	if !ursp.Ok {
+		return fmt.Errorf("Failed to update msg for %+v", req)
+	}
+
+	return nil
+}
+
+// msgText builds the message text payload (contains markdown).
+func msgText(req access.Request, status string) string {
+	b := new(strings.Builder)
+	b.Grow(128)
+
+	fmt.Fprintln(b, "```")
+	msgFieldToBuilder(b, "Request ", req.ID)
+
+	if len(req.User) > 0 {
+		msgFieldToBuilder(b, "User    ", req.User)
+	}
+	if req.Roles != nil {
+		msgFieldToBuilder(b, "Role(s) ", strings.Join(req.Roles, ","))
+	}
+
+	msgFieldToBuilder(b, "Status  ", status)
+	fmt.Fprintln(b, "```")
+
+	return b.String()
+}
+
+func msgFieldToBuilder(b *strings.Builder, field, value string) {
+	b.WriteString(field)
+	b.WriteString(value)
+	b.WriteString("\n")
+}
+
+// msgSection builds a slack message section (obeys markdown).
+func msgSection(msg string) slack.SectionBlock {
+	return slack.SectionBlock{
+		Type: slack.MBTSection,
+		Text: &slack.TextBlockObject{
+			Type: slack.MarkdownType,
+			Text: msg,
+		},
+	}
+}
+
+// actionBlock builds a slack action block for a pending request.
+func actionBlock(reqID string) *slack.ActionBlock {
+	return slack.NewActionBlock(
+		"approve_or_deny",
+		&slack.ButtonBlockElement{
+			Type:     slack.METButton,
+			ActionID: ActionApprove,
+			Text:     slack.NewTextBlockObject("plain_text", "Approve", true, false),
+			Value:    reqID,
+			Style:    slack.StylePrimary,
+		},
+		&slack.ButtonBlockElement{
+			Type:     slack.METButton,
+			ActionID: ActionDeny,
+			Text:     slack.NewTextBlockObject("plain_text", "Deny", true, false),
+			Value:    reqID,
+			Style:    slack.StyleDanger,
+		},
+	)
+}


### PR DESCRIPTION
What I've done here:

- Extracted messaging logic into `SlackClient`.
- Extracted webhook logic into `CallbbackServer`.
- Extracted request management & caching logic into `RequestManager`.
- Added documentation for the most functions and types.

Extracting things from `App` reduced its responsibility and reduced the main file size almost by half.

What do you think?