### PR TITLE
Added install script that copies teleport-slackbot to /usr/local/bin

### DIFF
--- a/access/slackbot/Makefile
+++ b/access/slackbot/Makefile
@@ -37,6 +37,7 @@ release: clean $(VERSRC) $(BINARY)
 	cp -rf $(BINARY) \
 		README.md \
 		CHANGELOG.md \
+		install \
 		$(RELEASE_NAME)/
 	echo $(GITTAG) > $(RELEASE_NAME)/VERSION
 	tar -czf $(RELEASE).tar.gz $(RELEASE_NAME)

--- a/access/slackbot/install
+++ b/access/slackbot/install
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#
+# the directory where Teleport binaries will be located
+#
+BINDIR=/usr/local/bin
+
+[ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
+cd $(dirname $0)
+mkdir -p $BINDIR
+cp -f slackbot $BINDIR/ || exit 1
+
+echo "Teleport Slackbot binaries have been copied to $BINDIR"
+echo "You can run slackbot configure > /etc/teleport-slackbot.toml to bootstrap your config file"


### PR DESCRIPTION
Tested this locally but didn't write any tests. I'll add the example systemd service and build up on top of this, too. 