### PR TITLE
Better config support for ./slackbot start

### DIFF
--- a/access/slackbot/slackbot.go
+++ b/access/slackbot/slackbot.go
@@ -62,8 +62,9 @@ func main() {
 	app := kingpin.New("slackbot", "Teleport plugin for access requests approval via Slack.")
 	app.Command("configure", "Prints an example configuration file")
 	startCmd := app.Command("start", "Starts a bot daemon")
-	path := startCmd.Arg("path", "Configuration file path").
-		Required().
+	path := startCmd.Flag("config", "TOML config file path").
+		Short('c').
+		Default("/etc/teleport-slackbot.toml").
 		String()
 	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
 		Short('d').


### PR DESCRIPTION
When using `./slackbot start`, you currently have to add an unnamed arg with a path to the config file, like this: `./slackbot start config.toml`. It won't work with `-f config.toml`.

This is inconsistent with how other Teleport services work: 
- Teleport daemon expects /etc/teleport.yaml
- `tctl` actions expect an unnamed argument, or a `-f` argument.

1. Should we switch to yaml so all the configs are in the same format? 
2. Should Slackbot also expect a config in /etc/teleport-slackbot.yaml by default? 
3. Should it parse both unnamed and `-f` argument? 

/cc @fspmarshall, @klizhentas. 