### PR TITLE
Structured logs

### DIFF
--- a/access/slackbot/cache.go
+++ b/access/slackbot/cache.go
@@ -113,7 +113,7 @@ func (c *RequestCache) tick() int {
 	}
 	for reqID, entry := range c.entries {
 		if entry.exp < c.index {
-			log.Debugf("removing expired cache entry %s...", reqID)
+			log.WithField("request_id", reqID).Debugf("removing expired cache entry...")
 			delete(c.entries, reqID)
 			continue
 		}

--- a/access/slackbot/callback_server.go
+++ b/access/slackbot/callback_server.go
@@ -57,7 +57,7 @@ func (s *CallbackServer) processCallback(ctx context.Context, rw http.ResponseWr
 
 	sv, err := slack.NewSecretsVerifier(r.Header, s.secret)
 	if err != nil {
-		log.Errorf("Failed to initialize secrets verifier: %s", err)
+		log.WithError(err).Error("Failed to initialize secrets verifier")
 		http.Error(rw, "verification failed", 500)
 		return
 	}
@@ -68,20 +68,20 @@ func (s *CallbackServer) processCallback(ctx context.Context, rw http.ResponseWr
 	// the FormValue method exhausts the reader, so signature
 	// verification can now proceed.
 	if err := sv.Ensure(); err != nil {
-		log.Errorf("Secret verification failed: %s", err)
+		log.WithError(err).Error("Secret verification failed")
 		http.Error(rw, "verification failed", 500)
 		return
 	}
 
 	var cb slack.InteractionCallback
 	if err := json.Unmarshal(payload, &cb); err != nil {
-		log.Errorf("Failed to parse json response: %s", err)
+		log.WithError(err).Error("Failed to parse json response")
 		http.Error(rw, "failed to parse response", 500)
 		return
 	}
 
 	if err := s.onCallback(ctx, cb); err != nil {
-		log.Errorf("Failed to process callback: %s", err)
+		log.WithError(err).Error("Failed to process callback")
 		var code int
 		switch {
 		case access.IsCanceled(err) || access.IsDeadline(err):


### PR DESCRIPTION
This PR utilizes logrus' structured logs. When the output is sent to stdout/stderr, it looks like this (+colors):

```
DEBU[0000] DEBUG logging enabled
INFO[0000] Starting Teleport Access Slackbot 0.1.0-dev.1:
INFO[0000] Starting a request watcher...
INFO[0000] Starting insecure HTTP server on :9090
ERRO[0005] Cannot connect to Teleport Auth server. Reconnecting...  error=watcher initialization timed out
ERRO[0010] Cannot connect to Teleport Auth server. Reconnecting...  error=watcher initialization timed out
INFO[0014] Watcher connected
DEBU[0023] Posted to Slack                               slack_channel=CSV21S85U slack_timestamp=1580128123.001300
INFO[0026] Slack user denied the request                 request_id=828e6aaa-832a-4ce3-a25b-54bace51a614 roles=[admin] slack_channel=general slack_user=darthsim user=darthsim
DEBU[0027] Successfully updated Slack message            request_id=828e6aaa-832a-4ce3-a25b-54bace51a614
INFO[0038] Attempting graceful shutdown...
```

When the output is sent to a file, coloring is disabled, and log looks like this:

```
time="2020-01-27T18:49:59+06:00" level=debug msg="DEBUG logging enabled" 
time="2020-01-27T18:49:59+06:00" level=info msg="Starting Teleport Access Slackbot 0.1.0-dev.1:" 
time="2020-01-27T18:49:59+06:00" level=info msg="Starting a request watcher..." 
time="2020-01-27T18:49:59+06:00" level=info msg="Starting insecure HTTP server on :9090" 
time="2020-01-27T18:50:04+06:00" level=error msg="Cannot connect to Teleport Auth server. Reconnecting..." error="watcher initialization timed out" 
time="2020-01-27T18:50:09+06:00" level=error msg="Cannot connect to Teleport Auth server. Reconnecting..." error="watcher initialization timed out" 
time="2020-01-27T18:50:12+06:00" level=info msg="Watcher connected" 
time="2020-01-27T18:50:23+06:00" level=debug msg="Posted to Slack" slack_channel=CSV21S85U slack_timestamp=1580129434.001500 
time="2020-01-27T18:50:28+06:00" level=info msg="Slack user denied the request" request_id=77a49079-25cc-4a36-af68-1f4dc2e588cd roles=[admin] slack_channel=general slack_user=darthsim user=darthsim 
time="2020-01-27T18:50:32+06:00" level=debug msg="Successfully updated Slack message" request_id=77a49079-25cc-4a36-af68-1f4dc2e588cd 
time="2020-01-27T18:50:37+06:00" level=info msg="Attempting graceful shutdown..." 
```

Users asked for this feature for my imgproxy, and I think this would be useful for slackbot users too.