### PR TITLE
Cluster name in Slack message

### DIFF
--- a/access/slackbot/bot.go
+++ b/access/slackbot/bot.go
@@ -106,6 +106,7 @@ func msgText(req access.Request, status string) string {
 
 	fmt.Fprintln(b, "```")
 	msgFieldToBuilder(b, "Request ", req.ID)
+	msgFieldToBuilder(b, "Cluster ", req.ClusterName)
 
 	if len(req.User) > 0 {
 		msgFieldToBuilder(b, "User    ", req.User)


### PR DESCRIPTION
Closes #27 

Had to use `auth.Client` because I can't figure out how to get a cluster name with `proto.AuthServiceClient`.

Conflicts with #40 