### PR TITLE
Consider graceful shutdown for outgoing HTTP-requests too

### DIFF
--- a/access/slackbot/slackbot_test.go
+++ b/access/slackbot/slackbot_test.go
@@ -100,7 +100,8 @@ func (s *SlackbotSuite) SetUpTest(c *C) {
 }
 
 func (s *SlackbotSuite) TearDownTest(c *C) {
-	s.app.Stop()
+	err := s.app.Shutdown(context.TODO())
+	c.Assert(err, IsNil)
 	<-s.appDone
 	s.slackServer.Stop()
 	for _, tmp := range s.tmpFiles {

--- a/utils/http.go
+++ b/utils/http.go
@@ -68,6 +68,8 @@ func (h *httpHandlerWrapper) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 // ListenAndServe runs a http(s) server on a provided port.
 func (h *HTTP) ListenAndServe(ctx context.Context) error {
+	defer log.Info("HTTP server terminated")
+
 	h.server.Handler = newHttpHandlerWrapper(ctx, h.Router)
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
We already have `httpServer.Shutdown()` to ensure that all incoming HTTP requests are finished before we terminate the process.

However, we don't do the same for outgoing HTTP requests. On termination, all the background operations are simply halted by context cancellation. To challenge this problem, I extended the use of existing `WaitGroup` and introduced the `spawn(func(ctx)...)` method to execute goroutines as jobs that could be waited to finish.