### PR TITLE
Verify client certificate for PagerDuty webhooks

### DIFF
--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -42,9 +42,17 @@ service-id = "PIJ90N7"        # PagerDuty service id
 
 [http]
 listen = ":8081"          # PagerDuty webhook listener
+base-url = "https://teleport-pagerduty.infra.yourcorp.com" # The public address of the teleport-pagerduty webhook listener. 
 # host = "example.com"    # Host name by which bot is accessible
 # https-key-file = "/var/lib/teleport/plugins/pagerduty/server.key"  # TLS private key
 # https-cert-file = "/var/lib/teleport/plugins/pagerduty/server.crt" # TLS certificate
+
+[http.tls]
+verify-client-cert = true # The preferred way to authenticate webhooks on Pagerduty. See more: https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls
+
+[http.basic-auth]
+user = "user"
+password = "password" # If you prefer to use basic auth for Pagerduty Webhooks authentication, use this section to store user and password
 
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"


### PR DESCRIPTION
Hi!

Unlike other services we have intergated, PagerDuty does not implement anything like HMAC signature of the webhook payload to ensure that webhook comes from PagerDuty but not from the bad guys. Instead of HMAC it provides a bunch of options:

1. IP Safelists.

https://support.pagerduty.com/docs/whitelisting-ips#section-webhooks

Requires polling of https://app.pagerduty.com/webhook_ips endpoint. We don't have it yet and I don't think we should. I don't find it reliable because when running a bot behind a proxy we must be sure that it sets `X-Forwarded-For` header correctly, and also this IP list itself could be changed without a notice.

2. HTTP Basic authentication.

In some sense it's weak too but it's good to have it if there's no other option. Basic auth support was added in 7b6df598159dceb4cf3815b0a9261743118088d0 and must work in all the plugins that we have, though I'm not sure that all services we've integrated support URLs in form of "http://user:password@example.com" but PagerDuty promises they do - https://developer.pagerduty.com/docs/webhooks/webhook-behavior/#basic-authentication.

To activate basic auth for PagerDuty, simply set `base-url` to something like `"https://username:password@example.com"` (cc @xnutsive it must be reflected in PagerDuty integration docs as one of the possible measures for authentication).

3. Mutual TLS aka client certificate verification.

This is the most interesting thing which is described here: https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls

It appears that during TLS handshake we could require a client to provide a *client* certificate and if it's a valid certificate from trusted CA then we also check its `Subject` field for a specific value `"CN=webhooks.pagerduty.com,O=PagerDuty Inc,L=San Francisco,ST=California,C=US"`.

I added a certificate verification support in 4100863.

@xnutsive:

In the docs, we must insist on "Mutual TLS" as a **recommended** way to authenticate incoming requests from PagerDuty. There're two cases we must consider:

1. Customer runs `teleport-pagerduty` with HTTPS ON.

Then, to activate mutual tls one must set `verify-client-cert = true` in the `[http.tls]` section of the config file.

2. Customer runs `teleport-pagerduty --insecure-no-tls` with HTTPS OFF behind a reverse proxy that does SSL termination.

In this case certificate verification, if possible, must be done on the proxy side. Examples on how to set it up for NGINX and Apache are provided in PagerDuty docs about mutual tls and we should refer this link in our docs.