### PR TITLE
Fix example code and address linter complaint

### DIFF
--- a/access/example/example.go
+++ b/access/example/example.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/gravitational/teleport-plugins/access"
 
 	"github.com/gravitational/trace"
@@ -81,7 +80,7 @@ func run(configPath string) error {
 		return trace.Wrap(err)
 	}
 
-	log.Debug("Watcher connected")
+	eprintln("Watcher connected")
 
 	for {
 		select {

--- a/access/pagerduty/bot.go
+++ b/access/pagerduty/bot.go
@@ -207,6 +207,9 @@ func (b *Bot) CreateIncident(ctx context.Context, reqID string, reqData RequestD
 	client := b.NewClient(ctx)
 
 	body, err := b.buildIncidentBody(reqID, reqData)
+	if err != nil {
+		return PagerdutyData{}, trace.Wrap(err)
+	}
 
 	incident, err := client.CreateIncident(b.from, &pd.CreateIncidentOptions{
 		Title:       fmt.Sprintf("Access request from %s", reqData.User),


### PR DESCRIPTION
Added a quick fix for the example code so that the linter doesn't complain. At the same time, I also fixed another `ineffassign` issue from the linter.