### PR TITLE
Add caching to Drone test phase

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,56 +9,18 @@ trigger:
     - tag
 
 workspace:
-  path: /go
+  path: /go/src/github.com/gravitational/teleport-plugins
 
 clone:
   disable: true
 
 steps:
-  - name: Restore lint cache
-    image: meltwater/drone-cache
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-    settings:
-      restore: true
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      region: us-west-2
-      cache_key: "{{.Commit.Branch}}-lint"
-      mount:
-        - /go/cache
-        - /go/pkg/mod
-
-  - name: Run linter
-    image: golangci/golangci-lint:v1.27.0
-    environment:
-      GOCACHE: /go/cache
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-      - cd /go/src/github.com/gravitational/teleport-plugins
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git checkout $DRONE_COMMIT
-      - make lint
-
-  - name: Save lint cache
-    image: meltwater/drone-cache
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-    settings:
-      rebuild: true
-      cache_key: "{{.Commit.Branch}}-lint"
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      region: us-west-2
-      mount:
-        - /go/cache
-        - /go/pkg/mod
+- name: Run linter
+  image: golangci/golangci-lint:v1.27.0
+  commands:
+    - git clone https://github.com/gravitational/teleport-plugins.git .
+    - git checkout $DRONE_COMMIT
+    - make lint
 
 ---
 kind: pipeline
@@ -77,50 +39,48 @@ clone:
   disable: true
 
 steps:
-  - name: Restore test cache
-    image: meltwater/drone-cache
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-    settings:
-      restore: true
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      region: us-west-2
-      cache_key: "{{.Commit.Branch}}-test"
-      mount:
-        - /go/cache
-        - /go/pkg/mod
+- name: Restore cache
+  image: meltwater/drone-cache
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  settings:
+    restore: true
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    mount:
+      - /go/cache
+      - /go/pkg/mod
 
-  - name: Run tests
-    image: golang:1.13.2
-    environment:
-      GOCACHE: /go/cache
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-      - cd /go/src/github.com/gravitational/teleport-plugins
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git checkout $DRONE_COMMIT
-      - make test
+- name: Run tests
+  image: golang:1.13.2
+  environment:
+    GOCACHE: /go/cache
+  commands:
+    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+    - cd /go/src/github.com/gravitational/teleport-plugins
+    - git clone https://github.com/gravitational/teleport-plugins.git .
+    - git checkout $DRONE_COMMIT
+    - make test
 
-  - name: Save test cache
-    image: meltwater/drone-cache
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-    settings:
-      rebuild: true
-      cache_key: "{{.Commit.Branch}}-test"
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      region: us-west-2
-      mount:
-        - /go/cache
-        - /go/pkg/mod
+- name: Save cache
+  image: meltwater/drone-cache
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+  settings:
+    rebuild: true
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    mount:
+      - /go/cache
+      - /go/pkg/mod
 
 ---
 kind: pipeline
@@ -420,6 +380,6 @@ steps:
 
 ---
 kind: signature
-hmac: 59ce501de99f6ad0a25e6b29608bd1b55d3613927a19352a3617edfacdd96d5a
+hmac: cc9c7f65ee2b9e60eb3f28b795f5cec00bd200b904cf3ab5c706bfbda3be69d7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,36 +1,11 @@
 ---
 kind: pipeline
 type: kubernetes
-name: lint
+name: restore-cache
 
 trigger:
   event:
     - pull_request
-    - tag
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-- name: Run linter
-  image: golangci/golangci-lint:v1.27.0
-  commands:
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make lint
-
----
-kind: pipeline
-type: kubernetes
-name: test
-
-trigger:
-  event:
-    - pull_request
-    - tag
 
 workspace:
   path: /go
@@ -56,6 +31,57 @@ steps:
       - /go/cache
       - /go/pkg/mod
 
+---
+kind: pipeline
+type: kubernetes
+name: lint
+
+depends_on:
+  - restore_cache
+
+trigger:
+  event:
+    - pull_request
+    - tag
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+- name: Run linter
+  image: golangci/golangci-lint:v1.27.0
+  environment:
+    GOCACHE: /go/cache
+  commands:
+    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+    - cd /go/src/github.com/gravitational/teleport-plugins
+    - git clone https://github.com/gravitational/teleport-plugins.git .
+    - git checkout $DRONE_COMMIT
+    - make lint
+
+---
+kind: pipeline
+type: kubernetes
+name: test
+
+depends_on:
+  - restore_cache
+
+trigger:
+  event:
+    - pull_request
+    - tag
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
 - name: Run tests
   image: golang:1.13.2
   environment:
@@ -67,6 +93,26 @@ steps:
     - git checkout $DRONE_COMMIT
     - make test
 
+---
+kind: pipeline
+type: kubernetes
+name: save-cache
+
+depends_on:
+  - lint
+  - test
+
+trigger:
+  event:
+    - pull_request
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
 - name: Save cache
   image: meltwater/drone-cache
   environment:
@@ -382,6 +428,6 @@ steps:
 
 ---
 kind: signature
-hmac: d5b362f208a5283e4454be607d94ebe49e53a568cd57acd292d6fa116489ed41
+hmac: 2ae667f6f73e7c41f4128e721f467e102b46f14a83c84cfa196192ff86c65292
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,12 +41,13 @@ clone:
 steps:
 - name: Restore cache
   image: meltwater/drone-cache
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     restore: true
-    access-key:
-      from_secret: AWS_ACCESS_KEY_ID
-    secret-key:
-      from_secret: AWS_SECRET_ACCESS_KEY
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-east-1
@@ -62,12 +63,13 @@ steps:
 
 - name: Save cache
   image: meltwater/drone-cache
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     rebuild: true
-    access-key:
-      from_secret: AWS_ACCESS_KEY_ID
-    secret-key:
-      from_secret: AWS_SECRET_ACCESS_KEY
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-east-1
@@ -372,6 +374,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7854d3dc2ef995350da39f2e848738b01610d64b8c723055e62d7db137887272
+hmac: 3d25a62230e63f5352dc499dbb99be987739beea6a88ed50a24bcf8d019e936f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -59,8 +59,10 @@ steps:
   image: golang:1.13.2
   environment:
     GOCACHE: /go/cache
+    WORKING_DIRECTORY: /go/src/github.com/gravitational/teleport-plugins
   commands:
-    - cd /go/src/github.com/gravitational/teleport-plugins
+    - mkdir -p $WORKING_DIRECTORY
+    - cd $WORKING_DIRECTORY
     - git clone https://github.com/gravitational/teleport-plugins.git .
     - git checkout $DRONE_COMMIT
     - make test
@@ -380,6 +382,6 @@ steps:
 
 ---
 kind: signature
-hmac: 888ea5c938df62ccce525e0a535bcf678ef10c11be4f4fdcbd01d281f90c7563
+hmac: 8d69fd5ea47f12dfd7b91799acce83b74dd6fa824310f1ae2509d240ae21317b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,15 +54,15 @@ steps:
     region: us-west-2
     mount:
       - /go/cache
+      - /go/pkg/mod
 
 - name: Run tests
   image: golang:1.13.2
   environment:
     GOCACHE: /go/cache
-    WORKING_DIRECTORY: /go/src/github.com/gravitational/teleport-plugins
   commands:
-    - mkdir -p $WORKING_DIRECTORY
-    - cd $WORKING_DIRECTORY
+    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+    - cd /go/src/github.com/gravitational/teleport-plugins
     - git clone https://github.com/gravitational/teleport-plugins.git .
     - git checkout $DRONE_COMMIT
     - make test
@@ -382,6 +382,6 @@ steps:
 
 ---
 kind: signature
-hmac: 8d69fd5ea47f12dfd7b91799acce83b74dd6fa824310f1ae2509d240ae21317b
+hmac: d5b362f208a5283e4454be607d94ebe49e53a568cd57acd292d6fa116489ed41
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,18 +9,56 @@ trigger:
     - tag
 
 workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
+  path: /go
 
 clone:
   disable: true
 
 steps:
-- name: Run linter
-  image: golangci/golangci-lint:v1.27.0
-  commands:
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make lint
+  - name: Restore lint cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      restore: true
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      region: us-west-2
+      cache_key: "{{.Commit.Branch}}-lint"
+      mount:
+        - /go/cache
+        - /go/pkg/mod
+
+  - name: Run linter
+    image: golangci/golangci-lint:v1.27.0
+    environment:
+      GOCACHE: /go/cache
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+      - cd /go/src/github.com/gravitational/teleport-plugins
+      - git clone https://github.com/gravitational/teleport-plugins.git .
+      - git checkout $DRONE_COMMIT
+      - make lint
+
+  - name: Save lint cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      rebuild: true
+      cache_key: "{{.Commit.Branch}}-lint"
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      region: us-west-2
+      mount:
+        - /go/cache
+        - /go/pkg/mod
 
 ---
 kind: pipeline
@@ -39,48 +77,50 @@ clone:
   disable: true
 
 steps:
-- name: Restore cache
-  image: meltwater/drone-cache
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  settings:
-    restore: true
-    bucket:
-      from_secret: AWS_S3_BUCKET
-    region: us-west-2
-    mount:
-      - /go/cache
-      - /go/pkg/mod
+  - name: Restore test cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      restore: true
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      region: us-west-2
+      cache_key: "{{.Commit.Branch}}-test"
+      mount:
+        - /go/cache
+        - /go/pkg/mod
 
-- name: Run tests
-  image: golang:1.13.2
-  environment:
-    GOCACHE: /go/cache
-  commands:
-    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-    - cd /go/src/github.com/gravitational/teleport-plugins
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make test
+  - name: Run tests
+    image: golang:1.13.2
+    environment:
+      GOCACHE: /go/cache
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+      - cd /go/src/github.com/gravitational/teleport-plugins
+      - git clone https://github.com/gravitational/teleport-plugins.git .
+      - git checkout $DRONE_COMMIT
+      - make test
 
-- name: Save cache
-  image: meltwater/drone-cache
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  settings:
-    rebuild: true
-    bucket:
-      from_secret: AWS_S3_BUCKET
-    region: us-west-2
-    mount:
-      - /go/cache
-      - /go/pkg/mod
+  - name: Save test cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      rebuild: true
+      cache_key: "{{.Commit.Branch}}-test"
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      region: us-west-2
+      mount:
+        - /go/cache
+        - /go/pkg/mod
 
 ---
 kind: pipeline
@@ -380,6 +420,6 @@ steps:
 
 ---
 kind: signature
-hmac: cc9c7f65ee2b9e60eb3f28b795f5cec00bd200b904cf3ab5c706bfbda3be69d7
+hmac: 59ce501de99f6ad0a25e6b29608bd1b55d3613927a19352a3617edfacdd96d5a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,12 +39,40 @@ clone:
   disable: true
 
 steps:
+- name: Restore cache
+  image: meltwater/drone-cache
+  settings:
+    restore: true
+    access-key:
+      from_secret: AWS_ACCESS_KEY_ID
+    secret-key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-east-1
+    mount:
+      - '/root/.cache/go-build'
+
 - name: Run tests
   image: golang:1.13.2
   commands:
     - git clone https://github.com/gravitational/teleport-plugins.git .
     - git checkout $DRONE_COMMIT
     - make test
+
+- name: Save cache
+  image: meltwater/drone-cache
+  settings:
+    rebuild: true
+    access-key:
+      from_secret: AWS_ACCESS_KEY_ID
+    secret-key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-east-1
+    mount:
+      - '/root/.cache/go-build'
 
 ---
 kind: pipeline
@@ -344,6 +372,6 @@ steps:
 
 ---
 kind: signature
-hmac: 181d0c0705db7a60daf4e5cd6b5aa449eddfe6695e3f66bb694b345d264d3c96
+hmac: 7854d3dc2ef995350da39f2e848738b01610d64b8c723055e62d7db137887272
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,12 +15,12 @@ clone:
   disable: true
 
 steps:
-- name: Run linter
-  image: golangci/golangci-lint:v1.27.0
-  commands:
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make lint
+  - name: Run linter
+    image: golangci/golangci-lint:v1.27.0
+    commands:
+      - git clone https://github.com/gravitational/teleport-plugins.git .
+      - git checkout $DRONE_COMMIT
+      - make lint
 
 ---
 kind: pipeline
@@ -39,48 +39,50 @@ clone:
   disable: true
 
 steps:
-- name: Restore cache
-  image: meltwater/drone-cache
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  settings:
-    restore: true
-    bucket:
-      from_secret: AWS_S3_BUCKET
-    region: us-west-2
-    mount:
-      - /go/cache
-      - /go/pkg/mod
+  - name: Restore cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      restore: true
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      archive_format: gzip
+      region: us-west-2
+      mount:
+        - /go/cache
+        - /go/pkg/mod
 
-- name: Run tests
-  image: golang:1.13.2
-  environment:
-    GOCACHE: /go/cache
-  commands:
-    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-    - cd /go/src/github.com/gravitational/teleport-plugins
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make test
+  - name: Run tests
+    image: golang:1.13.2
+    environment:
+      GOCACHE: /go/cache
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+      - cd /go/src/github.com/gravitational/teleport-plugins
+      - git clone https://github.com/gravitational/teleport-plugins.git .
+      - git checkout $DRONE_COMMIT
+      - make test
 
-- name: Save cache
-  image: meltwater/drone-cache
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  settings:
-    rebuild: true
-    bucket:
-      from_secret: AWS_S3_BUCKET
-    region: us-west-2
-    mount:
-      - /go/cache
-      - /go/pkg/mod
+  - name: Save cache
+    image: meltwater/drone-cache
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    settings:
+      rebuild: true
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      archive_format: gzip
+      region: us-west-2
+      mount:
+        - /go/cache
+        - /go/pkg/mod
 
 ---
 kind: pipeline
@@ -380,6 +382,6 @@ steps:
 
 ---
 kind: signature
-hmac: cc9c7f65ee2b9e60eb3f28b795f5cec00bd200b904cf3ab5c706bfbda3be69d7
+hmac: cd1d2f44701124de6deb899c7c9db3742dc5ea44b0ee2550e6c814d11d582687
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,7 @@ type: kubernetes
 name: lint
 
 depends_on:
-  - restore_cache
+  - restore-cache
 
 trigger:
   event:
@@ -68,7 +68,7 @@ type: kubernetes
 name: test
 
 depends_on:
-  - restore_cache
+  - restore-cache
 
 trigger:
   event:
@@ -428,6 +428,6 @@ steps:
 
 ---
 kind: signature
-hmac: 2ae667f6f73e7c41f4128e721f467e102b46f14a83c84cfa196192ff86c65292
+hmac: 74d92675dcc4fb9da7568b2942eef3660a9ea0e16dac886ee8b0a8b0b7035315
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,8 +33,7 @@ trigger:
     - tag
 
 workspace:
-  base: /go
-  path: src/github.com/gravitational/teleport-plugins
+  path: /go
 
 clone:
   disable: true
@@ -55,13 +54,13 @@ steps:
     region: us-west-2
     mount:
       - /go/cache
-      - /go/pkg/mod
 
 - name: Run tests
   image: golang:1.13.2
   environment:
     GOCACHE: /go/cache
   commands:
+    - cd /go/src/github.com/gravitational/teleport-plugins
     - git clone https://github.com/gravitational/teleport-plugins.git .
     - git checkout $DRONE_COMMIT
     - make test
@@ -381,6 +380,6 @@ steps:
 
 ---
 kind: signature
-hmac: ba786b25f6afb51dffcf4e2cc4347de87921d6fabba2ba421a424f95d84e620d
+hmac: 888ea5c938df62ccce525e0a535bcf678ef10c11be4f4fdcbd01d281f90c7563
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,8 @@ trigger:
     - tag
 
 workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
+  base: /go
+  path: src/github.com/gravitational/teleport-plugins
 
 clone:
   disable: true
@@ -380,6 +381,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7c21ac68658d76e06fdc2c9825c500935ca9453eeb4c94662510a1a2a39a1620
+hmac: ba786b25f6afb51dffcf4e2cc4347de87921d6fabba2ba421a424f95d84e620d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,7 +50,7 @@ steps:
     restore: true
     bucket:
       from_secret: AWS_S3_BUCKET
-    region: us-east-1
+    region: us-west-2
     mount:
       - '/root/.cache/go-build'
 
@@ -72,7 +72,7 @@ steps:
     rebuild: true
     bucket:
       from_secret: AWS_S3_BUCKET
-    region: us-east-1
+    region: us-west-2
     mount:
       - '/root/.cache/go-build'
 
@@ -374,6 +374,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3d25a62230e63f5352dc499dbb99be987739beea6a88ed50a24bcf8d019e936f
+hmac: 58c6b4d9959178e29e9212b2848bf8df06d58f9c59c18e6dcdabc524d1c7a8b1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,14 +48,18 @@ steps:
       from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     restore: true
+    archive_format: gzip
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-west-2
     mount:
-      - '/root/.cache/go-build'
+      - /go/cache
+      - /go/pkg/mod
 
 - name: Run tests
   image: golang:1.13.2
+  environment:
+    GOCACHE: /go/cache
   commands:
     - git clone https://github.com/gravitational/teleport-plugins.git .
     - git checkout $DRONE_COMMIT
@@ -70,11 +74,13 @@ steps:
       from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     rebuild: true
+    archive_format: gzip
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-west-2
     mount:
-      - '/root/.cache/go-build'
+      - /go/cache
+      - /go/pkg/mod
 
 ---
 kind: pipeline
@@ -374,6 +380,6 @@ steps:
 
 ---
 kind: signature
-hmac: 58c6b4d9959178e29e9212b2848bf8df06d58f9c59c18e6dcdabc524d1c7a8b1
+hmac: 7c21ac68658d76e06fdc2c9825c500935ca9453eeb4c94662510a1a2a39a1620
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,7 @@ type: kubernetes
 name: lint
 
 depends_on:
-  - restore-cache
+  - restore_cache
 
 trigger:
   event:
@@ -68,7 +68,7 @@ type: kubernetes
 name: test
 
 depends_on:
-  - restore-cache
+  - restore_cache
 
 trigger:
   event:
@@ -428,6 +428,6 @@ steps:
 
 ---
 kind: signature
-hmac: 74d92675dcc4fb9da7568b2942eef3660a9ea0e16dac886ee8b0a8b0b7035315
+hmac: 2ae667f6f73e7c41f4128e721f467e102b46f14a83c84cfa196192ff86c65292
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,6 @@ steps:
       from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     restore: true
-    archive_format: gzip
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-west-2
@@ -76,7 +75,6 @@ steps:
       from_secret: AWS_SECRET_ACCESS_KEY
   settings:
     rebuild: true
-    archive_format: gzip
     bucket:
       from_secret: AWS_S3_BUCKET
     region: us-west-2
@@ -382,6 +380,6 @@ steps:
 
 ---
 kind: signature
-hmac: d5b362f208a5283e4454be607d94ebe49e53a568cd57acd292d6fa116489ed41
+hmac: cc9c7f65ee2b9e60eb3f28b795f5cec00bd200b904cf3ab5c706bfbda3be69d7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,11 +1,36 @@
 ---
 kind: pipeline
 type: kubernetes
-name: restore-cache
+name: lint
 
 trigger:
   event:
     - pull_request
+    - tag
+
+workspace:
+  path: /go/src/github.com/gravitational/teleport-plugins
+
+clone:
+  disable: true
+
+steps:
+- name: Run linter
+  image: golangci/golangci-lint:v1.27.0
+  commands:
+    - git clone https://github.com/gravitational/teleport-plugins.git .
+    - git checkout $DRONE_COMMIT
+    - make lint
+
+---
+kind: pipeline
+type: kubernetes
+name: test
+
+trigger:
+  event:
+    - pull_request
+    - tag
 
 workspace:
   path: /go
@@ -31,57 +56,6 @@ steps:
       - /go/cache
       - /go/pkg/mod
 
----
-kind: pipeline
-type: kubernetes
-name: lint
-
-depends_on:
-  - restore_cache
-
-trigger:
-  event:
-    - pull_request
-    - tag
-
-workspace:
-  path: /go
-
-clone:
-  disable: true
-
-steps:
-- name: Run linter
-  image: golangci/golangci-lint:v1.27.0
-  environment:
-    GOCACHE: /go/cache
-  commands:
-    - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-    - cd /go/src/github.com/gravitational/teleport-plugins
-    - git clone https://github.com/gravitational/teleport-plugins.git .
-    - git checkout $DRONE_COMMIT
-    - make lint
-
----
-kind: pipeline
-type: kubernetes
-name: test
-
-depends_on:
-  - restore_cache
-
-trigger:
-  event:
-    - pull_request
-    - tag
-
-workspace:
-  path: /go
-
-clone:
-  disable: true
-
-steps:
 - name: Run tests
   image: golang:1.13.2
   environment:
@@ -93,26 +67,6 @@ steps:
     - git checkout $DRONE_COMMIT
     - make test
 
----
-kind: pipeline
-type: kubernetes
-name: save-cache
-
-depends_on:
-  - lint
-  - test
-
-trigger:
-  event:
-    - pull_request
-
-workspace:
-  path: /go
-
-clone:
-  disable: true
-
-steps:
 - name: Save cache
   image: meltwater/drone-cache
   environment:
@@ -428,6 +382,6 @@ steps:
 
 ---
 kind: signature
-hmac: 2ae667f6f73e7c41f4128e721f467e102b46f14a83c84cfa196192ff86c65292
+hmac: d5b362f208a5283e4454be607d94ebe49e53a568cd57acd292d6fa116489ed41
 
 ...


### PR DESCRIPTION
Adds caching to subsequent test runs in Drone. Makes things more than twice as fast at the cost of about 60MB of S3 storage.

Before:

![2020-05-27-164359__971x277__maim](https://user-images.githubusercontent.com/897821/83065129-5225a400-a039-11ea-9379-106066f06e97.png)

After:

![2020-05-27-164406__967x377__maim](https://user-images.githubusercontent.com/897821/83065136-55b92b00-a039-11ea-9d8e-dbe139cbcb30.png)