### PR TITLE
Reformat the Drone pipeline to re-use more code

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,8 @@ type: kubernetes
 name: test
 
 trigger:
+  branch:
+    - master
   event:
     exclude:
       - promote
@@ -80,7 +82,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: build
+name: build-${DRONE_TAG##*-v}
 
 trigger:
   event:
@@ -174,6 +176,6 @@ steps:
 
 ---
 kind: signature
-hmac: 892186192d8c3e931968d4bd78022b39ca3e69562273830be7fea5915488f850
+hmac: 3bbed19e26bd58aac2dd60a598eae6a5b6a1e0408a7fe7a3f04dd64d56529bbb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,36 +1,12 @@
 ---
 kind: pipeline
 type: kubernetes
-name: lint
-
-trigger:
-  event:
-    - pull_request
-    - tag
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Run linter
-    image: golangci/golangci-lint:v1.27.0
-    commands:
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git checkout $DRONE_COMMIT
-      - make lint
-
----
-kind: pipeline
-type: kubernetes
 name: test
 
 trigger:
   event:
-    - pull_request
-    - tag
+    exclude:
+      - promote
 
 workspace:
   path: /go
@@ -39,10 +15,28 @@ clone:
   disable: true
 
 steps:
+  - name: Check out code
+    image: golangci/golangci-lint:v1.27.0
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
+      - cd /go/src/github.com/gravitational/teleport-plugins
+      - git clone https://github.com/gravitational/teleport-plugins.git .
+      - git checkout $DRONE_COMMIT
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
+
   - name: Write source branch to file
     image: busybox
     commands:
       - echo $DRONE_SOURCE_BRANCH > .drone_source_branch.txt
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
 
   - name: Restore cache
     image: meltwater/drone-cache
@@ -61,17 +55,35 @@ steps:
       mount:
         - /go/cache
         - /go/pkg/mod
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
+
+  - name: Run linter
+    image: golangci/golangci-lint:v1.27.0
+    environment:
+      GOCACHE: /go/cache
+    commands:
+      - make lint
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
 
   - name: Run tests
     image: golang:1.13.2
     environment:
       GOCACHE: /go/cache
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport-plugins
-      - cd /go/src/github.com/gravitational/teleport-plugins
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git checkout $DRONE_COMMIT
       - make test
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
 
   - name: Save cache
     image: meltwater/drone-cache
@@ -90,22 +102,24 @@ steps:
       mount:
         - /go/cache
         - /go/pkg/mod
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
 
 ---
 kind: pipeline
 type: kubernetes
-name: build-jira
-
-depends_on:
-  - lint
-  - test
+name: build
 
 trigger:
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/teleport-jira-*
+    exclude:
+      - promote
+
+depends_on:
+  - test
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -121,11 +135,17 @@ steps:
       - git fetch --all --tags
       - git checkout $DRONE_TAG
       - mkdir -p build/
-      - make release/access-jira
+      - make release/access-${DRONE_TAG##*-v}
       - find access/ -iname "*.tar.gz" -print -exec cp {} build/ \;
       - cd build
       - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
       - ls -l .
+    when:
+      event:
+        - tag
+      ref:
+        include:
+          - refs/tags/teleport-*-v*
 
   - name: Upload to S3
     image: plugins/s3
@@ -140,206 +160,12 @@ steps:
       source: /go/src/github.com/gravitational/teleport-plugins/build/*
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-
----
-kind: pipeline
-type: kubernetes
-name: build-slack
-
-depends_on:
-  - lint
-  - test
-
-trigger:
-  event:
-    - tag
-  ref:
-    include:
-      - refs/tags/teleport-slack-*
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Build artifacts
-    image: golang:1.13.2
-    commands:
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git fetch --all --tags
-      - git checkout $DRONE_TAG
-      - mkdir -p build/
-      - make release/access-slack
-      - find access/ -iname "*.tar.gz" -print -exec cp {} build/ \;
-      - cd build
-      - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
-      - ls -l .
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/src/github.com/gravitational/teleport-plugins/build/*
-      target: teleport-plugins/tag/${DRONE_TAG}
-      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-
----
-kind: pipeline
-type: kubernetes
-name: build-mattermost
-
-depends_on:
-  - lint
-  - test
-
-trigger:
-  event:
-    - tag
-  ref:
-    include:
-      - refs/tags/teleport-mattermost-*
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Build artifacts
-    image: golang:1.13.2
-    commands:
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git fetch --all --tags
-      - git checkout $DRONE_TAG
-      - mkdir -p build/
-      - make release/access-mattermost
-      - find access/ -iname "*.tar.gz" -print -exec cp {} build/ \;
-      - cd build
-      - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
-      - ls -l .
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/src/github.com/gravitational/teleport-plugins/build/*
-      target: teleport-plugins/tag/${DRONE_TAG}
-      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-
----
-kind: pipeline
-type: kubernetes
-name: build-pagerduty
-
-depends_on:
-  - lint
-  - test
-
-trigger:
-  event:
-    - tag
-  ref:
-    include:
-      - refs/tags/teleport-pagerduty-*
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Build artifacts
-    image: golang:1.13.2
-    commands:
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git fetch --all --tags
-      - git checkout $DRONE_TAG
-      - mkdir -p build/
-      - make release/access-pagerduty
-      - find access/ -iname "*.tar.gz" -print -exec cp {} build/ \;
-      - cd build
-      - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
-      - ls -l .
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/src/github.com/gravitational/teleport-plugins/build/*
-      target: teleport-plugins/tag/${DRONE_TAG}
-      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-
----
-kind: pipeline
-type: kubernetes
-name: build-gitlab
-
-depends_on:
-  - lint
-  - test
-
-trigger:
-  event:
-    - tag
-  ref:
-    include:
-      - refs/tags/teleport-gitlab-*
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Build artifacts
-    image: golang:1.13.2
-    commands:
-      - git clone https://github.com/gravitational/teleport-plugins.git .
-      - git fetch --all --tags
-      - git checkout $DRONE_TAG
-      - mkdir -p build/
-      - make release/access-gitlab
-      - find access/ -iname "*.tar.gz" -print -exec cp {} build/ \;
-      - cd build
-      - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
-      - ls -l .
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/src/github.com/gravitational/teleport-plugins/build/*
-      target: teleport-plugins/tag/${DRONE_TAG}
-      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
+    when:
+      event:
+        - tag
+      ref:
+        include:
+          - refs/tags/teleport-*-v*
 
 ---
 kind: pipeline
@@ -389,6 +215,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4208c75d75dc6cb2e2921ab2fade468d697c9f370025a055ea4ae895be5ce431
+hmac: a139656fd764ef804dd854c5ac9f749a3d98df4743cff43569bf006efeb16f31
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ trigger:
   event:
     exclude:
       - promote
+      - rollback
 
 workspace:
   path: /go
@@ -22,21 +23,11 @@ steps:
       - cd /go/src/github.com/gravitational/teleport-plugins
       - git clone https://github.com/gravitational/teleport-plugins.git .
       - git checkout $DRONE_COMMIT
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
   - name: Write source branch to file
     image: busybox
     commands:
       - echo $DRONE_SOURCE_BRANCH > .drone_source_branch.txt
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
   - name: Restore cache
     image: meltwater/drone-cache
@@ -55,11 +46,6 @@ steps:
       mount:
         - /go/cache
         - /go/pkg/mod
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
   - name: Run linter
     image: golangci/golangci-lint:v1.27.0
@@ -68,11 +54,6 @@ steps:
     commands:
       - cd /go/src/github.com/gravitational/teleport-plugins
       - make lint
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
   - name: Run tests
     image: golang:1.13.2
@@ -81,11 +62,6 @@ steps:
     commands:
       - cd /go/src/github.com/gravitational/teleport-plugins
       - make test
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
   - name: Save cache
     image: meltwater/drone-cache
@@ -104,11 +80,6 @@ steps:
       mount:
         - /go/cache
         - /go/pkg/mod
-    when:
-      event:
-        - pull_request
-        - push
-        - tag
 
 ---
 kind: pipeline
@@ -118,6 +89,9 @@ name: build
 trigger:
   event:
     - tag
+  ref:
+    include:
+      - refs/tags/teleport-*-v*
 
 depends_on:
   - test
@@ -141,10 +115,6 @@ steps:
       - cd build
       - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
       - ls -l .
-    when:
-      ref:
-        include:
-          - refs/tags/teleport-*-v*
 
   - name: Upload to S3
     image: plugins/s3
@@ -159,10 +129,6 @@ steps:
       source: /go/src/github.com/gravitational/teleport-plugins/build/*
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-    when:
-      ref:
-        include:
-          - refs/tags/teleport-*-v*
 
 ---
 kind: pipeline
@@ -212,6 +178,6 @@ steps:
 
 ---
 kind: signature
-hmac: 20cf25ee15b510845577f8f0a3d4febd7c8e5136dc387d500cf571501129416e
+hmac: dc051ebc2e3ea8d4c731ba9aa799120afcdc4dd18a6b934bff52a7cb8854ba9d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,6 +66,7 @@ steps:
     environment:
       GOCACHE: /go/cache
     commands:
+      - cd /go/src/github.com/gravitational/teleport-plugins
       - make lint
     when:
       event:
@@ -78,6 +79,7 @@ steps:
     environment:
       GOCACHE: /go/cache
     commands:
+      - cd /go/src/github.com/gravitational/teleport-plugins
       - make test
     when:
       event:
@@ -210,6 +212,6 @@ steps:
 
 ---
 kind: signature
-hmac: b244c39e93ae8ef2494123865d5e3c8cd736e76ba7c50b3f8e447d0dc8488442
+hmac: 20cf25ee15b510845577f8f0a3d4febd7c8e5136dc387d500cf571501129416e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
       - cd /go/src/github.com/gravitational/teleport-plugins
       - git clone https://github.com/gravitational/teleport-plugins.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > .drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
 
   - name: Restore cache
     image: meltwater/drone-cache
@@ -174,6 +174,6 @@ steps:
 
 ---
 kind: signature
-hmac: 646bd046a1e9be9fc3d7a651b62f51bee53fe852a6a1d82c6d6db1b7b901befb
+hmac: 892186192d8c3e931968d4bd78022b39ca3e69562273830be7fea5915488f850
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,10 +23,6 @@ steps:
       - cd /go/src/github.com/gravitational/teleport-plugins
       - git clone https://github.com/gravitational/teleport-plugins.git .
       - git checkout $DRONE_COMMIT
-
-  - name: Write source branch to file
-    image: busybox
-    commands:
       - echo $DRONE_SOURCE_BRANCH > .drone_source_branch.txt
 
   - name: Restore cache
@@ -178,6 +174,6 @@ steps:
 
 ---
 kind: signature
-hmac: dc051ebc2e3ea8d4c731ba9aa799120afcdc4dd18a6b934bff52a7cb8854ba9d
+hmac: 646bd046a1e9be9fc3d7a651b62f51bee53fe852a6a1d82c6d6db1b7b901befb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -115,8 +115,7 @@ name: build
 
 trigger:
   event:
-    exclude:
-      - promote
+    - tag
 
 depends_on:
   - test
@@ -141,8 +140,6 @@ steps:
       - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
       - ls -l .
     when:
-      event:
-        - tag
       ref:
         include:
           - refs/tags/teleport-*-v*
@@ -161,8 +158,6 @@ steps:
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
     when:
-      event:
-        - tag
       ref:
         include:
           - refs/tags/teleport-*-v*
@@ -215,6 +210,6 @@ steps:
 
 ---
 kind: signature
-hmac: a139656fd764ef804dd854c5ac9f749a3d98df4743cff43569bf006efeb16f31
+hmac: b244c39e93ae8ef2494123865d5e3c8cd736e76ba7c50b3f8e447d0dc8488442
 
 ...


### PR DESCRIPTION
Pros:
- Refactors the pipeline to have way less boilerplate code
- Will now run the test pipeline against pushes to branches (mainly so we get verification that `master` will always build - testing all pushes is OK but would be nice to avoid it)
- Uses the S3 caching to speed up the linter as well as the test phase

Cons:
- Runs two sets of tests on every PR because there's both `pull_request` and `push` webhooks being triggered.

Hypothesis on the best way to fix this is to define the pipeline steps once by using YAML anchors and then have two different sets of match conditions - see https://github.com/drone/drone/issues/2323 for a rough idea.