### PR TITLE
Conteinerized manual QA plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ release/access-gitlab:
 .PHONY: releases
 releases: release/access-slack release/access-jira release/access-mattermost release/access-pagerduty release/access-gitlab
 
+.PHONY: build-all
+build-all: access-slack access-jira access-mattermost access-pagerduty access-gitlab
+
 #
 # Lint the Go code.
 # By default lint scans the entire repo. Pass FLAGS='--new' to only scan local

--- a/docker/.bashrc
+++ b/docker/.bashrc
@@ -1,0 +1,9 @@
+export PS1='\[\033[33;1m\]container(\h)\[\033[0;33m\] \w\[\033[00m\]: '
+export PATH=$PATH:/teleport/build 
+export LS_COLORS="rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:"
+
+alias ls="ls --color=auto"
+alias ll="ls -alF"
+
+# quick way to get into teleport repo dir
+alias t="cd $HOME/go/src/github.com/gravitational/teleport"

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,5 @@
+# file used by docker-compose itself (variables in yaml)
+DEBUG=1
+CONTAINERHOME=/root/go/src/github.com/gravitational/teleport
+PLUGINSHOME=/root/go/src/github.com/gravitational/teleport-plugins
+SLACK_PLUGIN_PATH=/root/go/src/github.com/gravitational/teleport-plugins/access/slack

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,8 @@
+# data dir should contain /var/lib/teleport and is mounted to
+# the containers. It usually contains test data, and should not
+# be committed to git.
+data
+
+# ngrok configs contain ngrok auth keys, don't commit those.
+ngrok.yaml
+ngrok-insecure.yaml

--- a/docker/.screenrc
+++ b/docker/.screenrc
@@ -1,0 +1,2 @@
+# forcefully make bash the default shell
+defshell -bash

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,95 @@
+# teleport-plugins docker flow makefile
+# Based on Teleport's Docker Makefile
+# https://github.com/gravitational/teleport/blob/master/docker/Makefile
+
+# source directory in the build box
+SRCDIR ?= /go/src/github.com/gravitational/teleport-plugins
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+
+# Teleport Enterprise Binary release name. Can be any teleport
+# enterprise version, but has to be available on get.gravitational.com
+RELEASE ?= teleport-ent-v4.3.5-linux-amd64-bin
+
+RUNTIME ?= go1.14.4
+BBOX ?= teleport-buildbox:$(RUNTIME)
+
+# Teleport CLI and plugins CLI flags to pass to them on start
+# This is used in insecure-up and debug to pass
+# --debug and --insecure-no-tls flags
+TELEPORT_FLAGS ?=
+PLUGIN_FLAGS ?=
+
+# Which plugins to run on make up?
+PLUGINS ?= teleport-slack teleport-jira teleport-mattermost teleport-gitlab teleport-pagerduty
+
+#
+# Default target starts a teleport cluster with a single node,
+# provisions all the required configurations for users and roles,
+# and then starts all the plugins.
+#
+.PHONY: up
+up: down
+	TELEPORT_FLAGS=${TELEPORT_FLAGS} PLUGIN_FLAGS=${PLUGIN_FLAGS} docker-compose up teleport ${PLUGINS}
+
+# 'make down' stops all Teleport containers, deletes them
+# and their network
+#
+.PHONY:down
+down:
+	docker-compose down
+
+# `make enter-teleport` gives you shell inside auth server
+# of cluster "one"
+#
+.PHONY:enter-teleport
+enter-teleport:
+	docker-compose run teleport /bin/bash
+
+# builds teleport:latest docker image
+# Using the ../../teleport's docker instructions
+# Note: This doesn't build Teleport itself. If you need to build teleport,
+# go to teleport repo root, and run make -c build.assets
+#
+.PHONY: teleport-ent
+teleport-ent:
+	docker build -t teleport-ent:latest -f ./teleport/Dockerfile \
+		--build-arg RELEASE=$(RELEASE) .
+
+# `make config` provisions configs for the `teleport cluster:
+# 1. Creates the role and user for tests
+# 2. Creates the role and user for plugins to run with
+# 3. Exports the access-plugin certs so that we can later use them for plugins.
+#
+.PHONY: config
+config:
+	docker-compose up -d teleport
+
+	# ----> Creating dummy roles for requests and plugins to use.
+	docker-compose exec teleport /bin/bash -c "tctl create -f \$$PLUGINSHOME/docker/teleport/foo-role.yaml"
+	docker-compose exec teleport /bin/bash -c "tctl create -f \$$PLUGINSHOME/docker/teleport/access-plugin-user-role.yaml"
+
+	# ----> Exporting certificates.
+	docker-compose exec teleport /bin/bash -c "tctl auth sign --format=tls --user=access-plugin --out=plug"
+	docker-compose exec teleport /bin/bash -c "mkdir -p /mnt/shared/certs/access-plugin && mv plug.* /mnt/shared/certs/access-plugin/"
+
+	docker-compose stop teleport
+
+# Builds teleport-plugins:latest docker image that will run plugins in it.
+#
+.PHONY: plugins
+plugins: build-plugins
+	docker build -t teleport-plugins:latest . -f ./plugins/Dockerfile \
+		--build-arg RUNTIME=$(RUNTIME)
+
+# Builds all of the extensions inside the build box docker container.
+#
+.PHONY: build-plugins
+build-plugins:
+	docker run \
+		-v $(MKFILE_PATH)/../../:$(SRCDIR) \
+		$(BBOX) \
+			make -C $(SRCDIR) build-all
+
+.PHONY: clean
+clean:
+	rm -rf data

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,286 @@
+## Docker
+
+This directory contains Docker-based flow to run Teleport Plugins locally, and
+is indended for manual QA with the [Test Plan](../testplan.md) / testing
+purposuses.
+
+### TOC
+
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Starting](#starting)
+- [Stopping](#stopping)
+- [Testing and Manual QA](#testing)
+- [Adding new plugins](#adding-a-new-plugin)
+
+### Prerequisites
+
+This guide assumes you'll run the QA on a machine that has the following:
+
+- GNU Make
+- Docker
+- git
+- Public hostname or static IP address, or ngrok.
+
+### Setup
+
+This flow builds on top of
+[Teleport's own Docker flow](https://github.com/gravitational/teleport/tree/master/docker).
+Teleport's own Docker image and services are managed with that flow.
+
+#### Overview
+
+The setup process builds up several Docker images, and then helps you configure
+the Teleport cluster on those images and some plugins to run together.
+
+Docker images are responsible for the software (i.e. have the correct version of
+Teleport Enterprise to run the plugins), but the further confuguration, like
+what specific certificates and addresses to use for different services is
+performed _after Dockerfiles are built_:
+
+- `Dockerfile` is generally responsible for the software running in the
+  container.
+- `docker-compose.yml` is responsible for baseline configuration for the cluster
+  to work together, and for passing runtime params to the containers.
+- `make config-*` subcommands will help you setup specific configs for specific
+  plugins, and they should work even if the config format changes in the fugure.
+
+#### Getting started with Teleport's Docker flow
+
+First prepare your teleport directory to work with the Docker flow. The flow
+assumes that you have `teleport` alongside `teleport-plugins`, and they have the
+same parent directory.
+
+Teleport's Docker image uses the `teleport-buildbox` image, so we'll set it up
+first. Teleport also uses quay.io to store images, but for the purpose of this
+guide, we'll store images locally.
+
+_*Note: if you're also running Teleport's own dockerized testing kit, you may
+already have `teleport:lastest` and `teleport-buildox` ready.* If that's the
+case, just skip that part and jump to building `teleport-ent` and using it with
+the plugins._
+
+#### Building `teleport-buildbox`
+
+The Buildbox is defined and built in `teleport/build.assets` directory. The
+easiest way to build it is to run the following:
+
+```bash
+git clone git@gitnub.com:gravitational/teleport.git
+cd teleport
+make -C build.assets build
+```
+
+This will build the buildbox container for you, and tag it for quay. If you
+don't have access to that, you can run the command that make runs yourself, but
+with `-t teleport-builbox:go-{GOVERSION}`, like that:
+
+```bash
+# In the teleport/build.assets dir:
+docker build \
+	--build-arg UID=(id -u) \
+	--build-arg GID=(id -g) \
+	--build-arg RUNTIME=go1.13.2 \ # Set whatever runtime verison you want
+	--cache-from quay.io/gravitational/teleport-buildbox:go1.13.2 \
+	-t teleport-buildbox:go1.13.2
+	.
+```
+
+#### Building `teleport:latest`
+
+You'll need Teleport's `teleport:latest` Docker image to run plugins. This
+command will build it:
+
+```bash
+# In the parent directory of teleport-plugins
+git clone git@gitnub.com:gravitational/teleport.git
+cd teleport
+make -C docker build
+```
+
+Note that unlike the `build.assets` Makefile, `docker/Makefile` tags the image
+as `teleport:latest` by default, you don't have to tweak it and remove quay
+reference.
+
+After building the Teleport prerequisites, you should have `teleport` and
+`teleport-buildbox` images build and tagged like this:
+
+```bash
+nate-mbp17:~/g/s/g/g/teleport master docker image ls |grep teleport
+teleport                                  latest              9d87869a9aee        50 seconds ago      1.12GB
+teleport-buildbox                         go1.14.4            9aea93e15a50        6 minutes ago       866MB
+nate-mbp17:~/g/s/g/g/teleport master
+```
+
+If you don't have any of those two images built, the flow might not work
+correctly.
+
+#### Building `teleport-ent:latest`
+
+Teleport Plugins require Enterprise version of Teleport to run correctly, and
+`teleport:latest` won't have it by default, so you'll need to build a special
+Docker image running the enterprise version. This flow calls this immage
+`teleport-ent:latest`, and it's build like this:
+
+```shell
+# In your main teleport-plugins/docker directory
+make teleport-ent
+```
+
+_*Note*: you can pass a `-e RELEASE=binary-teleport-ent-name-to-download` to
+docker build command if you want to — that would install a specified Teleport
+Enterprise version to the container. All the build does, actually, is it takes
+the OSS built `teleport:latest`, downloads the Teleport Enterprise edition, and
+installs it._
+
+_*Note*: this setup requires you to bring your own Teleport Enterprise License
+and put it to `data/var/lib/teleport/license.pam`. Enterprise features, and
+hence the whole flow, might not work otherwise._
+
+After that, we'll build the teleport's image from teleport-plugin's directory.
+We'll still use teleport's own Dockerfile, but the services in
+`docker-compose.yml` are different, and teleport-plugins test flow uses it's own
+`data` directory, just so if you've been testing both teleport and
+teleport-plugins, they shouldn't interfere with each other.
+
+Please refer to Teleport's Docker documentation for more details about it's
+configuration.
+
+#### Building plugins and their docker images
+
+The flow uses the code in your `teleport-plugins` repo clone to build and run
+the plugins. To test different versions, redo this part for a different branch.
+
+To prepare the plugins, we'll build them all in the build box (the Docker image
+used to build Teleport itself), and then, we'll use a separate Docker image to
+run those plugins that we've just built, using the same architecture as we used
+for the buildbox.
+
+`make plugins` will first run the buildbox to build all the plugins, and then
+build their docker image.
+
+```bash
+make plugins
+```
+
+### Starting
+
+#### First start
+
+Before starting testing, you'll need to provision the Teleport cluster
+configuration: multiple user roles and accounts for the plugins to work, and
+their auth certificates, then export them to /mnt/shared/certs.
+
+The auth certificates will have a rather small TTL by default. If you start the
+plugins later and get an auth error, you should run `make config` agian.
+
+```bash
+make config
+```
+
+#### Starting Teleport and the plugins
+
+```bash
+make up # Starts a single node Teleport cluster and all of the available plugins via docker-compose.yml
+# OR
+docker-compose up teleport teleport-slack # Will only start Teleport and Teleport Slack plugin
+```
+
+You can pass CLI flags to both Teleport and every plugin. For example, here's
+how to enable debug logging:
+
+```bash
+TELEPORT_FLAGS="--debug" PLUGIN_FLAGS="--debug" make up
+```
+
+If you prefer to QA without TLS for web proxies and plugin endpoints, you can
+disable TLS and pass the `--insecure-no-tls` flags:
+
+```bash
+TELEPORT_FLAGS="--insecure-no-tls" PLUGIN_FLAGS="--insecure-no-tls" make up
+```
+
+#### Exposing the plugin's HTTP endpoints for webhooks and such
+
+Most of the plugins rely on 3rd party services sending webhooks when some action
+happened on their side. For example, teleport-slack expects to receive a webhook
+when a request is approved or denied on Slack.
+
+For those webhooks to work correctly, you'd need to expose a public address for
+each plugin so that the 3rd party service can reach the plugin running locally
+in your test flow.
+
+If you already have a publicly available hostnames for each plugin — great. If
+not, you can use the supplied ngrok configurations to expose all of the plugins
+like this:
+
+```bash
+ngrok start --all --config ./ngrok.yaml
+```
+
+Gotchas:
+
+- The repo supplies `ngrok.yaml.example` and `ngrok-insecure.yaml.example`. To
+  get started with ngrok, copy those config files and add your own ngrok auth
+  key into them.
+- You'll need at least the Basic plan with ngrok to run more than one tunnel at
+  a time (i.e. test more than a one plugin simultaneously). If you prefer to run
+  just one plugin at a time, you can run ngrok like this:
+  `ngrok start teleport-slack --config ngrok-insecure.yaml`.
+- `ngrok.yaml.example` expects you to use TLS/HTTPS and provide certificates.
+  Use `ngrok-insecure.yaml.example` with `--insecure-no-tls` option to test the
+  plugins without HTTPS.
+
+### Stopping
+
+```bash
+make down
+```
+
+### Testing
+
+Here's a good starting point on what needs to be tested before each release of
+the plugins: [Test Plan](/testplan.md).
+
+After setting everything up and starting Teleport and the plugins for the first
+time with the default config files, you'll notice that most of them fail their
+API healthchecks and exit. **You'll need to provide valid plugin configs,
+specifically any 3rd party OAuth application credentials and URLs for the
+plugins to work and to be tested**.
+
+Two major things to provide:
+
+- Any application credentials, like Slack app ID and app secret, Gitlab URL and
+  app id & secret, etc.
+- The flow does not provision public URLs for the plugins. You'll need to setup
+  public URLs with `ngrok` or another server / service, and set those URLs up in
+  `public_addr` setting of each corresponding plugin. **Note that the default
+  config does map ports for each plugin to your local testing machine, so you
+  might just want to expose that machine with a public address and use it's
+  address and corresponding ports**.
+
+The flow is designed to provide two points where you can change the
+configuration of the cluster to test different scenarios:
+
+- `docker/docker-compose.yml` to change the cluster layout (which services to
+  run). For example, if you'd want to run all of the services with
+  `--insecure-no-tls` flag, adding the flag to the corresponding services
+  `command:` key would work.
+- `docker/teleport/*.yaml` configures the Teleport service itself.
+- `docker/plugins/teleport-*.yaml` configures the plugins. **You'll most likely
+  want to edit any additional plugin configuration, like OAuth app
+  credentials.**
+
+## Contributing
+
+### Adding a new plugin
+
+1. Make sure that the plugin will be built by invoking
+   `make -C docker build-plugins`. The easiest way to do that, is to make sure
+   that is to ensure that the [Makefile in teleport-plugins](/Makefile) repo
+   root will build it when `build-all` is invoked. The new plugin will use the
+   same Docker image as the other plugins.
+2. Add a new service to the `docker/docker-compose.yml` for the plugin to be
+   started on `make up` or `docker-compose up`.
+3. Create a configuration file for the plugin. Run the plugin's `configure`
+   command and save that into a new configuration file, then edit that.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,132 @@
+version: "2"
+
+x-plugin: &plugin
+  image: teleport-plugins:latest
+  env_file:
+    - teleport.env
+  mem_limit: 300M
+  volumes:
+    - ./data/var/lib/teleport:/var/lib/teleport
+    - ../../teleport:/root/go/src/github.com/gravitational/teleport
+    - ..:/root/go/src/github.com/gravitational/teleport-plugins
+    - certs:/mnt/shared/certs
+
+services:
+  # Teleport is a single-node Teleport cluster running all 3 services (Auth, Proxy, and Web).
+  # It assumes that teleport source code is in the same parent dir as teleport-plugins, i.e.
+  # ../../teleport.
+  # It uses image `teleport-ent:latest` and runs enterprise version of Teleport.
+  # Put the license.pem file in data/var/lib/teleport/ before starting.
+  #
+  teleport:
+    image: teleport-ent:latest
+    env_file:
+      - teleport.env
+    container_name: teleport
+    command: |
+      ${CONTAINERHOME}/build/teleport start
+      -c ${PLUGINSHOME}/docker/teleport/teleport.yaml
+      ${TELEPORT_FLAGS}
+    mem_limit: 300M
+    ports:
+      - "3080:3080"
+      - "3023:3023"
+      - "3025:3025"
+    volumes:
+      - ./data/var/lib/teleport:/var/lib/teleport
+      - ../../teleport:/root/go/src/github.com/gravitational/teleport
+      - ..:/root/go/src/github.com/gravitational/teleport-plugins
+      - certs:/mnt/shared/certs
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.1
+        aliases:
+          - "teleport.cluster.local"
+
+  teleport-slack:
+    <<: *plugin
+    container_name: teleport-slack
+    command: |
+      ${PLUGINSHOME}/access/slack/build/teleport-slack start
+      -c ${PLUGINSHOME}/docker/plugins/teleport-slack.toml
+      ${PLUGIN_FLAGS}
+    ports:
+      - "8041:8041"
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.41
+        aliases:
+          - "teleport-slack.cluster.local"
+
+  teleport-mattermost:
+    <<: *plugin
+    container_name: teleport-mattermost
+    command: |
+      ${PLUGINSHOME}/access/mattermost/build/teleport-mattermost start
+      -c ${PLUGINSHOME}/docker/plugins/teleport-mattermost.toml
+      ${PLUGIN_FLAGS}
+    ports:
+      - "8042:8042"
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.42
+        aliases:
+          - "teleport-mattermost.cluster.local"
+
+  teleport-pagerduty:
+    <<: *plugin
+    container_name: teleport-pagerduty
+    command: |
+      ${PLUGINSHOME}/access/pagerduty/build/teleport-pagerduty start
+      -c ${PLUGINSHOME}/docker/plugins/teleport-pagerduty.toml
+      ${PLUGIN_FLAGS}
+    ports:
+      - "8043:8043"
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.43
+        aliases:
+          - "teleport-pagerduty.cluster.local"
+
+  teleport-gitlab:
+    <<: *plugin
+    container_name: teleport-gitlab
+    command: |
+      ${PLUGINSHOME}/access/gitlab/build/teleport-gitlab start
+      -c ${PLUGINSHOME}/docker/plugins/teleport-gitlab.toml
+      ${PLUGIN_FLAGS}
+    ports:
+      - "8044:8044"
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.44
+        aliases:
+          - "teleport-gitlab.cluster.local"
+
+  teleport-jira-cloud:
+    <<: *plugin
+    container_name: teleport-jira-cloud
+    command: |
+      ${PLUGINSHOME}/access/jira/build/teleport-jira start
+      -c ${PLUGINSHOME}/docker/plugins/teleport-jira-cloud.toml
+      ${PLUGIN_FLAGS}
+    ports:
+      - "8045:8045"
+    networks:
+      teleport-network:
+        ipv4_address: 172.10.1.45
+        aliases:
+          - "teleport-jira-cloud.cluster.local"
+
+networks:
+  teleport-network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.10.1.0/16
+        ip_range: 172.10.1.0/24
+        gateway: 172.10.1.254
+
+volumes:
+  certs:

--- a/docker/etc/ssh/sshd_config
+++ b/docker/etc/ssh/sshd_config
@@ -1,0 +1,93 @@
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel DEBUG3
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# allowe users to login
+PermitRootLogin yes
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+TrustedUserCAKeys /mnt/shared/certs/teleport.pub

--- a/docker/ngrok-insecure.yaml.example
+++ b/docker/ngrok-insecure.yaml.example
@@ -1,0 +1,34 @@
+authtoken: INSERT_YOUR_NGROK_TOKEN_HERE #Get your token on https://dashboard.ngrok.com
+tunnels:
+  # Each Ngrok tunnel corresponds to one plugin.
+  # See docker-compose.yaml to see which host and port each plugin
+  # is running on.
+  # The config below uses localhost and relies on docker-compose
+  # port forwarding to get all of the plugins exposed.
+  #
+  # For each of the plugins, make sure that the port and it's
+  # hostname matches it's settings:
+  # - addr: {PORT} should match the port forwarded in docker-compose
+  # - addr: {PORT} should match the port in teleport-{plugin}.toml
+  #   listen: key.
+  # - host_header: should match the plugin config's public host.
+  teleport-slack:
+    addr: 8041 # See docker-compose.yaml for details.
+    proto: http # --insecure-no-tls
+    host_header: teleport-slack.cluster.local # should match the plugin config
+  teleport-mattermost:
+    addr: 8042
+    proto: http
+    host_header: teleport-mattermost.cluster.local
+  teleport-gitlab:
+    addr: 8044
+    proto: http
+    host_header: teleport-gitlab.cluster.local
+  teleport-jira:
+    addr: 8045
+    proto: http
+    host_header: teleport-jira.cluster.local
+  teleport-pagerduty:
+    addr: 8043
+    proto: http
+    host_header: teleport-pagerduty.cluster.local

--- a/docker/plugins/Dockerfile
+++ b/docker/plugins/Dockerfile
@@ -1,0 +1,25 @@
+# Defines Teleport Slack image
+# Based on Teleport's image
+# Tweak this and then do `make build-teleport-slack-image` to rebuild the image.
+
+# The base image (buildbox:latest) is built by running `make -C build.assets`
+# from the teleport repo directory $GOPATH/gravitational.com/teleport
+ARG RUNTIME="go1.14.4"
+FROM teleport-buildbox:$RUNTIME
+RUN apt-get update
+# DEBUG=1 is needed for the Web UI to be loaded from static assets instead
+# of the binary
+ENV DEBUG=1 GOPATH=/root/go PATH=$PATH:/root/go/src/github.com/gravitational/teleport/build:/root/go/src/github.com/gravitational/teleport-plugins/access/slack/build:/root/go/bin
+
+# htop is useful for testing terminal resizing
+RUN apt-get update; apt-get install -y htop vim screen;
+
+# allows ansible and ssh testing
+RUN apt-get install -y ansible ssh inetutils-syslogd
+
+RUN mkdir /run/sshd
+
+VOLUME ["/root/go/src/github.com/gravitational/teleport-plugins", "/var/lib/teleport"]
+COPY .bashrc /root/.bashrc
+COPY .screenrc /root/.screenrc
+COPY ./sshd/start.sh /usr/bin/start-sshd.sh

--- a/docker/plugins/teleport-gitlab.toml
+++ b/docker/plugins/teleport-gitlab.toml
@@ -1,0 +1,24 @@
+[teleport]
+auth_server = "teleport.cluster.local:3025"                  # Teleport Auth Server GRPC API address
+client_key = "/mnt/shared/certs/access-plugin/plug.key" # Teleport GRPC client secret key
+client_crt = "/mnt/shared/certs/access-plugin/plug.crt" # Teleport GRPC client certificate
+root_cas = "/mnt/shared/certs/access-plugin/plug.cas"   # Teleport cluster CA certs
+
+[db]
+path = "/var/lib/teleport/plugins/gitlab/database" # Path to the database file
+
+[gitlab]
+url = ""                                   # Leave empty if you are using cloud
+token = "token"                            # GitLab API Token
+project_id = "1812345"                     # GitLab Project ID
+webhook_secret = "your webhook passphrase" # A secret used to encrypt data we use in webhooks. Basically anything you'd like.
+
+[http]
+public_addr = "teleport-gitlab.cluster.local" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+listen_addr = ":8044" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
+https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
+https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/gitlab.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/docker/plugins/teleport-jira-cloud.toml
+++ b/docker/plugins/teleport-jira-cloud.toml
@@ -1,0 +1,21 @@
+[teleport]
+auth_server = "teleport.cluster.local:3025"                  # Teleport Auth Server GRPC API address
+client_key = "/mnt/shared/certs/access-plugin/plug.key" # Teleport GRPC client secret key
+client_crt = "/mnt/shared/certs/access-plugin/plug.crt" # Teleport GRPC client certificate
+root_cas = "/mnt/shared/certs/access-plugin/plug.cas"   # Teleport cluster CA certs
+
+[jira]
+url = "https://example.com/jira"    # JIRA URL. For JIRA Cloud, https://[my-jira].atlassian.net
+username = "jira-bot"               # JIRA username
+api_token = "token"                 # JIRA API Basic Auth token, or our password in case you're using Jira Server.
+project = "MYPROJ"                  # JIRA Project key
+
+[http]
+public_addr = "teleport-jira.cluster.local" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+listen_addr = ":8045" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
+# https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
+# https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/jira.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/docker/plugins/teleport-mattermost.toml
+++ b/docker/plugins/teleport-mattermost.toml
@@ -1,0 +1,23 @@
+[teleport]
+auth_server = "teleport.cluster.local:3025"                  # Teleport Auth Server GRPC API address
+client_key = "/mnt/shared/certs/access-plugin/plug.key" # Teleport GRPC client secret key
+client_crt = "/mnt/shared/certs/access-plugin/plug.crt" # Teleport GRPC client certificate
+root_cas = "/mnt/shared/certs/access-plugin/plug.cas"   # Teleport cluster CA certs
+
+
+[mattermost]
+url = "https://mattermost.example.com" # Mattermost Server URL
+team = "team-name"                     # Mattermost team in which the channel resides.
+channel = "channel-name"               # Mattermost Channel name to post requests to
+token = "api-token"                    # Mattermost Bot OAuth token
+secret = "signing-secret-value"        # Mattermost API signing Secret
+
+[http]
+public_addr = "teleport-mattermost.cluster.local" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+listen_addr = ":8042" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
+# https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
+# https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/mattermost.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/docker/plugins/teleport-pagerduty.toml
+++ b/docker/plugins/teleport-pagerduty.toml
@@ -1,0 +1,28 @@
+[teleport]
+auth_server = "teleport.cluster.local:3025"                  # Teleport Auth Server GRPC API address
+client_key = "/mnt/shared/certs/access-plugin/plug.key" # Teleport GRPC client secret key
+client_crt = "/mnt/shared/certs/access-plugin/plug.crt" # Teleport GRPC client certificate
+root_cas = "/mnt/shared/certs/access-plugin/plug.cas"   # Teleport cluster CA certs
+
+[pagerduty]
+api_key = "key"               # PagerDuty API Key
+user_email = "me@example.com" # PagerDuty bot user email (Could be admin email)
+service_id = "PIJ90N7"        # PagerDuty service id
+auto_approve = true           # Automatically approve access requests if requestor is on-call
+
+[http]
+public_addr = "teleport-apgerduty.cluster.local" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+# listen_addr = ":8043" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
+https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
+https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
+
+[http.tls]
+verify_client_cert = true # The preferred way to authenticate webhooks on Pagerduty. See more: https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls
+
+[http.basic_auth]
+user = "user"
+password = "password" # If you prefer to use basic auth for Pagerduty Webhooks authentication, use this section to store user and password
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/docker/plugins/teleport-slack.toml
+++ b/docker/plugins/teleport-slack.toml
@@ -1,0 +1,22 @@
+# example slack plugin configuration TOML file
+[teleport]
+# Auth server address from `docker-compose.yml`
+auth_server = "teleport.cluster.local:3025"
+client_key = "/mnt/shared/certs/access-plugin/plug.key" # Teleport GRPC client secret key
+client_crt = "/mnt/shared/certs/access-plugin/plug.crt" # Teleport GRPC client certificate
+root_cas = "/mnt/shared/certs/access-plugin/plug.cas"   # Teleport cluster CA certs
+
+[slack]
+token = "api_token"             # Slack Bot OAuth token
+secret = "signing-secret-value" # Slack API Signing Secret
+channel = "channel-name"        # Slack Channel name to post requests to
+
+[http]
+listen_addr = ":8041" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:443
+public_addr = "teleport-slack.cluster.local" # Hostname on which callback server is accessible externally
+# https_key_file = "/var/lib/teleport/plugins/slack/server.key"  # TLS private key
+# https_cert_file = "/var/lib/teleport/plugins/slack/server.crt" # TLS certificate
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/slack.log"
+severity = "DEBUG" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".

--- a/docker/sshd/etc/ssh/sshd_config
+++ b/docker/sshd/etc/ssh/sshd_config
@@ -1,0 +1,93 @@
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel DEBUG3
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# allowe users to login
+PermitRootLogin yes
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+TrustedUserCAKeys /mnt/shared/certs/teleport.pub

--- a/docker/sshd/pam.d/ssh
+++ b/docker/sshd/pam.d/ssh
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    optional     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/docker/sshd/scripts/export.sh
+++ b/docker/sshd/scripts/export.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while [ 1 ]
+do
+    tctl auth export --type=user | sed s/cert-authority\ // > /mnt/shared/certs/teleport.pub
+    sleep 10
+done

--- a/docker/sshd/start.sh
+++ b/docker/sshd/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+syslogd&
+/usr/sbin/sshd -D

--- a/docker/teleport.env
+++ b/docker/teleport.env
@@ -1,0 +1,3 @@
+DEBUG=1
+CONTAINERHOME=/root/go/src/github.com/gravitational/teleport
+PLUGINSHOME=/root/go/src/github.com/gravitational/teleport-plugins

--- a/docker/teleport/Dockerfile
+++ b/docker/teleport/Dockerfile
@@ -1,0 +1,10 @@
+# This image builds a Docker image with Teleport Enterprise.
+FROM teleport:latest
+
+ARG RELEASE="teleport-ent-v4.2.10-linux-amd64-bin"
+
+# Install Teleport  
+RUN (cd /teleport;\
+      curl -L https://get.gravitational.com/$RELEASE.tar.gz | tar -xz ;\
+      ./teleport-ent/install)
+

--- a/docker/teleport/access-plugin-user-role.yaml
+++ b/docker/teleport/access-plugin-user-role.yaml
@@ -1,0 +1,19 @@
+kind: user
+metadata:
+  name: access-plugin
+spec:
+  roles: ["access-plugin"]
+version: v2
+---
+kind: role
+metadata:
+  name: access-plugin
+spec:
+  allow:
+    rules:
+      - resources: ["access_request"]
+        verbs: ["list", "read", "update"]
+    # teleport currently refuses to issue certs for a user with 0 logins,
+    # this restriction may be lifted in future versions.
+    logins: ["access-plugin"]
+version: v3

--- a/docker/teleport/foo-role.yaml
+++ b/docker/teleport/foo-role.yaml
@@ -1,0 +1,25 @@
+---
+kind: user
+metadata:
+  name: foo
+spec:
+  roles:
+    - foo
+  traits:
+    logins: ["foo"]
+version: v2
+---
+kind: role
+metadata:
+  name: foo
+spec:
+  allow:
+    request:
+      roles: ["admin"]
+    rules:
+      - resources: ["access_request"]
+        verbs: ["list", "read", "update"]
+    # teleport currently refuses to issue certs for a user with 0 logins,
+    # this restriction may be lifted in future versions.
+    logins: ["root"]
+version: v3

--- a/docker/teleport/teleport.yaml
+++ b/docker/teleport/teleport.yaml
@@ -1,0 +1,39 @@
+# Single-node Teleport cluster called "one" (runs all 3 roles: proxy, auth and node)
+teleport:
+  advertise_ip: 172.10.1.1
+  auth_token: foobar
+  auth_servers: ["localhost:3025"]
+  cache:
+    enabled: false
+  log:
+    output: stdout
+    severity: INFO
+    # severity: DEBUG
+
+  data_dir: /var/lib/teleport
+  storage:
+      path: /var/lib/teleport/backend
+      type: dir
+
+auth_service:
+  enabled: yes
+  license_file: /var/lib/teleport/license.pem
+
+  cluster_name: one
+  tokens:
+       - "node,auth,proxy:foobar"
+       - "trustedcluster:bar"
+
+ssh_service:
+  enabled: yes
+  labels:
+      cluster: docker-cluster
+  commands:
+      - name: kernel
+        command: [/bin/uname, -r]
+        period: 5m
+  public_addr: ['localhost']
+
+proxy_service:
+  enabled: yes
+  public_addr: ['localhost:3080']


### PR DESCRIPTION
## Containerized QA flow

This PR adds a `./docker/` directory that does simplifies starting the plugins locally, without requiring any external VMs to QA them. 

The PR doesn't add any new features to the plugins themselves, and doesn't add any new plugins. The PR also doesn't change the way any of the plugins work. It only contains some tooling that we can use internally to quickly QA the plugins, using the [test plan](/testplan.md) or not.

### What to review

I've based the whole thing on Teleport's Docker flow, but some of the things it does (like providing stub licenses) are not implemented and not used in teleport-plugins flow, so there might be some leftovers, especially in `Makefile` and `docker-compose.yaml`. 

Here's what to review thoroughly: 
1. Is the Readme readable? Does it give a clear picture of when one might want to use this, and how to get started? If not, what part can be clarified?
2. I'm new to writing `Makefile`s, might be some weird stuff in there. 
3. Manual testing: I'll try to add a screencast on how to get started step by step, but maybe @benarent will want to try running this, maybe specifically for Pagerduty plugin to debug the webhooks problem? That would help make both readme and the flow itself easier.  

###  TODOs

That's my WIP todo list, disregard that :)

- [x] Run Teleport, tctl, and Teleport Web UI with root access to them.
- [x] Test that we're able to create new roles and users
- [x] Test that we're able to sign and export certificates
- [x] Run Slack Plugin and provide a way to edit it's configuration
- [x] Run Mattermost Plugin and provide a way to edit it's configuration
- [x] Run Pagerduty Plugin and provide a way to edit it's configuration
- [x] Run Gitlab Plugin and provide a way to edit it's configuration
- [x] Run Jira Plugin and provide a way to edit it's configuration

- [x] Provide a runner for both regular and `--insecure-no-tctl` modes
- [x] Optional: Document how to setup public hosts for plugins with ngrok / provide a make command for this as well.
- [ ] Optional: Document how to setup your own certificates with certmanager / LE

- [ ] Optional: Provide a way to run Jira Server as one of the Dockerized services, and run two different versions of Jira plugin (Server & Cloud).