### PR TITLE
Implements Version subcommand:

### DIFF
--- a/access/gitlab/main.go
+++ b/access/gitlab/main.go
@@ -23,6 +23,7 @@ func main() {
 	app := kingpin.New("teleport-gitlab", "Teleport plugin for access requests approval via GitLab.")
 
 	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", "Prints teleport-gitlab version and exits.")
 
 	startCmd := app.Command("start", "Starts a Teleport GitLab plugin.")
 	path := startCmd.Flag("config", "TOML config file path").
@@ -44,6 +45,8 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		fmt.Print(exampleConfig)
+	case "version":
+		utils.PrintVersion(app.Name, Version, Gitref)
 	case "start":
 		if err := run(*path, *insecure, *debug); err != nil {
 			utils.Bail(err)

--- a/access/jira/main.go
+++ b/access/jira/main.go
@@ -39,6 +39,7 @@ func main() {
 	app := kingpin.New("teleport-jira", "Teleport plugin for access requests approval via JIRA.")
 
 	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", "Prints teleport-jira version and exits.")
 
 	startCmd := app.Command("start", "Starts a Teleport JIRA plugin.")
 	path := startCmd.Flag("config", "TOML config file path").
@@ -60,6 +61,8 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		fmt.Print(exampleConfig)
+	case "version":
+		utils.PrintVersion(app.Name, Version, Gitref)
 	case "start":
 		if err := run(*path, *insecure, *debug); err != nil {
 			utils.Bail(err)

--- a/access/mattermost/main.go
+++ b/access/mattermost/main.go
@@ -39,6 +39,7 @@ func main() {
 	app := kingpin.New("teleport-mattermost", "Teleport plugin for access requests approval via Mattermost.")
 
 	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", "Prints teleport-mattermost version and exits.")
 
 	startCmd := app.Command("start", "Starts a Teleport Mattermost plugin.")
 	path := startCmd.Flag("config", "TOML config file path").
@@ -60,6 +61,8 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		fmt.Print(exampleConfig)
+	case "version":
+		utils.PrintVersion(app.Name, Version, Gitref)
 	case "start":
 		if err := run(*path, *insecure, *debug); err != nil {
 			utils.Bail(err)

--- a/access/pagerduty/main.go
+++ b/access/pagerduty/main.go
@@ -23,6 +23,7 @@ func main() {
 	app := kingpin.New("teleport-pagerduty", "Teleport plugin for access requests approval via PagerDuty.")
 
 	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", "Prints teleport-pagerduty version and exits.")
 
 	startCmd := app.Command("start", "Starts a Teleport PagerDuty plugin.")
 	path := startCmd.Flag("config", "TOML config file path").
@@ -44,6 +45,8 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		fmt.Print(exampleConfig)
+	case "version":
+		utils.PrintVersion(app.Name, Version, Gitref)
 	case "start":
 		if err := run(*path, *insecure, *debug); err != nil {
 			utils.Bail(err)

--- a/access/slack/main.go
+++ b/access/slack/main.go
@@ -41,9 +41,10 @@ const (
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("slack", "Teleport plugin for access requests approval via Slack.")
+	app := kingpin.New("teleport-slack", "Teleport plugin for access requests approval via Slack.")
 
 	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", "Prints teleport-slack version and exits.")
 
 	startCmd := app.Command("start", "Starts a the Teleport Slack plugin.")
 	path := startCmd.Flag("config", "TOML config file path").
@@ -65,6 +66,8 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		fmt.Print(exampleConfig)
+	case "version":
+		utils.PrintVersion(app.Name, Version, Gitref)
 	case "start":
 		if err := run(*path, *insecure, *debug); err != nil {
 			utils.Bail(err)

--- a/utils/runner.go
+++ b/utils/runner.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// PrintVersion prints the specified app version to STDOUT
+func PrintVersion(appName string, version string, gitref string) {
+	if gitref != "" {
+		fmt.Printf("%v v%v git:%v %v\n", appName, version, gitref, runtime.Version())
+	} else {
+		fmt.Printf("%v v%v %v\n", appName, version, runtime.Version())
+	}
+}


### PR DESCRIPTION
- Closes #113
- Works for all current plugins: Slack, Jira, Mattermost,
  Pagerduty, and Gitlab.
- Print func in utils to dry things up a bit.

Disclaimer: I was just curious about go and wrote a few lines, please go extra thorough on the review. 

Next steps: I noticed that most of the `main.go` in all of the plugin is the same, save for the plugin name. I think it would be nice to have a `runner` utility struct that would have a func to declare a standard Kingpin app with three shared commands (start, configure, version), and accept any extra commands / expose the app in case a new integration needs more flexibility. 

I'll play around with this next if you don't mind ;-) 