### PR TITLE
Prettier all the READMEs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: "always"

--- a/README.md
+++ b/README.md
@@ -7,44 +7,48 @@ Set of plugins for Teleport
 ## Access API
 
 The [access](./access) package exposes a simple API for managing access requests
-which can be used for writing plugins.  More info can be found in
-[access/README.md](./access/README.md), including instructions on how to properly
-provision necessary certificates.
+which can be used for writing plugins. More info can be found in
+[access/README.md](./access/README.md), including instructions on how to
+properly provision necessary certificates.
 
 ### Example
 
-The [access/example](./access/example) plugin automatically approves access requests based
-on a user whitelist.  This is a good place to start if you are trying to understand
-how to use the [`access`](./access) API.
+The [access/example](./access/example) plugin automatically approves access
+requests based on a user whitelist. This is a good place to start if you are
+trying to understand how to use the [`access`](./access) API.
 
-Use `make access-example` to build the plugin and `./build/access-example configure` to print out
-a sample configuration file.
+Use `make access-example` to build the plugin and
+`./build/access-example configure` to print out a sample configuration file.
 
 ### Slack Bot
 
-A basic slack plugin (WIP) can be found in [access/slack](./access/slack).
-The plugin can be built with `make access-slack` and instructions for configuring the
-plugin can be found in the plugin's [README](./access/slack/README.md).
+A basic slack plugin (WIP) can be found in [access/slack](./access/slack). The
+plugin can be built with `make access-slack` and instructions for configuring
+the plugin can be found in the plugin's [README](./access/slack/README.md).
 
 ### JIRA Bot
 
-A basic Teleport / JIRA integration (WIP) can be found in [access/jira](./access/jira).
-The plugin can be built with `make access-jira` and instructions for configuring the
-plugin can be found in the plugin's [README](./access/jira/README.md).
+A basic Teleport / JIRA integration (WIP) can be found in
+[access/jira](./access/jira). The plugin can be built with `make access-jira`
+and instructions for configuring the plugin can be found in the plugin's
+[README](./access/jira/README.md).
 
 ### Mattermost Bot
 
-Mattermost is a private cloud messaging platform (think Slack for enterprise). Teleport provides a
-Mattermost integration that supports request flows similar to Slack integration above.
-The plugin can be built with `make access-mattermost`, and instructions for configuring the
-plugin can be found in the plugin's [README](./access/mattermost/README.md).
+Mattermost is a private cloud messaging platform (think Slack for enterprise).
+Teleport provides a Mattermost integration that supports request flows similar
+to Slack integration above. The plugin can be built with
+`make access-mattermost`, and instructions for configuring the plugin can be
+found in the plugin's [README](./access/mattermost/README.md).
 
 ### Pagerduty Extension
 
-A Teleport integration with Pagerduty that allows your team to treat Teleport permission requests
-as Pagerduty incidents, and provides Pagerduty special actions to approve or deny permission requests.
-Run `make teleport-pagerduty` to build it. More docs in the [README](./access/pagerduty/README.md).
+A Teleport integration with Pagerduty that allows your team to treat Teleport
+permission requests as Pagerduty incidents, and provides Pagerduty special
+actions to approve or deny permission requests. Run `make teleport-pagerduty` to
+build it. More docs in the [README](./access/pagerduty/README.md).
 
 ## Notes
 
-Use `scripts/dep` for dependencies management. It is a wrapper over `dep` which ignores git submodules.
+Use `scripts/dep` for dependencies management. It is a wrapper over `dep` which
+ignores git submodules.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ Use `make access-example` to build the plugin and
 
 ### Slack Bot
 
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_slack/)
+
 A basic slack plugin (WIP) can be found in [access/slack](./access/slack). The
 plugin can be built with `make access-slack` and instructions for configuring
 the plugin can be found in the plugin's [README](./access/slack/README.md).
 
 ### JIRA Bot
+
+- [See detailed setup instructions for Jira Cloud on the website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_jira_cloud/)
+- [See detailed setup instructions for Jira Server on the website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_jira_server/)
 
 A basic Teleport / JIRA integration (WIP) can be found in
 [access/jira](./access/jira). The plugin can be built with `make access-jira`
@@ -35,6 +40,8 @@ and instructions for configuring the plugin can be found in the plugin's
 
 ### Mattermost Bot
 
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_mattermost/)
+
 Mattermost is a private cloud messaging platform (think Slack for enterprise).
 Teleport provides a Mattermost integration that supports request flows similar
 to Slack integration above. The plugin can be built with
@@ -42,6 +49,8 @@ to Slack integration above. The plugin can be built with
 found in the plugin's [README](./access/mattermost/README.md).
 
 ### Pagerduty Extension
+
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_pagerduty/)
 
 A Teleport integration with Pagerduty that allows your team to treat Teleport
 permission requests as Pagerduty incidents, and provides Pagerduty special

--- a/access/gitlab/README.md
+++ b/access/gitlab/README.md
@@ -1,17 +1,22 @@
 # Teleport / Gitlab plugin
 
-The plugin allows teams to setup permissions workflow over their existing or new Gitlab projects. 
-When someone requests new permissions, an issue will be opened, and the team members can assign approval or denied label to the issue to approve or deny the request.
-
+The plugin allows teams to setup permissions workflow over their existing or new
+Gitlab projects. When someone requests new permissions, an issue will be opened,
+and the team members can assign approval or denied label to the issue to approve
+or deny the request.
 
 ## Quick setup
 
 To get things up & running quickly:
 
-
-1. On Gitlab, go "User Settings" -> "Access Tokens". Create a token with api scope, remember the token.
-2. Create a project, get its numeric "Project ID" from "Project Overview" -> "Details" page.
-3. You might want to create the Board with lists: `Teleport: Pending`, `Teleport: Approved`, and `Teleport: Denied`. The plugin will work if you just change labels on issues, but with a Board you can just drag the issue into a status-column you want.
+1. On Gitlab, go "User Settings" -> "Access Tokens". Create a token with api
+   scope, remember the token.
+2. Create a project, get its numeric "Project ID" from "Project Overview" ->
+   "Details" page.
+3. You might want to create the Board with lists: `Teleport: Pending`,
+   `Teleport: Approved`, and `Teleport: Denied`. The plugin will work if you
+   just change labels on issues, but with a Board you can just drag the issue
+   into a status-column you want.
 4. Create an /etc/teleport-gitlab.yml
 
 ```toml
@@ -42,4 +47,6 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-The plugin creates labels on Gitlab automatically if they don't exist yet. You don't have to set anything up on Gitlab, except for the project (create new, or grab project ID from an existing one), and the Board.
+The plugin creates labels on Gitlab automatically if they don't exist yet. You
+don't have to set anything up on Gitlab, except for the project (create new, or
+grab project ID from an existing one), and the Board.

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -1,14 +1,17 @@
 # Teleport JIRA Bot
 
-This package provides Teleport <-> Jira integration that allows teams to approve or deny Access Requests on a Jira Project Board.
-It works with both Jira Cloud and Jira Server 8.
+This package provides Teleport <-> Jira integration that allows teams to approve
+or deny Access Requests on a Jira Project Board. It works with both Jira Cloud
+and Jira Server 8.
 
 ## Setup
 
 Setup process is different for the Jira Cloud and Jira Server editions:
 
-- Please refer to [INSTALL-JIRA-CLOUD.md](./INSTALL-JIRA-CLOUD.md) for a detailed Jira Cloud getting started guide.
-- Jira Server getting started guide: [INSTALL-JIRA-SERVER.md](./INSTALL-JIRA-SERVER.md)
+- Please refer to [INSTALL-JIRA-CLOUD.md](./INSTALL-JIRA-CLOUD.md) for a
+  detailed Jira Cloud getting started guide.
+- Jira Server getting started guide:
+  [INSTALL-JIRA-SERVER.md](./INSTALL-JIRA-SERVER.md)
 
 Next few paragraphs will guide you through building the plugin locally.
 
@@ -55,34 +58,43 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 
 ### `[teleport]`
 
-This configuration section ensures that the bot can talk to your teleport
-auth server & manage access-requests.  Use `tctl auth sign --format=tls`
-to generate the required PEM files, and make sure that the Auth Server's
-GRPC API is accessible at the address indicated by `auth_server`.
+This configuration section ensures that the bot can talk to your teleport auth
+server & manage access-requests. Use `tctl auth sign --format=tls` to generate
+the required PEM files, and make sure that the Auth Server's GRPC API is
+accessible at the address indicated by `auth_server`.
 
-*NOTE*: The jira plugin must be given a teleport user identity with
-appropriate permissions.  See the [access package README](../README.md#authentication)
-for an example of how to configure an appropriate user & role.
+_NOTE_: The jira plugin must be given a teleport user identity with appropriate
+permissions. See the [access package README](../README.md#authentication) for an
+example of how to configure an appropriate user & role.
 
 ### `[jira]`
 
-This block manages interacting with your Jira installation. You'd need to paste your Jira dashboard URL, project key, and your access token.
-You can grab a JIRA Cloud API token [on this page](https://id.atlassian.com/manage/api-tokens).
+This block manages interacting with your Jira installation. You'd need to paste
+your Jira dashboard URL, project key, and your access token. You can grab a JIRA
+Cloud API token [on this page](https://id.atlassian.com/manage/api-tokens).
 
-You'll need to setup a custom issue field on Jira. It's name must be `TeleportAccessRequestId`, and it should be on the issue type `Task` in the project you intend to use with Teleport.GET
+You'll need to setup a custom issue field on Jira. It's name must be
+`TeleportAccessRequestId`, and it should be on the issue type `Task` in the
+project you intend to use with Teleport.GET
 
 ### `[http]`
 
-Jirabot starts it's own http server and listens to a webhook from JIRA, this block covers the http server's behavior, including the listen host & port, and TLS certs.
+Jirabot starts it's own http server and listens to a webhook from JIRA, this
+block covers the http server's behavior, including the listen host & port, and
+TLS certs.
 
 ## Usage
 
 Once your jira plugin has been configured, you can verify that it is working
-correctly by using `tctl request create <user> --roles=<roles>` to simulate
-an access request. You should see a new JIRA card pop up. You can now drag the card to either Approved or Denied column, and that should approve or deny the request on Teleport. You can verify that the request was indeed processed correctly by running `tctl request ls`.
-
+correctly by using `tctl request create <user> --roles=<roles>` to simulate an
+access request. You should see a new JIRA card pop up. You can now drag the card
+to either Approved or Denied column, and that should approve or deny the request
+on Teleport. You can verify that the request was indeed processed correctly by
+running `tctl request ls`.
 
 ## Security
 
-Currently, this Bot does not make any distinction about *who* approves/denies
-a request. Any user with access to the Jira project, if not constrained by JIRA workflows, can approve or deny Teleport requests. You can use JIRA workflows to limit who can approve or deny the requests.
+Currently, this Bot does not make any distinction about _who_ approves/denies a
+request. Any user with access to the Jira project, if not constrained by JIRA
+workflows, can approve or deny Teleport requests. You can use JIRA workflows to
+limit who can approve or deny the requests.

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -6,6 +6,9 @@ and Jira Server 8.
 
 ## Setup
 
+- [See detailed setup instructions for Jira Cloud on the website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_jira_cloud/)
+- [See detailed setup instructions for Jira Server on the website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_jira_server/)
+
 Setup process is different for the Jira Cloud and Jira Server editions:
 
 - Please refer to [INSTALL-JIRA-CLOUD.md](./INSTALL-JIRA-CLOUD.md) for a

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -5,6 +5,8 @@ approve or deny Teleport access requests using Mattermost.
 
 ## Setup
 
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_mattermost/)
+
 ### Prerequisites
 
 This guide assumes that you have:

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -1,6 +1,7 @@
 # Teleport Mattermost Bot
 
-This package provides Teleport <-> Mattermost integrataion that allows teams to approve or deny Teleport access requests using Mattermost.
+This package provides Teleport <-> Mattermost integrataion that allows teams to
+approve or deny Teleport access requests using Mattermost.
 
 ## Setup
 
@@ -8,37 +9,45 @@ This package provides Teleport <-> Mattermost integrataion that allows teams to 
 
 This guide assumes that you have:
 
-* Teleport Enterprise 4.2.8 or newer
-* Admin privileges with access to `tctl`
-* Mattermost account with admin privileges.
+- Teleport Enterprise 4.2.8 or newer
+- Admin privileges with access to `tctl`
+- Mattermost account with admin privileges.
 
 #### Setting up a sandbox Mattermost instance for testing
 
-If you want to build the plugin and test it with Mattermost, the easiest way to get Mattermost running is with the docker image:
+If you want to build the plugin and test it with Mattermost, the easiest way to
+get Mattermost running is with the docker image:
 
 ```bash
 docker run --name mattermost-preview -d --publish 8065:8065 --add-host dockerhost:127.0.0.1 mattermost/mattermost-preview
 ```
 
-Check out [more documentation on running Mattermost](https://docs.mattermost.com/install/docker-local-machine.html).
-
+Check out
+[more documentation on running Mattermost](https://docs.mattermost.com/install/docker-local-machine.html).
 
 #### Setting up Mattermost to work with the bot
 
-In Mattermost, go to System Console -> Integrations -> Enable Bot Account Creation -> Set to True.
-This will allow us to create a new bot account that the Teleport bot will use.
+In Mattermost, go to System Console -> Integrations -> Enable Bot Account
+Creation -> Set to True. This will allow us to create a new bot account that the
+Teleport bot will use.
 
 Go back to your team, then Integrations -> Bot Accounts -> Add Bot Account.
 
 The new bot account will need Post All permission.
 
-The confirmation screen after you've created the bot will give you the access token. We'll use this in the config later.
+The confirmation screen after you've created the bot will give you the access
+token. We'll use this in the config later.
 
 #### Create an access-plugin role and user within Teleport
-First off, using an existing Teleport Cluster, we are going to create a new Teleport User and Role to access Teleport.
+
+First off, using an existing Teleport Cluster, we are going to create a new
+Teleport User and Role to access Teleport.
 
 #### Create User and Role for access.
-Log into Teleport Authentication Server, this is where you normally run `tctl`. Don't change the username and the role name, it should be `access-plugin` for the plugin to work correctly.
+
+Log into Teleport Authentication Server, this is where you normally run `tctl`.
+Don't change the username and the role name, it should be `access-plugin` for
+the plugin to work correctly.
 
 ```bash
 $ cat > rscs.yaml <<EOF
@@ -68,21 +77,29 @@ $ tctl create -f rscs.yaml
 ```
 
 #### Export access-plugin Certificate
-Teleport Plugin uses the `access-plugin`role and user to peform the approval. We export the identify files, using [`tctl auth sign`](https://gravitational.com/teleport/docs/cli-docs/#tctl-auth-sign).
+
+Teleport Plugin uses the `access-plugin`role and user to peform the approval. We
+export the identify files, using
+[`tctl auth sign`](https://gravitational.com/teleport/docs/cli-docs/#tctl-auth-sign).
 
 ```bash
 $ tctl auth sign --format=tls --user=access-plugin --out=auth --ttl=8760h
 # ...
 ```
 
-The above sequence should result in three PEM encoded files being generated: auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs respectively).  We'll reference these later in the bot config, and move them to an appropriate directory.
+The above sequence should result in three PEM encoded files being generated:
+auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs
+respectively). We'll reference these later in the bot config, and move them to
+an appropriate directory.
 
-_Note: by default, tctl auth sign produces certificates with a relatively short lifetime. For production deployments, the --ttl flag can be used to ensure a more practical certificate lifetime. --ttl=8760h exports a 1 year token_
-
+_Note: by default, tctl auth sign produces certificates with a relatively short
+lifetime. For production deployments, the --ttl flag can be used to ensure a
+more practical certificate lifetime. --ttl=8760h exports a 1 year token_
 
 ## Downloading and installing the plugin
 
-The recommended way to run Teleport Mattermost plugin is by downloading the release version and installing it:
+The recommended way to run Teleport Mattermost plugin is by downloading the
+release version and installing it:
 
 ```bash
 $ wget https://get.gravitational.com/teleport-mattermost-v0.0.1-linux-amd64-bin.tar.gz
@@ -107,7 +124,8 @@ make
 
 ### Configuring Mattermost bot
 
-Mattermost Bot uses a config file in TOML format. Generate a boilerplate config by running the following command:
+Mattermost Bot uses a config file in TOML format. Generate a boilerplate config
+by running the following command:
 
 ```
 teleport-mattermost configure > /etc/teleport-mattermost.yml
@@ -143,4 +161,5 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 
 ### Running the bot
 
-With the config above, you should be able to run the bot invoking `teleport-mattermost start`
+With the config above, you should be able to run the bot invoking
+`teleport-mattermost start`

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -5,6 +5,8 @@ treat Teleport access and permission requests as Pagerduty incidents — and
 notify the appropriate team, and approve or deny the requests via Pagerduty
 special action.
 
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_pagerduty/)
+
 ## Prerequisites
 
 This guide assumes you have

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -1,20 +1,30 @@
 # Teleport Pagerduty Integration
 
-This package provides a Teleport <-> Pagerduty integration that allows you to treat Teleport access and permission requests as Pagerduty incidents — and notify the appropriate team, and approve or deny the requests via Pagerduty special action.
+This package provides a Teleport <-> Pagerduty integration that allows you to
+treat Teleport access and permission requests as Pagerduty incidents — and
+notify the appropriate team, and approve or deny the requests via Pagerduty
+special action.
 
 ## Prerequisites
+
 This guide assumes you have
 
-* Teleport Enterprise 4.2.8 or newer with admin permissions and access to `tctl`
-* Pagerduty account already set, with access to creating a new API token.
+- Teleport Enterprise 4.2.8 or newer with admin permissions and access to `tctl`
+- Pagerduty account already set, with access to creating a new API token.
 
 ### Create an access-plugin role and user within Teleport
-First off, using an existing Teleport Cluster, we are going to create a new Teleport User and Role to access Teleport.
+
+First off, using an existing Teleport Cluster, we are going to create a new
+Teleport User and Role to access Teleport.
 
 #### Create User and Role for access.
-Log into Teleport Authent Server, this is where you normally run `tctl`. Don't change the username and the role name, it should be `access-plugin` for the plugin to work correctly.
 
-_Note: if you're using other plugins, you might want to create different users and roles for different plugins_.
+Log into Teleport Authent Server, this is where you normally run `tctl`. Don't
+change the username and the role name, it should be `access-plugin` for the
+plugin to work correctly.
+
+_Note: if you're using other plugins, you might want to create different users
+and roles for different plugins_.
 
 ```
 $ cat > rscs.yaml <<EOF
@@ -44,35 +54,53 @@ $ tctl create -f rscs.yaml
 ```
 
 #### Export access-plugin Certificate
-Teleport Plugin uses the `access-plugin`role and user to perform the approval. We export the identify files, using [`tctl auth sign`](https://gravitational.com/teleport/docs/cli-docs/#tctl-auth-sign).
+
+Teleport Plugin uses the `access-plugin`role and user to perform the approval.
+We export the identify files, using
+[`tctl auth sign`](https://gravitational.com/teleport/docs/cli-docs/#tctl-auth-sign).
 
 ```
 $ tctl auth sign --format=tls --user=access-plugin --out=auth --ttl=8760h
 # ...
 ```
 
-The above sequence should result in three PEM encoded files being generated: auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs respectively).  We'll reference these later in the Pagerduty integration config file.
+The above sequence should result in three PEM encoded files being generated:
+auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs
+respectively). We'll reference these later in the Pagerduty integration config
+file.
 
-_Note: by default, tctl auth sign produces certificates with a relatively short lifetime. For production deployments, the --ttl flag can be used to ensure a more practical certificate lifetime. --ttl=8760h exports a 1 year token_
+_Note: by default, tctl auth sign produces certificates with a relatively short
+lifetime. For production deployments, the --ttl flag can be used to ensure a
+more practical certificate lifetime. --ttl=8760h exports a 1 year token_
 
 ### Setting up Pagerduty API key
 
-In your Pagerduty dashboard, go to **Configuration -> API Access -> Create New API Key**, add a key description, and save the key. We'll use the key in the plugin config file later.
-
+In your Pagerduty dashboard, go to **Configuration -> API Access -> Create New
+API Key**, add a key description, and save the key. We'll use the key in the
+plugin config file later.
 
 ### Securing Pagerduty webhooks
 
-Pagerduty doesn't have a mechanism to sign it's webhook payload. Instead, they provide two good ways for you to verify the integrity and origin of the webhook requests (i.e. that the webhook is actually sent by Pagerduty, not bo something else):
+Pagerduty doesn't have a mechanism to sign it's webhook payload. Instead, they
+provide two good ways for you to verify the integrity and origin of the webhook
+requests (i.e. that the webhook is actually sent by Pagerduty, not bo something
+else):
 
 - Basic auth (not recommended)
 - Certificate verification (recommended and default).
 
-To setup Basic Auth, setup a usename and password in the config below. in `[http.basic_auth]` section.
+To setup Basic Auth, setup a usename and password in the config below. in
+`[http.basic_auth]` section.
 
-If you intend to run `teleport-pagerduty` with TLS anyway, then to ensure mutual TLS verification, you need to setup `verify-client-cert = true` in the config below in `[http.tls]` section.
+If you intend to run `teleport-pagerduty` with TLS anyway, then to ensure mutual
+TLS verification, you need to setup `verify-client-cert = true` in the config
+below in `[http.tls]` section.
 
-If you're running `teleport-pagerduty` with `--insecure-no-tls`, and another Proxy server provides TLS certs for your setup, you'll need to setup TLS verification on that proxy server instead.
-Pagerduty documentation covers that process here: [https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls](https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls).
+If you're running `teleport-pagerduty` with `--insecure-no-tls`, and another
+Proxy server provides TLS certs for your setup, you'll need to setup TLS
+verification on that proxy server instead. Pagerduty documentation covers that
+process here:
+[https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls](https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls).
 
 ## Install
 
@@ -93,16 +121,22 @@ make access-pagerduty
 # Run the plugin, assuming you have teleport running:
 ./build/teleport-pagerduty start
 ```
-The teleport-pagerduty executable should be placed onto a server that can access the auth server address.
+
+The teleport-pagerduty executable should be placed onto a server that can access
+the auth server address.
 
 ### Config file
-Teleport Pagerduty plugin has its own configuration file in TOML format. Before starting the plugin for the first time, you'll need to generate and edit that config file.
+
+Teleport Pagerduty plugin has its own configuration file in TOML format. Before
+starting the plugin for the first time, you'll need to generate and edit that
+config file.
 
 ```bash
 teleport-pagerduty configure > /etc/teleport-pagerduty.toml
 ```
 
 #### Editing the config file
+
 Afger generating the config, edit it as follows:
 
 ```TOML
@@ -142,4 +176,5 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 teleport-pagerduty start
 ```
 
-By default, `teleport-pagerduty` will assume it's config is in `/etc/teleport-pagerduty.toml`, but you can override it with `--config` option.
+By default, `teleport-pagerduty` will assume it's config is in
+`/etc/teleport-pagerduty.toml`, but you can override it with `--config` option.

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -6,6 +6,8 @@ interactive Slack messages.
 
 ## Setup
 
+[See setup instructions on Teleport's website](https://gravitational.com/teleport/docs/enterprise/workflow/ssh_approval_slack/)
+
 Run `make access-slack && ./access/slack/build/teleport-slack configure` from
 the repository root. The `configure` command will produce an example
 configuration file that looks something like this:

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -1,13 +1,13 @@
 # slack
 
 This package implements a simple Slack plugin using the API provided in the
-[`access`](../) package which allows Access Requests to be approved/denied
-via interactive Slack messages.
+[`access`](../) package which allows Access Requests to be approved/denied via
+interactive Slack messages.
 
 ## Setup
 
-Run `make access-slack && ./access/slack/build/teleport-slack configure` from the
-repository root.  The `configure` command will produce an example
+Run `make access-slack && ./access/slack/build/teleport-slack configure` from
+the repository root. The `configure` command will produce an example
 configuration file that looks something like this:
 
 ```toml
@@ -33,23 +33,24 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-Detailed install steps are provided within the [`install`](INSTALL.md) instructions.
+Detailed install steps are provided within the [`install`](INSTALL.md)
+instructions.
 
 ### `[teleport]`
 
-This configuration section ensures that the bot can talk to your teleport
-auth server & manage access-requests.  Use `tctl auth sign --format=tls`
-to generate the required PEM files, and make sure that the Auth Server's
-GRPC API is accessible at the address indicated by `auth_server`.
+This configuration section ensures that the bot can talk to your teleport auth
+server & manage access-requests. Use `tctl auth sign --format=tls` to generate
+the required PEM files, and make sure that the Auth Server's GRPC API is
+accessible at the address indicated by `auth_server`.
 
-*NOTE*: The slack plugin must be given a teleport user identity with
-appropriate permissions.  See the [acccess package README](../README.md#authentication)
-for an example of how to configure an appropriate user & role.
+_NOTE_: The slack plugin must be given a teleport user identity with appropriate
+permissions. See the [acccess package README](../README.md#authentication) for
+an example of how to configure an appropriate user & role.
 
 ### `[slack]`
 
-In order to interact with slack, we need a valid bot OAuth token and we need
-to be able to receive callbacks from slack when users interact with messages.
+In order to interact with slack, we need a valid bot OAuth token and we need to
+be able to receive callbacks from slack when users interact with messages.
 
 A token can be provisioned from [api.slack.com](https://api.slack.com) by
 registering an App and associated Bot User for your workspace.
@@ -58,24 +59,21 @@ In order to receive interaction callbacks, make sure the `host` address is
 publicly accessible and register it with your App under
 `Features > Interactive Components > Request URL`.
 
-*NOTE*: For debug purposes, slack recommends using `ngrok http` to get a
-public HTTPS endpoint for your interaction callback. You must also use
+_NOTE_: For debug purposes, slack recommends using `ngrok http` to get a public
+HTTPS endpoint for your interaction callback. You must also use
 `--insecure-no-tls` option when running Slackbot under `ngrok`.
 
 ## Usage
 
 Once your Slack plugin has been configured, you can verify that it is working
-correctly by using `tctl request create <user> --roles=<roles>` to simulate
-an access request.  If everything is working as intended, a message with
-`Approve` and `Deny` buttons should appear in the channel specified under
-`slack.channel`.  Select `Deny` and verify that the request was indeed
-denied using `tctl request ls`.
-
+correctly by using `tctl request create <user> --roles=<roles>` to simulate an
+access request. If everything is working as intended, a message with `Approve`
+and `Deny` buttons should appear in the channel specified under `slack.channel`.
+Select `Deny` and verify that the request was indeed denied using
+`tctl request ls`.
 
 ## Security
 
-Currently, this Bot does not make any distinction about *who* approves/denies
-a request.  Any user with access to the specified channel will be able to
-manage requests.  Therefore, it is important that access to the channel
-be limited.
-
+Currently, this Bot does not make any distinction about _who_ approves/denies a
+request. Any user with access to the specified channel will be able to manage
+requests. Therefore, it is important that access to the channel be limited.


### PR DESCRIPTION
Just cleaned up the readme files, and included a .prettierc to enforce 80 characters per line and proper word wrapping. @benarent, please take another look in case I messed them up. There should be no visible changes to README files when you view them, but the diffs should look like they're just reformatted. If there's a difference in how they look when they're rendered, that might be a problem ;) 