### PR TITLE
Refactored plugin Kingpin apps into utils/runner

### DIFF
--- a/access/gitlab/main.go
+++ b/access/gitlab/main.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/utils"
-
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -16,44 +13,13 @@ import (
 
 const (
 	DefaultDir = "/var/lib/teleport/plugins/gitlab"
+	PluginName = "teleport-gitlab"
 )
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("teleport-gitlab", "Teleport plugin for access requests approval via GitLab.")
-
-	app.Command("configure", "Prints an example .TOML configuration file.")
-	app.Command("version", "Prints teleport-gitlab version and exits.")
-
-	startCmd := app.Command("start", "Starts a Teleport GitLab plugin.")
-	path := startCmd.Flag("config", "TOML config file path").
-		Short('c').
-		Default("/etc/teleport-gitlab.toml").
-		String()
-	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
-		Short('d').
-		Bool()
-	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
-		Default("false").
-		Bool()
-
-	selectedCmd, err := app.Parse(os.Args[1:])
-	if err != nil {
-		utils.Bail(err)
-	}
-
-	switch selectedCmd {
-	case "configure":
-		fmt.Print(exampleConfig)
-	case "version":
-		utils.PrintVersion(app.Name, Version, Gitref)
-	case "start":
-		if err := run(*path, *insecure, *debug); err != nil {
-			utils.Bail(err)
-		} else {
-			log.Info("Successfully shut down")
-		}
-	}
+	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/gitlab/main.go
+++ b/access/gitlab/main.go
@@ -18,7 +18,7 @@ const (
 
 func main() {
 	utils.InitLogger()
-	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner := utils.NewPlugin(PluginName, exampleConfig, Version, Gitref)
 	runner.ParseCommand(os.Args[1:], run)
 }
 

--- a/access/jira/main.go
+++ b/access/jira/main.go
@@ -18,13 +18,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/utils"
-
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -32,44 +29,13 @@ import (
 
 const (
 	DefaultDir = "/var/lib/teleport/plugins/jira"
+	PluginName = "teleport-jira"
 )
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("teleport-jira", "Teleport plugin for access requests approval via JIRA.")
-
-	app.Command("configure", "Prints an example .TOML configuration file.")
-	app.Command("version", "Prints teleport-jira version and exits.")
-
-	startCmd := app.Command("start", "Starts a Teleport JIRA plugin.")
-	path := startCmd.Flag("config", "TOML config file path").
-		Short('c').
-		Default("/etc/teleport-jira.toml").
-		String()
-	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
-		Short('d').
-		Bool()
-	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
-		Default("false").
-		Bool()
-
-	selectedCmd, err := app.Parse(os.Args[1:])
-	if err != nil {
-		utils.Bail(err)
-	}
-
-	switch selectedCmd {
-	case "configure":
-		fmt.Print(exampleConfig)
-	case "version":
-		utils.PrintVersion(app.Name, Version, Gitref)
-	case "start":
-		if err := run(*path, *insecure, *debug); err != nil {
-			utils.Bail(err)
-		} else {
-			log.Info("Successfully shut down")
-		}
-	}
+	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/jira/main.go
+++ b/access/jira/main.go
@@ -34,7 +34,7 @@ const (
 
 func main() {
 	utils.InitLogger()
-	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner := utils.NewPlugin(PluginName, exampleConfig, Version, Gitref)
 	runner.ParseCommand(os.Args[1:], run)
 }
 

--- a/access/mattermost/main.go
+++ b/access/mattermost/main.go
@@ -18,13 +18,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/utils"
-
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -32,44 +29,13 @@ import (
 
 const (
 	DefaultDir = "/var/lib/teleport/plugins/mattermost"
+	PluginName = "teleport-mattermost"
 )
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("teleport-mattermost", "Teleport plugin for access requests approval via Mattermost.")
-
-	app.Command("configure", "Prints an example .TOML configuration file.")
-	app.Command("version", "Prints teleport-mattermost version and exits.")
-
-	startCmd := app.Command("start", "Starts a Teleport Mattermost plugin.")
-	path := startCmd.Flag("config", "TOML config file path").
-		Short('c').
-		Default("/etc/teleport-mattermost.toml").
-		String()
-	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
-		Short('d').
-		Bool()
-	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
-		Default("false").
-		Bool()
-
-	selectedCmd, err := app.Parse(os.Args[1:])
-	if err != nil {
-		utils.Bail(err)
-	}
-
-	switch selectedCmd {
-	case "configure":
-		fmt.Print(exampleConfig)
-	case "version":
-		utils.PrintVersion(app.Name, Version, Gitref)
-	case "start":
-		if err := run(*path, *insecure, *debug); err != nil {
-			utils.Bail(err)
-		} else {
-			log.Info("Successfully shut down")
-		}
-	}
+	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/mattermost/main.go
+++ b/access/mattermost/main.go
@@ -34,7 +34,7 @@ const (
 
 func main() {
 	utils.InitLogger()
-	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner := utils.NewPlugin(PluginName, exampleConfig, Version, Gitref)
 	runner.ParseCommand(os.Args[1:], run)
 }
 

--- a/access/pagerduty/main.go
+++ b/access/pagerduty/main.go
@@ -18,8 +18,9 @@ const (
 
 func main() {
 	utils.InitLogger()
-	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
-	runner.ParseCommand(os.Args[1:], run)
+
+	plugin := utils.NewPlugin(PluginName, exampleConfig, Version, Gitref)
+	plugin.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/pagerduty/main.go
+++ b/access/pagerduty/main.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/utils"
-
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -16,44 +13,13 @@ import (
 
 const (
 	DefaultDir = "/var/lib/teleport/plugins/pagerduty"
+	PluginName = "teleport-pagerduty"
 )
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("teleport-pagerduty", "Teleport plugin for access requests approval via PagerDuty.")
-
-	app.Command("configure", "Prints an example .TOML configuration file.")
-	app.Command("version", "Prints teleport-pagerduty version and exits.")
-
-	startCmd := app.Command("start", "Starts a Teleport PagerDuty plugin.")
-	path := startCmd.Flag("config", "TOML config file path").
-		Short('c').
-		Default("/etc/teleport-pagerduty.toml").
-		String()
-	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
-		Short('d').
-		Bool()
-	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
-		Default("false").
-		Bool()
-
-	selectedCmd, err := app.Parse(os.Args[1:])
-	if err != nil {
-		utils.Bail(err)
-	}
-
-	switch selectedCmd {
-	case "configure":
-		fmt.Print(exampleConfig)
-	case "version":
-		utils.PrintVersion(app.Name, Version, Gitref)
-	case "start":
-		if err := run(*path, *insecure, *debug); err != nil {
-			utils.Bail(err)
-		} else {
-			log.Info("Successfully shut down")
-		}
-	}
+	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/slack/main.go
+++ b/access/slack/main.go
@@ -40,8 +40,8 @@ const (
 
 func main() {
 	utils.InitLogger()
-	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
-	runner.ParseCommand(os.Args[1:], run)
+	plugin := utils.NewPlugin(PluginName, exampleConfig, Version, Gitref)
+	plugin.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/access/slack/main.go
+++ b/access/slack/main.go
@@ -18,13 +18,11 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/utils"
 
-	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -37,44 +35,13 @@ const (
 	ActionDeny = "deny_request"
 
 	DefaultDir = "/var/lib/teleport/plugins/slack"
+	PluginName = "teleport-slack"
 )
 
 func main() {
 	utils.InitLogger()
-	app := kingpin.New("teleport-slack", "Teleport plugin for access requests approval via Slack.")
-
-	app.Command("configure", "Prints an example .TOML configuration file.")
-	app.Command("version", "Prints teleport-slack version and exits.")
-
-	startCmd := app.Command("start", "Starts a the Teleport Slack plugin.")
-	path := startCmd.Flag("config", "TOML config file path").
-		Short('c').
-		Default("/etc/teleport-slack.toml").
-		String()
-	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
-		Short('d').
-		Bool()
-	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
-		Default("false").
-		Bool()
-
-	selectedCmd, err := app.Parse(os.Args[1:])
-	if err != nil {
-		utils.Bail(err)
-	}
-
-	switch selectedCmd {
-	case "configure":
-		fmt.Print(exampleConfig)
-	case "version":
-		utils.PrintVersion(app.Name, Version, Gitref)
-	case "start":
-		if err := run(*path, *insecure, *debug); err != nil {
-			utils.Bail(err)
-		} else {
-			log.Info("Successfully shut down")
-		}
-	}
+	runner := utils.NewPluginApp(PluginName, exampleConfig, Version, Gitref)
+	runner.ParseCommand(os.Args[1:], run)
 }
 
 func run(configPath string, insecure bool, debug bool) error {

--- a/utils/runner.go
+++ b/utils/runner.go
@@ -1,8 +1,13 @@
+// Contains common subcommands and CLI app management.
+
 package utils
 
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/gravitational/kingpin"
+	log "github.com/sirupsen/logrus"
 )
 
 // PrintVersion prints the specified app version to STDOUT
@@ -11,5 +16,89 @@ func PrintVersion(appName string, version string, gitref string) {
 		fmt.Printf("%v v%v git:%v %v\n", appName, version, gitref, runtime.Version())
 	} else {
 		fmt.Printf("%v v%v %v\n", appName, version, runtime.Version())
+	}
+}
+
+// PluginApp struct contains the plugin name, and the CLI Kingpin
+// wrapper around the plugin application.
+type PluginApp struct {
+	Name          string
+	ExampleConfig string
+	Version       string
+	Gitref        string
+	KingpinApp    *kingpin.Application
+	Path          string
+	Insecure      bool
+	Debug         bool
+}
+
+// TODO: Maybe extract app runner arguments into a separate struct
+// that can be defined by the client application / plugin.
+// Build that struct from command line parameters, and then pass that struct
+// to the handler function in ParseCommand.
+// That way, the util will be more general and flexible.
+type AppRunnerFunc func(string, bool, bool) error
+
+// Initializes and returns a new instance of
+// PluginApp.
+func NewPluginApp(name, exampleConfig, version, gitref string) *PluginApp {
+	app := kingpin.New(name, "Teleport plugin for access requst approval workflows.")
+
+	app.Command("configure", "Prints an example .TOML configuration file.")
+	app.Command("version", fmt.Sprintf("Prints %s version and exits.", name))
+
+	startCmd := app.Command("start", fmt.Sprintf("Starts a %s plugin.", name))
+	path := startCmd.Flag("config", "TOML config file path").
+		Short('c').
+		Default(fmt.Sprintf("/etc/%s.toml", name)).
+		String()
+	debug := startCmd.Flag("debug", "Enable verbose logging to stderr").
+		Short('d').
+		Bool()
+	insecure := startCmd.Flag("insecure-no-tls", "Disable TLS for the callback server").
+		Default("false").
+		Bool()
+
+	plugin := &PluginApp{
+		Name:          name,
+		ExampleConfig: exampleConfig,
+		Version:       version,
+		Gitref:        gitref,
+		KingpinApp:    app,
+		Path:          *path,
+		Insecure:      *insecure,
+		Debug:         *debug,
+	}
+
+	return plugin
+}
+
+// Parses the CLI command and starts the required command.
+func (p *PluginApp) ParseCommand(args []string, run AppRunnerFunc) {
+	selectedCmd, err := p.KingpinApp.Parse(args)
+	if err != nil {
+		Bail(err)
+	}
+
+	// TODO: This assumes three specific commands, while the client
+	// app might want to define more.
+	// We can make this more generic by storing commangs in an
+	// map, and switching it's keys here.
+	//
+	// Additionally, we can provide common command handlers
+	// in the util, but let the client app define the mapping
+	// between the commands and the specific handler funcs that
+	// will be invoked to handle the commands.
+	switch selectedCmd {
+	case "configure":
+		fmt.Print(p.ExampleConfig)
+	case "version":
+		PrintVersion(p.Name, p.Version, p.Gitref)
+	case "start":
+		if err := run(p.Path, p.Insecure, p.Debug); err != nil {
+			Bail(err)
+		} else {
+			log.Info("Successfully shut down")
+		}
 	}
 }


### PR DESCRIPTION
- Moved most of `teleport-*/main.go:main()` to `utils/runner.go`
- The generic runner still assumes commands and the same set of
  arguments though.

I have a feeling this code is far from perfect, so requesting review from Martians first to learn from you guys, and if we think it's good enough — I'll ping everyone else for another review and merge. 