### PR TITLE
Ensure certs directory exists before trying to write self-signed certs

### DIFF
--- a/access/access.go
+++ b/access/access.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// Minimal Teleport version the plugin supports.
 const MinServerVersion = "4.3.0"
 
 // State represents the state of an access request.

--- a/access/tls.go
+++ b/access/tls.go
@@ -36,8 +36,8 @@ func LoadTLSConfig(certPath, keyPath, rootCAsPath string) (conf *tls.Config, err
 	return
 }
 
-// LoadTLSCert loads a X.509 keypair from file paths and retains parsed form of
-// the certificate.
+// LoadTLSCert loads a X.509 keypair from file paths and
+// retains parsed form of the certificate.
 func LoadX509Cert(certPath, keyPath string) (tls.Certificate, error) {
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {


### PR DESCRIPTION
If the default certs directory doesn't exist yet, try creating it with 0644 permissions. Closes #111.

Cleaned up `utils/http.go` a little bit, too — trying to make go-lint happier, one file at a time. My goal with this is to heal my minor annoyance and learn. How does it look, what can I improve in the code I committed?