### PR TITLE
teleport-slack in notification-only mode

### DIFF
--- a/access/README.md
+++ b/access/README.md
@@ -43,7 +43,7 @@ spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list','read','update'] # Note that you can not provide the update permission to the Slack plugin in notification_only mode.
+        verbs: ['list','read','update'] # Note that you can not provide the update permission to the Slack plugin in notify_only mode.
     # teleport currently refuses to issue certs for a user with 0 logins,
     # this restriction may be lifted in future versions.
     logins: ['access-plugin']

--- a/access/README.md
+++ b/access/README.md
@@ -2,32 +2,30 @@
 
 ## Overview
 
-The Access API allows programmatic management (approval/denial) of
-Access Requests.
-
+The Access API allows programmatic management (approval/denial) of Access
+Requests.
 
 ## GRPC API
 
-The GRPC API, defined in `teleport/lib/auth/proto/auth.proto`,
-includes a handful of methods related to the `AccessRequest` resource.
-Most important for the purposes of *managing* access requests are the
-`WatchAccessRequests` and `SetAccessRequestState` methods:
+The GRPC API, defined in `teleport/lib/auth/proto/auth.proto`, includes a
+handful of methods related to the `AccessRequest` resource. Most important for
+the purposes of _managing_ access requests are the `WatchAccessRequests` and
+`SetAccessRequestState` methods:
 
 ```grpc
 rpc WatchAccessRequests(services.AccessRequestFilter) returns (stream services.AccessRequestV1);
 rpc SetAccessRequestState(RequestStateSetter) returns (google.protobuf.Empty);
 ```
 
-These methods allow integrations to be notified when requests are created,
-and approve/deny said requests based on external factors (e.g. approval,
-calendar, etc...).
-
+These methods allow integrations to be notified when requests are created, and
+approve/deny said requests based on external factors (e.g. approval, calendar,
+etc...).
 
 ## Authentication
 
 In order to interact with the Access Request API, you will need to provision
-appropriate TLS certificates.  In order to provision certificates, you will
-need to create an appropriate user with appropriate permissions:
+appropriate TLS certificates. In order to provision certificates, you will need
+to create an appropriate user with appropriate permissions:
 
 ```bash
 $ cat > rscs.yaml <<EOF
@@ -45,7 +43,7 @@ spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list','read','update']
+        verbs: ['list','read','update'] # Note that you can not provide the update permission to the Slack plugin in notification_only mode.
     # teleport currently refuses to issue certs for a user with 0 logins,
     # this restriction may be lifted in future versions.
     logins: ['access-plugin']
@@ -62,18 +60,15 @@ The above sequence should result in three PEM encoded files being generated:
 `auth.crt`, `auth.key`, and `auth.cas` (certificate, private key, and CA certs
 respectively).
 
-*Note:* by default, `tctl auth sign` produces certificates with a relatively short
-lifetime.  For production deployments, the `--ttl` flag can be used to ensure
-a more *practical* certificate lifetime.
-
+_Note:_ by default, `tctl auth sign` produces certificates with a relatively
+short lifetime. For production deployments, the `--ttl` flag can be used to
+ensure a more _practical_ certificate lifetime.
 
 ## The `access` Package
 
-The `access` package (defined in this directory) provides a thin wrapper
-around the GRPC API that abstracts over some implementation details.
-If you are writing an integration in golang, this is probably what you
-want.
+The `access` package (defined in this directory) provides a thin wrapper around
+the GRPC API that abstracts over some implementation details. If you are writing
+an integration in golang, this is probably what you want.
 
-See the [example](./example) directory for an example plugin implemented
-upon the `access` package.
-
+See the [example](./example) directory for an example plugin implemented upon
+the `access` package.

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -24,6 +24,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"    # Teleport cluster CA c
 token = "api-token"         # Slack Bot OAuth token
 secret = "secret-value"     # Slack API Signing Secret
 channel = "channel-name"    # Message delivery channel
+readonly = false            # Whether run the plugin in notification mode (Don't allow approval/denial via a Slack button)
 
 [http]
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:443

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -24,7 +24,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"    # Teleport cluster CA c
 token = "api-token"         # Slack Bot OAuth token
 secret = "secret-value"     # Slack API Signing Secret
 channel = "channel-name"    # Message delivery channel
-readonly = false            # Whether run the plugin in notification mode (Don't allow approval/denial via a Slack button)
+notification_only = false   # Whether run the plugin in notification only mode (Don't allow approval/denial via a Slack button)
 
 [http]
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:443
@@ -49,6 +49,19 @@ accessible at the address indicated by `auth_server`.
 _NOTE_: The slack plugin must be given a teleport user identity with appropriate
 permissions. See the [acccess package README](../README.md#authentication) for
 an example of how to configure an appropriate user & role.
+
+If you want to the plugin to only post notifications on Slack, without the
+ability to approve or deny requests from Slack, you can enforce read-only
+behavior by not adding the `update` verb to the plugin user permissions, like
+this:.
+
+```
+  # in the teleport user / role resource yaml
+  allow:
+    rules:
+      - resources: ['access_request']
+        verbs: ['list','read']
+```
 
 ### `[slack]`
 

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -24,7 +24,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"    # Teleport cluster CA c
 token = "api-token"         # Slack Bot OAuth token
 secret = "secret-value"     # Slack API Signing Secret
 channel = "channel-name"    # Message delivery channel
-notification_only = false   # Whether run the plugin in notification only mode (Don't allow approval/denial via a Slack button)
+notify_only = false         # Whether run the plugin in notification only mode (Don't allow approval/denial via a Slack button)
 
 [http]
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:443

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -176,8 +176,8 @@ func (a *App) onSlackCallback(ctx context.Context, cb Callback) error {
 
 	// If the plugin is working in read-only mode, do not process any
 	// callbacks from Slack, and return an error.
-	if a.conf.Slack.NotificationOnly {
-		return trace.Errorf("Received a Slack Webhook while in notification-only mode.")
+	if a.conf.Slack.NotifyOnly {
+		return trace.Errorf("Received a Slack Webhook while in notify-only mode.")
 	}
 
 	if len(cb.ActionCallback.BlockActions) != 1 {

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -176,8 +176,8 @@ func (a *App) onSlackCallback(ctx context.Context, cb Callback) error {
 
 	// If the plugin is working in read-only mode, do not process any
 	// callbacks from Slack, and return an error.
-	if a.conf.Slack.ReadOnly {
-		return trace.Errorf("Received a Slack Webhook while in read-only mode.")
+	if a.conf.Slack.NotificationOnly {
+		return trace.Errorf("Received a Slack Webhook while in notification-only mode.")
 	}
 
 	if len(cb.ActionCallback.BlockActions) != 1 {

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -26,6 +26,7 @@ type App struct {
 	*utils.Process
 }
 
+// NewApp initializes a new teleport-slack app and returns it.
 func NewApp(conf Config) (*App, error) {
 	app := &App{conf: conf}
 	app.mainJob = utils.NewServiceJob(app.run)
@@ -46,6 +47,8 @@ func (a *App) WaitReady(ctx context.Context) (bool, error) {
 	return a.mainJob.WaitReady(ctx)
 }
 
+// PublicURL checks if the app is running, and if it is —
+// returns the public callback URL for Slack.
 func (a *App) PublicURL() *url.URL {
 	if !a.mainJob.IsReady() {
 		panic("app is not running")
@@ -119,6 +122,8 @@ func (a *App) run(ctx context.Context) (err error) {
 	return trace.NewAggregate(httpJob.Err(), watcherJob.Err())
 }
 
+// checkTeleportVersion checks if the Teleport Auth server
+// is compatible with this plugin version.
 func (a *App) checkTeleportVersion(ctx context.Context) error {
 	log.Debug("Checking Teleport server version")
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -168,6 +173,12 @@ func (a *App) onWatcherEvent(ctx context.Context, event access.Event) error {
 // OnSlackCallback processes Slack actions and updates original Slack message with a new status
 func (a *App) onSlackCallback(ctx context.Context, cb Callback) error {
 	log := log.WithField("slack_http_id", cb.HTTPRequestID)
+
+	// If the plugin is working in read-only mode, do not process any
+	// callbacks from Slack, and return an error.
+	if a.conf.Slack.ReadOnly {
+		return trace.Errorf("Received a Slack Webhook while in read-only mode.")
+	}
 
 	if len(cb.ActionCallback.BlockActions) != 1 {
 		log.WithField("slack_block_actions", cb.ActionCallback.BlockActions).Warn("Received more than one Slack action")

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -22,11 +22,11 @@ const slackHTTPTimeout = 10 * time.Second
 // action occurs with an access request: a new request popped up, or a
 // request is processed/updated.
 type Bot struct {
-	client      *slack.Client
-	respClient  *http.Client
-	channel     string
-	clusterName string
-	readOnly    bool
+	client           *slack.Client
+	respClient       *http.Client
+	channel          string
+	clusterName      string
+	notificationOnly bool
 }
 
 // NewBot initializes the new Slack message generator (Bot)
@@ -50,10 +50,10 @@ func NewBot(conf SlackConfig) *Bot {
 	}
 
 	return &Bot{
-		client:     slack.New(conf.Token, slackOptions...),
-		channel:    conf.Channel,
-		respClient: httpClient,
-		readOnly:   conf.ReadOnly,
+		client:           slack.New(conf.Token, slackOptions...),
+		channel:          conf.Channel,
+		respClient:       httpClient,
+		notificationOnly: conf.NotificationOnly,
 	}
 }
 
@@ -190,8 +190,8 @@ func (b *Bot) msgSections(reqID string, reqData RequestData, status string) []sl
 	}
 
 	// Only show buttons for pending requests, and if the plugin is
-	// working in interactive mode (i.e. not readonly)
-	if status == "PENDING" && !b.readOnly {
+	// working in interactive mode (i.e. not notification-only)
+	if status == "PENDING" && !b.notificationOnly {
 		sections = append(sections, slack.NewActionBlock(
 			"approve_or_deny",
 			&slack.ButtonBlockElement{

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -22,11 +22,11 @@ const slackHTTPTimeout = 10 * time.Second
 // action occurs with an access request: a new request popped up, or a
 // request is processed/updated.
 type Bot struct {
-	client           *slack.Client
-	respClient       *http.Client
-	channel          string
-	clusterName      string
-	notificationOnly bool
+	client      *slack.Client
+	respClient  *http.Client
+	channel     string
+	clusterName string
+	notifyOnly  bool
 }
 
 // NewBot initializes the new Slack message generator (Bot)
@@ -50,10 +50,10 @@ func NewBot(conf SlackConfig) *Bot {
 	}
 
 	return &Bot{
-		client:           slack.New(conf.Token, slackOptions...),
-		channel:          conf.Channel,
-		respClient:       httpClient,
-		notificationOnly: conf.NotificationOnly,
+		client:     slack.New(conf.Token, slackOptions...),
+		channel:    conf.Channel,
+		respClient: httpClient,
+		notifyOnly: conf.NotifyOnly,
 	}
 }
 
@@ -190,8 +190,8 @@ func (b *Bot) msgSections(reqID string, reqData RequestData, status string) []sl
 	}
 
 	// Only show buttons for pending requests, and if the plugin is
-	// working in interactive mode (i.e. not notification-only)
-	if status == "PENDING" && !b.notificationOnly {
+	// working in interactive mode (i.e. notify-only)
+	if status == "PENDING" && !b.notifyOnly {
 		sections = append(sections, slack.NewActionBlock(
 			"approve_or_deny",
 			&slack.ButtonBlockElement{

--- a/access/slack/callback_server.go
+++ b/access/slack/callback_server.go
@@ -18,10 +18,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Callback struct represents an HTTP request that is a callback from Slack,
+// and wraps around slack client's InteractionCallback.
 type Callback struct {
 	HTTPRequestID string
 	slack.InteractionCallback
 }
+
+// CallbackFunc type represents a callback handler that takes a context and
+// a callback in, handles it, and optionally returns an error.
 type CallbackFunc func(ctx context.Context, callback Callback) error
 
 // CallbackServer is a wrapper around http.Server that processes Slack interaction events.
@@ -33,6 +38,7 @@ type CallbackServer struct {
 	counter    uint64
 }
 
+// NewCallbackServer initializes and returns an HTTP server that handles Slack callback (webhook) requests.
 func NewCallbackServer(conf utils.HTTPConfig, secret string, onCallback CallbackFunc) (*CallbackServer, error) {
 	httpSrv, err := utils.NewHTTP(conf)
 	if err != nil {
@@ -47,14 +53,21 @@ func NewCallbackServer(conf utils.HTTPConfig, secret string, onCallback Callback
 	return srv, nil
 }
 
+// ServiceJob returns a service job object from the Callback HTTP server.
 func (s *CallbackServer) ServiceJob() utils.ServiceJob {
 	return s.http.ServiceJob()
 }
 
+// BaseURL returns Slack Webhook (callback) HTTP server base URL.
 func (s *CallbackServer) BaseURL() *url.URL {
 	return s.http.BaseURL()
 }
 
+// EnsureCert uses http util's EnsureCert to make sure that TLS certificates
+// are there and are accessible and valid.
+// If using self-signed certs, this will also generate self-signed TLS certificates if they're missing.
+// Please note that self-signed certs would not work by default, since Slack won't respect / validate
+// the self-signed certs.
 func (s *CallbackServer) EnsureCert() error {
 	return s.http.EnsureCert(DefaultDir + "/server")
 }

--- a/access/slack/config.go
+++ b/access/slack/config.go
@@ -16,11 +16,11 @@ type Config struct {
 
 // SlackConfig holds Slack-specific configuration options.
 type SlackConfig struct {
-	Token            string `toml:"token"`
-	Secret           string `toml:"secret"`
-	Channel          string `toml:"channel"`
-	NotificationOnly bool   `toml:"notification_only"`
-	APIURL           string
+	Token      string `toml:"token"`
+	Secret     string `toml:"secret"`
+	Channel    string `toml:"channel"`
+	NotifyOnly bool   `toml:"notify_only"`
+	APIURL     string
 }
 
 const exampleConfig = `# example slack plugin configuration TOML file
@@ -34,7 +34,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport cluster CA ce
 token = "api_token"             # Slack Bot OAuth token
 secret = "signing-secret-value" # Slack API Signing Secret
 channel = "channel-name"        # Slack Channel name to post requests to
-notification_only = false                # Allow Approval / Denial actions on Slack, or use it as notification only
+notify_only = false                # Allow Approval / Denial actions on Slack, or use it as notification only
 
 [http]
 public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com

--- a/access/slack/config.go
+++ b/access/slack/config.go
@@ -16,11 +16,11 @@ type Config struct {
 
 // SlackConfig holds Slack-specific configuration options.
 type SlackConfig struct {
-	Token    string `toml:"token"`
-	Secret   string `toml:"secret"`
-	Channel  string `toml:"channel"`
-	ReadOnly bool   `toml:"readonly"`
-	APIURL   string
+	Token            string `toml:"token"`
+	Secret           string `toml:"secret"`
+	Channel          string `toml:"channel"`
+	NotificationOnly bool   `toml:"notification_only"`
+	APIURL           string
 }
 
 const exampleConfig = `# example slack plugin configuration TOML file
@@ -34,7 +34,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport cluster CA ce
 token = "api_token"             # Slack Bot OAuth token
 secret = "signing-secret-value" # Slack API Signing Secret
 channel = "channel-name"        # Slack Channel name to post requests to
-readonly = false                # Allow Approval / Denial actions on Slack, or use it as notification only
+notification_only = false                # Allow Approval / Denial actions on Slack, or use it as notification only
 
 [http]
 public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com

--- a/access/slack/config.go
+++ b/access/slack/config.go
@@ -34,7 +34,7 @@ root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport cluster CA ce
 token = "api_token"             # Slack Bot OAuth token
 secret = "signing-secret-value" # Slack API Signing Secret
 channel = "channel-name"        # Slack Channel name to post requests to
-readonly = false				# Allow Approval / Denial actions on Slack, or use it as notification only
+readonly = false                # Allow Approval / Denial actions on Slack, or use it as notification only
 
 [http]
 public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com

--- a/access/slack/main.go
+++ b/access/slack/main.go
@@ -36,7 +36,7 @@ const (
 	// ActionDeny uniquely identifies the deny button in events.
 	ActionDeny = "deny_request"
 	// DefaultDir is the directory to be used in various configurations.
-	// It's used accross the files in main package, and in utils.
+	// It's used across the files in main package, and in utils.
 	DefaultDir = "/var/lib/teleport/plugins/slack"
 )
 

--- a/access/slack/main.go
+++ b/access/slack/main.go
@@ -35,7 +35,8 @@ const (
 	ActionApprove = "approve_request"
 	// ActionDeny uniquely identifies the deny button in events.
 	ActionDeny = "deny_request"
-
+	// DefaultDir is the directory to be used in various configurations.
+	// It's used accross the files in main package, and in utils.
 	DefaultDir = "/var/lib/teleport/plugins/slack"
 )
 

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -117,7 +117,7 @@ func (s *SlackSuite) startSlack(c *C) {
 	go s.slackServer.Start()
 }
 
-func (s *SlackSuite) startApp(c *C, readonly bool) {
+func (s *SlackSuite) startApp(c *C, notificationOnly bool) {
 	auth := s.teleport.Process.GetAuthServer()
 	certAuthorities, err := auth.GetCertAuthorities(services.HostCA, false)
 	c.Assert(err, IsNil)
@@ -153,7 +153,7 @@ func (s *SlackSuite) startApp(c *C, readonly bool) {
 	conf.Slack.Secret = SlackSecret
 	conf.Slack.Token = "000000"
 	conf.Slack.Channel = "test"
-	conf.Slack.ReadOnly = readonly
+	conf.Slack.NotificationOnly = notificationOnly
 	conf.Slack.APIURL = "http://" + s.slackServer.ServerAddr + "/"
 	conf.HTTP.ListenAddr = ":0"
 	if s.publicURL != "" {

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -38,7 +38,6 @@ const (
 type SlackSuite struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
-	conf        *Config
 	app         *App
 	publicURL   string
 	me          *user.User

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -117,7 +117,7 @@ func (s *SlackSuite) startSlack(c *C) {
 	go s.slackServer.Start()
 }
 
-func (s *SlackSuite) startApp(c *C, notificationOnly bool) {
+func (s *SlackSuite) startApp(c *C, notifyOnly bool) {
 	auth := s.teleport.Process.GetAuthServer()
 	certAuthorities, err := auth.GetCertAuthorities(services.HostCA, false)
 	c.Assert(err, IsNil)
@@ -153,7 +153,7 @@ func (s *SlackSuite) startApp(c *C, notificationOnly bool) {
 	conf.Slack.Secret = SlackSecret
 	conf.Slack.Token = "000000"
 	conf.Slack.Channel = "test"
-	conf.Slack.NotificationOnly = notificationOnly
+	conf.Slack.NotifyOnly = notifyOnly
 	conf.Slack.APIURL = "http://" + s.slackServer.ServerAddr + "/"
 	conf.HTTP.ListenAddr = ":0"
 	if s.publicURL != "" {


### PR DESCRIPTION
This PR adds a read only (no buttons, i.e. notification only) mode for the Teleport Slack plugin, as @aelkugia and @benarent suggested. Closes #121.

In includes several behavior changes: 
1. The plugin doesn't render buttons in Slack notifications if `notification_only = true` in the config. 
2. The default is `notifications_only = false`. 
3. The plugin still starts up the http service, but doesn't process and errors out if a webhook from Slack is invoked in notifcation_only mode. 
4. The readme documents this + the `update` verb in role config. 

@marshall-lee, I've added an extra arg to `startApp` in tests, and I'm not sure if that is reasonable approach or not (everything else just takes `c *C`). Otherwise, this is ready for review.

TODOs:
- [x] Update example config so that `teleport-slack configure` works correctly
- [x] Add tests for readonly mode
- [x] Update the readme and make sure the docs will be updated, too

After the initial round of feedback: 
- [x] Rename readonly to notification_only in the config. 
- [x] Add a comment to the readme file that one could just not provide `update` permissions to the user.

### Checklist before merging

- [x] Check that this PR works as expected manually (@xnutsive)
- [ ] Confirm that we want this behavior in the plugin (@benarent, @aelkugia).