### PR TITLE
Making config examples more explicit

### DIFF
--- a/access/gitlab/config.go
+++ b/access/gitlab/config.go
@@ -46,7 +46,7 @@ project_id = "1812345"                     # GitLab Project ID
 webhook_secret = "your webhook passphrase" # A secret used to encrypt data we use in webhooks. Basically anything you'd like.
 
 [http]
-public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+public_addr = "example.com:8081" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com:8081
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
 https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
 https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate

--- a/access/jira/config.go
+++ b/access/jira/config.go
@@ -40,7 +40,7 @@ api_token = "token"                 # JIRA API Basic Auth token, or our password
 project = "MYPROJ"                  # JIRA Project key
 
 [http]
-public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+public_addr = "example.com:8081" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com:8081
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
 https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
 https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate

--- a/access/mattermost/config.go
+++ b/access/mattermost/config.go
@@ -36,7 +36,7 @@ token = "api-token"                    # Mattermost Bot OAuth token
 secret = "signing-secret-value"        # Mattermost API signing Secret
 
 [http]
-public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+public_addr = "example.com:8081" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com:8081
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
 https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
 https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -40,7 +40,7 @@ service_id = "PIJ90N7"        # PagerDuty service id
 auto_approve = true           # Automatically approve access requests if requestor is on-call
 
 [http]
-public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
+public_addr = "example.com:8081" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com:8081
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:8081
 https_key_file = "/var/lib/teleport/webproxy_key.pem"  # TLS private key
 https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
@@ -48,9 +48,10 @@ https_cert_file = "/var/lib/teleport/webproxy_cert.pem" # TLS certificate
 [http.tls]
 verify_client_cert = true # The preferred way to authenticate webhooks on Pagerduty. See more: https://developer.pagerduty.com/docs/webhooks/webhooks-mutual-tls
 
-[http.basic_auth]
-user = "user"
-password = "password" # If you prefer to use basic auth for Pagerduty Webhooks authentication, use this section to store user and password
+# If you prefer to use basic auth for Pagerduty Webhooks authentication, use this section to store user and password
+#[http.basic_auth]
+#user = "user"
+#password = "password"
 
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"


### PR DESCRIPTION
Helps make https://github.com/gravitational/teleport-plugins/issues/120 clearer, as port mapping can be confusing. 