### PR TITLE
WaitForReady false by default

### DIFF
--- a/access/gitlab/app.go
+++ b/access/gitlab/app.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/access"
 	"github.com/gravitational/teleport-plugins/utils"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/trace"
 
@@ -85,6 +86,8 @@ func (a *App) run(ctx context.Context) (err error) {
 		"gitlab",
 		a.conf.Teleport.AuthServer,
 		tlsConf,
+		grpc.WithBackoffMaxDelay(time.Second*2),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/jira/app.go
+++ b/access/jira/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/access"
 	"github.com/gravitational/teleport-plugins/utils"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/trace"
 
@@ -83,6 +84,8 @@ func (a *App) run(ctx context.Context) (err error) {
 		"jira",
 		a.conf.Teleport.AuthServer,
 		tlsConf,
+		grpc.WithBackoffMaxDelay(time.Second*2),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/mattermost/app.go
+++ b/access/mattermost/app.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/access"
 	"github.com/gravitational/teleport-plugins/utils"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/trace"
 
@@ -83,6 +84,8 @@ func (a *App) run(ctx context.Context) (err error) {
 		"mattermost",
 		a.conf.Teleport.AuthServer,
 		tlsConf,
+		grpc.WithBackoffMaxDelay(time.Second*2),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/access"
 	"github.com/gravitational/teleport-plugins/utils"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/trace"
 
@@ -83,6 +84,8 @@ func (a *App) run(ctx context.Context) error {
 		"pagerduty",
 		a.conf.Teleport.AuthServer,
 		tlsConf,
+		grpc.WithBackoffMaxDelay(time.Second*2),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/access"
 	"github.com/gravitational/teleport-plugins/utils"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/trace"
 
@@ -78,6 +79,8 @@ func (a *App) run(ctx context.Context) (err error) {
 		"slack",
 		a.conf.Teleport.AuthServer,
 		tlsConf,
+		grpc.WithBackoffMaxDelay(time.Second*2),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return


### PR DESCRIPTION
- Closes #102.
- Makes WaitForReady false by default on access.go NewClient()
- Also removes the default grcp.WithMaxBackoffTime(time.Second*2)
- Provides a way to supply additional grpc.DialOptions if needed
- All of the plugins use the previous options for now, to make
  sure this commit doesn't break any existing behavior.