### PR TITLE
Enable WaitForReady only for request watcher.

### DIFF
--- a/access/gitlab/app.go
+++ b/access/gitlab/app.go
@@ -87,7 +87,6 @@ func (a *App) run(ctx context.Context) (err error) {
 		a.conf.Teleport.AuthServer,
 		tlsConf,
 		grpc.WithBackoffMaxDelay(time.Second*2),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/jira/app.go
+++ b/access/jira/app.go
@@ -85,7 +85,6 @@ func (a *App) run(ctx context.Context) (err error) {
 		a.conf.Teleport.AuthServer,
 		tlsConf,
 		grpc.WithBackoffMaxDelay(time.Second*2),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/mattermost/app.go
+++ b/access/mattermost/app.go
@@ -85,7 +85,6 @@ func (a *App) run(ctx context.Context) (err error) {
 		a.conf.Teleport.AuthServer,
 		tlsConf,
 		grpc.WithBackoffMaxDelay(time.Second*2),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -85,7 +85,6 @@ func (a *App) run(ctx context.Context) error {
 		a.conf.Teleport.AuthServer,
 		tlsConf,
 		grpc.WithBackoffMaxDelay(time.Second*2),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/access/service_job.go
+++ b/access/service_job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/utils"
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -20,6 +21,7 @@ type watcherJob struct {
 }
 
 func NewWatcherJob(client Client, filter Filter, fn WatcherJobFunc) utils.ServiceJob {
+	client = client.WithCallOptions(grpc.WaitForReady(true)) // Enable backoff on reconnecting.
 	watcherJob := &watcherJob{
 		client:    client,
 		filter:    filter,

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -83,7 +83,6 @@ func (a *App) run(ctx context.Context) (err error) {
 		a.conf.Teleport.AuthServer,
 		tlsConf,
 		grpc.WithBackoffMaxDelay(time.Second*2),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
 		return


### PR DESCRIPTION
I found out that WaitForReady is only useful for reconnecting the watcher. As @fspmarshall said, enabling in globally really leads to cumbersome errors which are not easy to reason about but I think it's still nice to leverage the built-in backoff mechanism of grpc package.

Closes #102.