### PR TITLE
Add test-darwin exec pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: build
+name: build-linux
 
 trigger:
   event:
@@ -87,7 +87,7 @@ trigger:
       - refs/tags/teleport-*-v*
 
 depends_on:
-  - test
+  - test-linux
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -166,6 +166,6 @@ steps:
 
 ---
 kind: signature
-hmac: 544928929d6a902a619dc482ff75ca5152177a632dfbaba1ee9894a0d79f7059
+hmac: 7ba0986b68dfc1c5dc1d21a1540b451385c3cd7f6165aeab1a21b92726c3e3c0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,85 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: build-linux
+name: build-on-push-linux
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+  repo:
+    include:
+      - gravitational/*
+
+depends_on:
+  - test-linux
+
+workspace:
+  path: /go/src/github.com/gravitational/teleport-plugins
+
+steps:
+  - name: Build artifacts
+    image: golang:1.14.4
+    commands:
+      - for PLUGIN_DIR in $(find access/ -mindepth 1 -maxdepth 1 -type d | grep -v example); do echo $PLUGIN_DIR:; make -C $PLUGIN_DIR; done
+
+---
+kind: pipeline
+type: exec
+name: build-on-push-darwin
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      # TODO(gus): uncomment after testing
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
+
+# TODO(gus): uncomment after testing
+# depends_on:
+#   - test-darwin
+
+workspace:
+  path: /tmp/teleport-plugins/build-darwin
+
+steps:
+  - name: Clean up exec runner storage (pre)
+    commands:
+      - rm -rf /tmp/teleport-plugins/build-darwin/go
+      - mkdir -p /tmp/teleport-plugins/build-darwin/go/cache
+      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
+
+  - name: Build artifacts (darwin)
+    environment:
+      GOPATH: /tmp/teleport-plugins/build-darwin/go
+      GOCACHE: /tmp/teleport-plugins/build-darwin/go/cache
+    commands:
+      - for PLUGIN_DIR in $(find access/ -mindepth 1 -maxdepth 1 -type d | grep -v example); do echo $PLUGIN_DIR:; make -C $PLUGIN_DIR; done
+
+  - name: Clean up exec runner storage (post)
+    commands:
+      - rm -rf /tmp/teleport-plugins/build-darwin/go
+
+---
+kind: pipeline
+type: kubernetes
+name: tag-build-linux
 
 trigger:
   event:
@@ -117,64 +195,6 @@ steps:
       source: /go/src/github.com/gravitational/teleport-plugins/build/*
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
-
----
-# note: this pipeline does not upload any Mac artifacts, it just
-# validates that teleport-plugins will build successfully on MacOS
-kind: pipeline
-type: exec
-name: build-darwin
-
-concurrency:
-  limit: 1
-
-platform:
-  os: darwin
-  arch: amd64
-
-# TODO(gus): uncomment after testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/teleport-*-v*
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
-
-# TODO(gus): uncomment after testing
-# depends_on:
-#   - test-darwin
-
-workspace:
-  path: /tmp/teleport-plugins/build-darwin
-
-steps:
-  - name: Clean up exec runner storage (pre)
-    commands:
-      - rm -rf /tmp/teleport-plugins/build-darwin/go
-      - mkdir -p /tmp/teleport-plugins/build-darwin/go/cache
-      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
-
-  - name: Build artifacts (darwin)
-    environment:
-      GOPATH: /tmp/teleport-plugins/build-darwin/go
-      GOCACHE: /tmp/teleport-plugins/build-darwin/go/cache
-    commands:
-      - for PLUGIN_DIR in $(find access/ -mindepth 1 -maxdepth 1 -type d | grep -v example); do echo $PLUGIN_DIR:; make -C $PLUGIN_DIR; done
-
-  - name: Clean up exec runner storage (post)
-    commands:
-      - rm -rf /tmp/teleport-plugins/build-darwin/go
 
 ---
 kind: pipeline
@@ -224,6 +244,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4a000c51378e82edec499ea6291234ec1c239290fcb39678798743feffb38808
+hmac: 0012e06087c089ddade27056228efc53e8a195c604766062ffe970552d2bba89
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: kubernetes
-name: test
+name: test-linux
 
 trigger:
   branch:
@@ -28,6 +28,51 @@ steps:
     image: golang:1.14.4
     commands:
       - make test
+
+---
+kind: pipeline
+type: exec
+name: test-darwin
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
+
+workspace:
+  path: /tmp/teleport-plugins
+
+steps:
+  - name: Clean up exec runner storage (pre)
+    commands:
+      - rm -rf test-darwin
+      - mkdir -p test-darwin/go/cache
+      - chmod -R u+rw test-darwin
+
+  - name: Run tests
+    environment:
+      GOPATH: /tmp/teleport-plugins/test-darwin/go
+      GOCACHE: /tmp/teleport-plugins/test-darwin/go/cache
+    commands:
+      - make test
+
+  - name: Clean up exec runner storage (post)
+    commands:
+      - rm -rf test-darwin
 
 ---
 kind: pipeline
@@ -121,6 +166,6 @@ steps:
 
 ---
 kind: signature
-hmac: 659d91eda782d8ca46f4e99022741226f6d1015b1539f3ce31e082a8c77f705e
+hmac: 544928929d6a902a619dc482ff75ca5152177a632dfbaba1ee9894a0d79f7059
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,14 +54,14 @@ trigger:
       - gravitational/*
 
 workspace:
-  path: /tmp/teleport-plugins
+  path: /tmp/teleport-plugins/test-darwin
 
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - rm -rf test-darwin
-      - mkdir -p test-darwin/go/cache
-      - chmod -R u+rw test-darwin
+      - rm -rf /tmp/teleport-plugins/test-darwin/go
+      - mkdir -p /tmp/teleport-plugins/test-darwin/go
+      - chmod -R u+rw /tmp/teleport-plugins/test-darwin/go
 
   - name: Run tests
     environment:
@@ -72,7 +72,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
-      - rm -rf test-darwin
+      - rm -rf /tmp/teleport-plugins/test-darwin/go
 
 ---
 kind: pipeline
@@ -117,6 +117,64 @@ steps:
       source: /go/src/github.com/gravitational/teleport-plugins/build/*
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
+
+---
+# note: this pipeline does not upload any Mac artifacts, it just
+# validates that teleport-plugins will build successfully on MacOS
+kind: pipeline
+type: exec
+name: build-darwin
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+# TODO(gus): uncomment after testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/teleport-*-v*
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
+
+# TODO(gus): uncomment after testing
+# depends_on:
+#   - test-darwin
+
+workspace:
+  path: /tmp/teleport-plugins/build-darwin
+
+steps:
+  - name: Clean up exec runner storage (pre)
+    commands:
+      - rm -rf /tmp/teleport-plugins/build-darwin/go
+      - mkdir -p /tmp/teleport-plugins/build-darwin/go/cache
+      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
+
+  - name: Build artifacts (darwin)
+    environment:
+      GOPATH: /tmp/teleport-plugins/build-darwin/go
+      GOCACHE: /tmp/teleport-plugins/build-darwin/go/cache
+    commands:
+      - for PLUGIN_DIR in $(find access/ -mindepth 1 -maxdepth 1 -type d | grep -v example); do echo $PLUGIN_DIR:; make -C $PLUGIN_DIR; done
+
+  - name: Clean up exec runner storage (post)
+    commands:
+      - rm -rf /tmp/teleport-plugins/build-darwin/go
 
 ---
 kind: pipeline
@@ -166,6 +224,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7ba0986b68dfc1c5dc1d21a1540b451385c3cd7f6165aeab1a21b92726c3e3c0
+hmac: 4a000c51378e82edec499ea6291234ec1c239290fcb39678798743feffb38808
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,15 +121,12 @@ trigger:
   event:
     include:
       - push
-      # TODO(gus): uncomment after testing
-      - pull_request
   repo:
     include:
       - gravitational/*
 
-# TODO(gus): uncomment after testing
-# depends_on:
-#   - test-darwin
+depends_on:
+  - test-darwin
 
 workspace:
   path: /tmp/teleport-plugins/build-darwin
@@ -244,6 +241,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0012e06087c089ddade27056228efc53e8a195c604766062ffe970552d2bba89
+hmac: e69a430a2b8c289f1a153f4334ea022dd366c170ce0c623a4aa0d811f75c48db
 
 ...


### PR DESCRIPTION
Pipeline changes:
- renames `test` to `test-linux` and updates dependencies
- adds `test-darwin` pipeline to run test suites using a MacOS exec runner
- adds `build-on-push-linux`
  - this pipeline tests building all artifacts on Linux when a push is made to `master` or `branch/*` (for example, when a PR is merged)
- adds `build-on-push-darwin`
  - this pipeline does the same thing, but on a MacOS exec runner
- renames `build` to `tag-build-linux`