### PR TITLE
Update go1.14.4 -> go1.15.5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
       - make lint
 
   - name: Run tests
-    image: golang:1.14.4
+    image: golang:1.15.5
     commands:
       - make test
 
@@ -98,7 +98,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.14.4
+    image: golang:1.15.5
     commands:
       - for PLUGIN_DIR in $(find access/ -mindepth 1 -maxdepth 1 -type d | grep -v example); do echo $PLUGIN_DIR:; make -C $PLUGIN_DIR; done
 
@@ -169,7 +169,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.14.4
+    image: golang:1.15.5
     commands:
       - mkdir -p build/
       - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
@@ -241,6 +241,6 @@ steps:
 
 ---
 kind: signature
-hmac: e69a430a2b8c289f1a153f4334ea022dd366c170ce0c623a4aa0d811f75c48db
+hmac: 05a0cbf9e41b88fbe0290b5d2987951faaa2763eebd7b5c5a64f6f4f897aba38
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,6 +68,7 @@ steps:
       GOPATH: /tmp/teleport-plugins/test-darwin/go
       GOCACHE: /tmp/teleport-plugins/test-darwin/go/cache
     commands:
+      - go version
       - make test
 
   - name: Clean up exec runner storage (post)
@@ -241,6 +242,6 @@ steps:
 
 ---
 kind: signature
-hmac: 05a0cbf9e41b88fbe0290b5d2987951faaa2763eebd7b5c5a64f6f4f897aba38
+hmac: 75cc39c2639db4d0c15d61327abcc0398bab3acda7aca7a70e69783db24deb30
 
 ...


### PR DESCRIPTION
Updates from `go1.14.4` to `go1.15.5` in line with Teleport.
Also print the output of `go version` for Darwin tests.