### PR TITLE
Fix data-race in FakeMattermost

### DIFF
--- a/access/gitlab/gitlab_test.go
+++ b/access/gitlab/gitlab_test.go
@@ -96,7 +96,7 @@ func (s *GitlabSuite) SetUpSuite(c *C) {
 }
 
 func (s *GitlabSuite) SetUpTest(c *C) {
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	s.publicURL = ""
 	dbFile := s.newTmpFile(c, "db.*")
 	s.dbPath = dbFile.Name()

--- a/access/gitlab/gitlab_test.go
+++ b/access/gitlab/gitlab_test.go
@@ -169,7 +169,11 @@ func (s *GitlabSuite) startApp(c *C) {
 	s.app, err = NewApp(conf)
 	c.Assert(err, IsNil)
 
-	go s.app.Run(s.ctx)
+	go func() {
+		if err := s.app.Run(s.ctx); err != nil {
+			panic(err)
+		}
+	}()
 	ok, err := s.app.WaitReady(s.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)

--- a/access/jira/jira_test.go
+++ b/access/jira/jira_test.go
@@ -89,7 +89,7 @@ func (s *JiraSuite) SetUpSuite(c *C) {
 }
 
 func (s *JiraSuite) SetUpTest(c *C) {
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	s.publicURL = ""
 	s.fakeJira = NewFakeJIRA(jira.User{Name: "Test User", EmailAddress: s.me.Username + "@example.com"}, s.raceNumber)
 }

--- a/access/jira/jira_test.go
+++ b/access/jira/jira_test.go
@@ -158,7 +158,11 @@ func (s *JiraSuite) startApp(c *C) {
 	s.app, err = NewApp(conf)
 	c.Assert(err, IsNil)
 
-	go s.app.Run(s.ctx)
+	go func() {
+		if err := s.app.Run(s.ctx); err != nil {
+			panic(err)
+		}
+	}()
 	ok, err := s.app.WaitReady(s.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -167,7 +167,11 @@ func (s *MattermostSuite) startApp(c *C) {
 	s.app, err = NewApp(conf)
 	c.Assert(err, IsNil)
 
-	go s.app.Run(s.ctx)
+	go func() {
+		if err := s.app.Run(s.ctx); err != nil {
+			panic(err)
+		}
+	}()
 	ok, err := s.app.WaitReady(s.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -92,7 +92,7 @@ func (s *MattermostSuite) SetUpSuite(c *C) {
 }
 
 func (s *MattermostSuite) SetUpTest(c *C) {
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	s.publicURL = ""
 	s.fakeMattermost = NewFakeMattermost(s.raceNumber)
 	s.mmUser = s.fakeMattermost.StoreUser(mm.User{

--- a/access/mattermost/types.go
+++ b/access/mattermost/types.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/gravitational/teleport-plugins/access"
 
 	log "github.com/sirupsen/logrus"
 )
+
+type logFields = log.Fields
+
+// Plugin data
 
 type RequestData struct {
 	User  string
@@ -23,7 +28,30 @@ type PluginData struct {
 	MattermostData
 }
 
-type logFields = log.Fields
+// Mattermost API types
+
+type Post struct {
+	ID        string                 `json:"id"`
+	ChannelID string                 `json:"channel_id"`
+	Message   string                 `json:"message"`
+	Props     map[string]interface{} `json:"props"`
+}
+
+type Attachment struct {
+	ID      int64        `json:"id"`
+	Actions []PostAction `json:"actions,omitempty"`
+}
+
+type PostAction struct {
+	ID          string                 `json:"id,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Integration *PostActionIntegration `json:"integration,omitempty"`
+}
+
+type PostActionIntegration struct {
+	URL     string                 `json:"url,omitempty"`
+	Context map[string]interface{} `json:"context,omitempty"`
+}
 
 func DecodePluginData(dataMap access.PluginDataMap) (data PluginData) {
 	data.User = dataMap["user"]
@@ -40,4 +68,19 @@ func EncodePluginData(data PluginData) access.PluginDataMap {
 		"post_id":    data.PostID,
 		"channel_id": data.ChannelID,
 	}
+}
+
+func (post Post) Attachments() []Attachment {
+	var attachments []Attachment
+	if slice, ok := post.Props["attachments"].([]interface{}); ok {
+		for _, dec := range slice {
+			if enc, err := json.Marshal(dec); err == nil {
+				var attachment Attachment
+				if json.Unmarshal(enc, &attachment) == nil {
+					attachments = append(attachments, attachment)
+				}
+			}
+		}
+	}
+	return attachments
 }

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -179,7 +179,11 @@ func (s *PagerdutySuite) startApp(c *C) {
 	s.app, err = NewApp(s.appConfig)
 	c.Assert(err, IsNil)
 
-	go s.app.Run(s.ctx)
+	go func() {
+		if err := s.app.Run(s.ctx); err != nil {
+			panic(err)
+		}
+	}()
 	ok, err := s.app.WaitReady(s.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -96,7 +96,7 @@ func (s *PagerdutySuite) SetUpSuite(c *C) {
 }
 
 func (s *PagerdutySuite) SetUpTest(c *C) {
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	s.publicURL = ""
 	s.fakePagerduty = NewFakePagerduty(s.raceNumber)
 	s.pdService = s.fakePagerduty.StoreService(Service{

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -97,7 +97,7 @@ func (s *SlackSuite) SetUpSuite(c *C) {
 }
 
 func (s *SlackSuite) SetUpTest(c *C) {
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	s.publicURL = ""
 	s.fakeSlack = NewFakeSlack(slack.User{Name: "slackbot"}, s.raceNumber)
 	s.slackUser = s.fakeSlack.StoreUser(slack.User{

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -176,7 +176,11 @@ func (s *SlackSuite) startApp(c *C) {
 	s.app, err = NewApp(s.appConfig)
 	c.Assert(err, IsNil)
 
-	go s.app.Run(s.ctx)
+	go func() {
+		if err := s.app.Run(s.ctx); err != nil {
+			panic(err)
+		}
+	}()
 	ok, err := s.app.WaitReady(s.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)


### PR DESCRIPTION
Use custom `Post` type instead of `*mm.Post`.

`FakeMattermost` should store copyable structs, not pointers because
pointers are racy. However, we cannot just use `mm.Post` because it
contains mutex field so it's not copyable.

As we already decided to transition away from http client libraries
towards go-resty with a bunch of custom types, lets start by defining
them at least for tests as data race occurs only in tests.

ref https://drone.gravitational.io/gravitational/teleport-plugins/456/1/3