### PR TITLE
add dockerfile for building and using slack plugin

### DIFF
--- a/Dockerfile.slack
+++ b/Dockerfile.slack
@@ -1,0 +1,14 @@
+FROM golang:1.16.0-alpine AS build
+RUN mkdir -p /go/src/github.com/gravitational/teleport-plugins/
+WORKDIR /go/src/github.com/gravitational/teleport-plugins/
+COPY . .
+RUN apk update && apk add make
+RUN cd access/slack
+RUN make && ls access/slack/*
+
+FROM alpine:3.12 as plugin
+RUN mkdir -p tmp/slack
+WORKDIR /tmp/slack
+COPY --from=build /go/src/github.com/gravitational/teleport-plugins/access/slack/ .
+RUN cp ./build/teleport-slack .
+RUN ./install

--- a/Dockerfile.slack
+++ b/Dockerfile.slack
@@ -1,12 +1,11 @@
-FROM golang:1.16.0-alpine AS build
+FROM golang:1.16.0 AS build
 RUN mkdir -p /go/src/github.com/gravitational/teleport-plugins/
 WORKDIR /go/src/github.com/gravitational/teleport-plugins/
 COPY . .
-RUN apk update && apk add make
 RUN cd access/slack
 RUN make && ls access/slack/*
 
-FROM alpine:3.12 as plugin
+FROM ubuntu:18.04 as plugin
 RUN mkdir -p tmp/slack
 WORKDIR /tmp/slack
 COPY --from=build /go/src/github.com/gravitational/teleport-plugins/access/slack/ .

--- a/Dockerfile.slack
+++ b/Dockerfile.slack
@@ -5,7 +5,7 @@ COPY . .
 RUN cd access/slack
 RUN make && ls access/slack/*
 
-FROM ubuntu:18.04 as plugin
+FROM ubuntu:20.04 as plugin
 RUN mkdir -p tmp/slack
 WORKDIR /tmp/slack
 COPY --from=build /go/src/github.com/gravitational/teleport-plugins/access/slack/ .


### PR DESCRIPTION
Is there any interest in building and publishing plugins as docker images?
This will make it a lot easier for kubernetes users to use these plugins.