### PR TITLE
Re-adds --skip-dirs=vendor and disables default skipping behaviour

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,4 +28,7 @@ output:
   uniq-by-line: false
 
 run:
+  skip-dirs:
+    - vendor
+  skip-dirs-use-default: false
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 issues:
   exclude-rules:
-    - linters: staticcheck
+    - linters: gosimple
       text: "S1002: should omit comparison to bool constant"
   exclude-use-default: true
   max-same-issues: 0


### PR DESCRIPTION
As per @awly's comment in https://github.com/gravitational/teleport-plugins/pull/200#discussion_r596419420, the original intention here was to only skip the `vendor` directory and test everything else.