### PR TITLE
Bump all plugin versions to 6.1.1

### DIFF
--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.2.0
+VERSION=6.1.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-jira

--- a/access/jira/version.go
+++ b/access/jira/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "0.2.0"
+	Version = "6.1.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,4 +1,4 @@
-VERSION=6.1.0
+VERSION=6.1.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-mattermost

--- a/access/mattermost/version.go
+++ b/access/mattermost/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "6.1.0"
+	Version = "6.1.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,4 +1,4 @@
-VERSION=6.1.0-dev
+VERSION=6.1.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-slack

--- a/access/slack/version.go
+++ b/access/slack/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "6.1.0-dev"
+	Version = "6.1.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Here are some notes on how to publish `teleport-plugins` artifacts - I'll make this into a Slab page and/or README at some point soon.

## Plugin versions

Each plugin has its own version string inside `access/<plugin>/Makefile` which needs to be updated when publishing a new artifact. `access/<plugin>/version.go` also has to be updated after doing this (this is the same way that teleport works) - `make -C access/<plugin> version.go`.

This was done originally because:
1) we wanted each plugin to be an individual download for space/efficiency, rather than bundling an increasing number of plugins into every single release tarball
2) we thought we might want to push new patch versions of certain plugins while keeping the others the same.

If we're proposing a change to keep all plugin versions level with a Teleport version, then 2) is probably no longer true and we should consider overhauling the plugins to have one central version defined in the main `Makefile` which they all inherit and modifying the publishing process accordingly.

## Drone artifact builds/publishing

Drone [looks for tags](https://github.com/gravitational/teleport-plugins/blob/master/.drone.yml#L163) formatted exactly like `teleport-<plugin>-v<version` and uses this tag to figure out what plugin it should build for a given tag, and what version that plugin has: https://github.com/gravitational/teleport-plugins/blob/master/.drone.yml#L176

This means that to publish version 6.1.1 of every plugin, you have to push one git tag per plugin:

```
teleport-jira-v6.1.1
teleport-slack-v6.1.1
teleport-gitlab-v6.1.1
teleport-webhooks-v6.1.1
teleport-pagerduty-v6.1.1
teleport-mattermost-v6.1.1
```

Once each tag is pushed, each tag must also be individually promoted to `production` to get published to get.gravitational.com for download. Again, this was done originally with the intention that we would be pushing individual plugin updates rather than doing them as one big group.

The version in the git tag **must** match the version in the `Makefile`, otherwise the paths in S3 will get messed up and Houston won't be able to find the artifact for download. This is because:
- the version string from the tag is used to create the S3 directory path (https://github.com/gravitational/teleport-plugins/blob/master/.drone.yml#L240)
- but the version string from the plugin's `Makefile`  is used to create its filename during release (https://github.com/gravitational/teleport-plugins/blob/master/access/slack/Makefile#L13)

Again, this is the same way that Teleport's publishing pipeline works. The idea was to keep things relatively consistent across both pipelines. 

If any of this needs overhauling/changing, please file an issue and I'll get to it.