### PR TITLE
Update terraform getting started doc to use identity file.

### DIFF
--- a/terraform/GETTING_STARTED.md
+++ b/terraform/GETTING_STARTED.md
@@ -69,6 +69,8 @@ terraform {
 }
 
 provider "teleport" {
+  # Update addr to point to Teleport Auth/Proxy
+  # e.g. addr = "example.teleport.sh:3025"
   addr               = "localhost:3025"
   identity_file_path = "terraform-identity"
 }

--- a/terraform/GETTING_STARTED.md
+++ b/terraform/GETTING_STARTED.md
@@ -51,7 +51,7 @@ Run:
 
 ```
 tctl create terraform.yaml
-tctl auth sign --format=tls --user=terraform --out=tf --ttl=10h
+tctl auth sign --format=file --user=terraform --out=terraform-identity --ttl=10h
 ```
 
 # Create Terraform configuration
@@ -69,10 +69,8 @@ terraform {
 }
 
 provider "teleport" {
-  addr         = "localhost:3025"
-  cert_path    = "tf.crt"
-  key_path     = "tf.key"
-  root_ca_path = "tf.cas"
+  addr               = "localhost:3025"
+  identity_file_path = "terraform-identity"
 }
 
 resource "teleport_user" "example" {

--- a/terraform/GETTING_STARTED.md
+++ b/terraform/GETTING_STARTED.md
@@ -29,6 +29,7 @@ mkdir ~/terraform-cluster && cd ~/terraform-cluster
 Put the following content into terraform.yaml:
 
 ```
+// terraform.yaml
 kind: role
 metadata:
   name: terraform
@@ -53,6 +54,8 @@ Run:
 tctl create terraform.yaml
 tctl auth sign --format=file --user=terraform --out=terraform-identity --ttl=10h
 ```
+
+Note: Teleport cloud users may want to use [impersonation](https://goteleport.com/docs/access-controls/guides/impersonation/) for this step.
 
 # Create Terraform configuration
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,7 +21,7 @@ make build
 
 ```bash
 tctl create example/teleport.yaml
-tctl auth sign --format=tls --user=terraform --out=tf --ttl=10h
+tctl auth sign --format=file --user=terraform --out=terraform-identity --ttl=10h
 ```
 
 Move generated keys to the desired location.

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -1,6 +1,4 @@
-variable "cert_path" {}
-variable "key_path" {}
-variable "root_ca_path" {}
+variable "identity_file_path" {}
 
 terraform {
   required_providers {
@@ -12,10 +10,8 @@ terraform {
 }
 
 provider "teleport" {
-  addr         = "localhost:3025"
-  cert_path    = var.cert_path
-  key_path     = var.key_path
-  root_ca_path = var.root_ca_path
+  addr               = "localhost:3025"
+  identity_file_path = "var.identity_file_path"
 
   # Specify addr if you want to use tctl profile
   # addr = "evilmartians.teleport.sh:443"

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -10,14 +10,11 @@ terraform {
 }
 
 provider "teleport" {
-  addr               = "localhost:3025"
   identity_file_path = "var.identity_file_path"
 
-  # Specify addr if you want to use tctl profile
+  addr = "localhost:3025"
+  # Update addr to point to Teleport Auth/Proxy
   # addr = "evilmartians.teleport.sh:443"
-
-  # Specify path to identity file if you have it
-  # identity_file_path = "id"
 }
 
 resource "teleport_provision_token" "example" {

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "teleport" {
-  identity_file_path = "var.identity_file_path"
+  identity_file_path = var.identity_file_path
 
   addr = "localhost:3025"
   # Update addr to point to Teleport Auth/Proxy

--- a/terraform/example/vars.tfvars.example
+++ b/terraform/example/vars.tfvars.example
@@ -1,4 +1,2 @@
-# Change these paths to actual certificate paths on your machine
-cert_path = "/etc/teleport-plugins/terraform.crt"
-key_path = "/etc/teleport-plugins/terraform.key"
-root_ca_path = "/etc/teleport-plugins/terraform.cas"
+# Change this path to an actual identity file path on your machine
+identity_file_path = "/etc/teleport-plugins/terraform-identity"


### PR DESCRIPTION
Identity file is now the suggested credential loader for terraform because it can connect through a Teleport Proxy.

Fixes https://github.com/gravitational/teleport/issues/6566