### PR TITLE
Add configurable IssueType to Jira plugin

### DIFF
--- a/access/jira/bot.go
+++ b/access/jira/bot.go
@@ -26,6 +26,7 @@ const (
 type Bot struct {
 	client      *resty.Client
 	project     string
+	issueType   string
 	clusterName string
 }
 
@@ -126,7 +127,7 @@ func NewBot(conf JIRAConfig) *Bot {
 		}
 		return nil
 	})
-	return &Bot{client: client, project: conf.Project}
+	return &Bot{client: client, project: conf.Project, issueType: conf.IssueType}
 }
 
 func (b *Bot) HealthCheck(ctx context.Context) error {
@@ -206,7 +207,7 @@ func (b *Bot) CreateIssue(ctx context.Context, reqID string, reqData RequestData
 			},
 		},
 		Fields: IssueFieldsInput{
-			Type:        &IssueType{Name: "Task"},
+			Type:        &IssueType{Name: b.issueType},
 			Project:     &Project{Key: b.project},
 			Summary:     fmt.Sprintf("%s requested %s", reqData.User, strings.Join(reqData.Roles, ", ")),
 			Description: description,

--- a/access/jira/config.go
+++ b/access/jira/config.go
@@ -21,10 +21,11 @@ type Config struct {
 }
 
 type JIRAConfig struct {
-	URL      string `toml:"url"`
-	Username string `toml:"username"`
-	APIToken string `toml:"api_token"`
-	Project  string `toml:"project"`
+	URL       string `toml:"url"`
+	Username  string `toml:"username"`
+	APIToken  string `toml:"api_token"`
+	Project   string `toml:"project"`
+	IssueType string `toml:"issue_type"`
 }
 
 const exampleConfig = `# example jira plugin configuration TOML file
@@ -39,6 +40,7 @@ url = "https://example.com/jira"    # JIRA URL. For JIRA Cloud, https://[my-jira
 username = "jira-bot"               # JIRA username
 api_token = "token"                 # JIRA API Basic Auth token, or our password in case you're using Jira Server.
 project = "MYPROJ"                  # JIRA Project key
+issue_type = "Task"                 # JIRA Issue type
 
 [http]
 public_addr = "example.com" # URL on which callback server is accessible externally, e.g. [https://]teleport-proxy.example.com
@@ -90,6 +92,9 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	if c.JIRA.APIToken == "" {
 		return trace.BadParameter("missing required value jira.api_token")
+	}
+	if c.JIRA.IssueType == "" {
+		c.JIRA.IssueType = "Task"
 	}
 	if c.HTTP.ListenAddr == "" {
 		c.HTTP.ListenAddr = ":8081"


### PR DESCRIPTION
~So I haven't had time to test this out on a live system yet, but~ I believe this will fix #237 . ~I'm planning to try~ I pushed the binary out to my plugins server and it is able to create tickets with the issueType I've configured. It builds with `make access-jira` and tests pass when I do `make test`.