### PR TITLE
Jira Plugin: Add basic /status endpoint

### DIFF
--- a/access/jira/webhook_server.go
+++ b/access/jira/webhook_server.go
@@ -55,6 +55,7 @@ func NewWebhookServer(conf lib.HTTPConfig, onWebhook WebhookFunc) (*WebhookServe
 		onWebhook: onWebhook,
 	}
 	httpSrv.POST("/", srv.processWebhook)
+	httpSrv.GET("/status", srv.processStatus)
 	return srv, nil
 }
 
@@ -104,4 +105,8 @@ func (s *WebhookServer) processWebhook(rw http.ResponseWriter, r *http.Request, 
 	} else {
 		rw.WriteHeader(http.StatusOK)
 	}
+}
+
+func (s *WebhookServer) processStatus(rw http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	rw.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
The webhook needs a status endpoint so that load balancers can health check it. This PR adds one at `/status` that always returns 200/OK.