### PR TITLE
teleport-plugins: Add darwin/linux release pipelines for Terraform provider

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -260,7 +260,6 @@ steps:
       - make release/terraform
       - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
       - cd build
-      - pwd
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
       - ls -l .
 
@@ -325,6 +324,6 @@ steps:
 
 ---
 kind: signature
-hmac: 44c8df93eb2f51675aeb6dfe7e84161a25321066ceef56d97c9f6a1837b2dff6
+hmac: 315bf9d19df8ffe72effa7a6204663c1f95ebedf409e20f7c7a124126f3db8c3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -262,21 +262,21 @@ steps:
       WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
       - set -u
-      - rm -rf ${WORKSPACE_DIR}/go
-      - mkdir -p ${WORKSPACE_DIR}/go/cache
-      - chmod -R u+rw ${WORKSPACE_DIR}/go
+      - rm -rf $WORKSPACE_DIR/go
+      - mkdir -p $WORKSPACE_DIR/go/cache
+      - chmod -R u+rw $WORKSPACE_DIR/go
 
   - name: Build artifacts (darwin)
     environment:
       WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
       - set -u
-      - export GOPATH=${WORKSPACE_DIR}/go
-      - export GOCACHE=${WORKSPACE_DIR}/go/cache
-      - mkdir -p ${WORKSPACE_DIR}/build/
+      - export GOPATH=$WORKSPACE_DIR/go
+      - export GOCACHE=$WORKSPACE_DIR/go/cache
+      - mkdir -p $WORKSPACE_DIR/build/
       - make release/terraform
-      - find ${WORKSPACE_DIR}/terraform/ -iname "*.tar.gz" -print -exec cp {} ${WORKSPACE_DIR}/build/ \;
-      - cd ${WORKSPACE_DIR}/build
+      - find $WORKSPACE_DIR/terraform/ -iname "*.tar.gz" -print -exec cp {} $WORKSPACE_DIR/build/ \;
+      - cd $WORKSPACE_DIR/build
       - pwd
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
       - ls -l .
@@ -293,7 +293,7 @@ steps:
       WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
       - set -u
-      - cd ${WORKSPACE_DIR}/build
+      - cd $WORKSPACE_DIR/build
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
 
   - name: Clean up exec runner storage (post)
@@ -301,7 +301,7 @@ steps:
       WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
       - set -u
-      - rm -rf ${WORKSPACE_DIR}/go
+      - rm -rf $WORKSPACE_DIR/go
 
 ---
 kind: pipeline
@@ -351,6 +351,6 @@ steps:
 
 ---
 kind: signature
-hmac: 555b19d1a0538620f20fe8ee3f2d6903f53ce93a81b94d875f10d517c4448087
+hmac: f81b0135253be317b90538ea0f6c01618e3df74aa7ed71f69ad66d45dd9651d0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -153,7 +153,7 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: tag-build-linux
+name: tag-build-plugins-linux
 
 trigger:
   event:
@@ -197,13 +197,113 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: promote-artifact
+name: tag-build-terraform-linux
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/terraform-*-v*
+
+workspace:
+  path: /go/src/github.com/gravitational/teleport-plugins
+
+steps:
+  - name: Build artifacts
+    image: golang:1.16.2
+    commands:
+      - mkdir -p build/
+      - make release/terraform
+      - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
+      - cd build
+      - for FILE in *.tar.gz; do sha256sum $FILE > $FILE.sha256; done
+      - ls -l .
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/src/github.com/gravitational/teleport-plugins/build/*
+      target: teleport-terraform/tag/${DRONE_TAG}
+      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
+
+---
+kind: pipeline
+type: exec
+name: tag-build-terraform-darwin
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/terraform-v*
+
+workspace:
+  path: /tmp/teleport-plugins/tag-build-terraform-darwin
+
+steps:
+  - name: Clean up exec runner storage (pre)
+    commands:
+      - rm -rf /tmp/teleport-plugins/tag-build-terraform-darwin/go
+      - mkdir -p /tmp/teleport-plugins/tag-build-terraform-darwin/go/cache
+      - chmod -R u+rw /tmp/teleport-plugins/tag-build-terraform-darwin/go
+
+  - name: Build artifacts (darwin)
+    environment:
+      GOPATH: /tmp/teleport-plugins/tag-build-terraform-darwin/go
+      GOCACHE: /tmp/teleport-plugins/tag-build-terraform-darwin/go/cache
+    commands:
+      - mkdir -p build/
+      - make release/terraform
+      - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
+      - cd build
+      - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
+      - ls -l .
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
+    commands:
+      - set -u
+      - cd /tmp/teleport-plugins/tag-build-terraform-darwin/build
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-terraform/tag/${DRONE_TAG}/
+
+  - name: Clean up exec runner storage (post)
+    commands:
+      - rm -rf /tmp/teleport-plugins/tag-build-terraform-darwin/go
+
+---
+kind: pipeline
+type: kubernetes
+name: promote-plugin-artifact
 
 trigger:
   event:
     - promote
   target:
-    - production
+    - production-plugin
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -212,7 +312,7 @@ clone:
   disable: true
 
 steps:
-  - name: Download artifact from S3 artifact publishing bucket
+  - name: Download plugin artifact from S3 artifact publishing bucket
     image: amazon/aws-cli
     environment:
       AWS_S3_BUCKET:
@@ -225,7 +325,7 @@ steps:
     commands:
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/ .
 
-  - name: Upload artifact to production S3 bucket with public read access
+  - name: Upload plugin artifact to production S3 bucket with public read access
     image: plugins/s3
     settings:
       bucket:
@@ -241,7 +341,53 @@ steps:
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/
 
 ---
+kind: pipeline
+type: kubernetes
+name: promote-terraform-artifact
+
+trigger:
+  event:
+    - promote
+  target:
+    - production-terraform
+
+workspace:
+  path: /go/src/github.com/gravitational/teleport-plugins
+
+clone:
+  disable: true
+
+steps:
+  - name: Download Terraform artifact from S3 artifact publishing bucket
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport-terraform/tag/${DRONE_TAG}/ .
+
+  - name: Upload Terraform artifact to production S3 bucket with public read access
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: PRODUCTION_AWS_S3_BUCKET
+      access_key:
+        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
+      region: us-east-1
+      acl: public-read
+      source: /go/src/github.com/gravitational/teleport-plugins/*
+      target: teleport-terraform/${DRONE_TAG##*-v}/
+      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/
+
+---
 kind: signature
-hmac: 80cf45ae20e0f6380385236a69ef16935fa8826147950147372a5306d8b059d7
+hmac: 2ad5620f6ab789b97626eb6eacd6efcfe13f6fac7fcc916a8596ee2a7c6a24a1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -204,7 +204,7 @@ trigger:
     - tag
   ref:
     include:
-      - refs/tags/terraform-*-v*
+      - refs/tags/terraform-provider-teleport-v*
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -231,7 +231,7 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       region: us-west-2
       source: /go/src/github.com/gravitational/teleport-plugins/build/*
-      target: teleport-terraform/tag/${DRONE_TAG}
+      target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
 
 ---
@@ -251,27 +251,33 @@ trigger:
     - tag
   ref:
     include:
-      - refs/tags/terraform-v*
+      - refs/tags/terraform-provider-teleport-v*
 
 workspace:
   path: /tmp/teleport-plugins/tag-build-terraform-darwin
 
 steps:
   - name: Clean up exec runner storage (pre)
+    environment:
+      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
-      - rm -rf /tmp/teleport-plugins/tag-build-terraform-darwin/go
-      - mkdir -p /tmp/teleport-plugins/tag-build-terraform-darwin/go/cache
-      - chmod -R u+rw /tmp/teleport-plugins/tag-build-terraform-darwin/go
+      - set -u
+      - rm -rf ${WORKSPACE_DIR}/go
+      - mkdir -p ${WORKSPACE_DIR}/go/cache
+      - chmod -R u+rw ${WORKSPACE_DIR}/go
 
   - name: Build artifacts (darwin)
     environment:
-      GOPATH: /tmp/teleport-plugins/tag-build-terraform-darwin/go
-      GOCACHE: /tmp/teleport-plugins/tag-build-terraform-darwin/go/cache
+      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
-      - mkdir -p build/
+      - set -u
+      - export GOPATH=${WORKSPACE_DIR}/go
+      - export GOCACHE=${WORKSPACE_DIR}/go/cache
+      - mkdir -p ${WORKSPACE_DIR}/build/
       - make release/terraform
-      - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
-      - cd build
+      - find ${WORKSPACE_DIR}/terraform/ -iname "*.tar.gz" -print -exec cp {} ${WORKSPACE_DIR}/build/ \;
+      - cd ${WORKSPACE_DIR}/build
+      - pwd
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
       - ls -l .
 
@@ -287,23 +293,26 @@ steps:
       WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
       - set -u
-      - cd /tmp/teleport-plugins/tag-build-terraform-darwin/build
-      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-terraform/tag/${DRONE_TAG}/
+      - cd ${WORKSPACE_DIR}/build
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
 
   - name: Clean up exec runner storage (post)
+    environment:
+      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
-      - rm -rf /tmp/teleport-plugins/tag-build-terraform-darwin/go
+      - set -u
+      - rm -rf ${WORKSPACE_DIR}/go
 
 ---
 kind: pipeline
 type: kubernetes
-name: promote-plugin-artifact
+name: promote-artifact
 
 trigger:
   event:
     - promote
   target:
-    - production-plugin
+    - production
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -312,7 +321,7 @@ clone:
   disable: true
 
 steps:
-  - name: Download plugin artifact from S3 artifact publishing bucket
+  - name: Download artifact from S3 artifact publishing bucket
     image: amazon/aws-cli
     environment:
       AWS_S3_BUCKET:
@@ -325,7 +334,7 @@ steps:
     commands:
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/ .
 
-  - name: Upload plugin artifact to production S3 bucket with public read access
+  - name: Upload artifact to production S3 bucket with public read access
     image: plugins/s3
     settings:
       bucket:
@@ -341,53 +350,7 @@ steps:
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/
 
 ---
-kind: pipeline
-type: kubernetes
-name: promote-terraform-artifact
-
-trigger:
-  event:
-    - promote
-  target:
-    - production-terraform
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-clone:
-  disable: true
-
-steps:
-  - name: Download Terraform artifact from S3 artifact publishing bucket
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - aws s3 sync s3://$AWS_S3_BUCKET/teleport-terraform/tag/${DRONE_TAG}/ .
-
-  - name: Upload Terraform artifact to production S3 bucket with public read access
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: PRODUCTION_AWS_S3_BUCKET
-      access_key:
-        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
-      region: us-east-1
-      acl: public-read
-      source: /go/src/github.com/gravitational/teleport-plugins/*
-      target: teleport-terraform/${DRONE_TAG##*-v}/
-      strip_prefix: /go/src/github.com/gravitational/teleport-plugins/
-
----
 kind: signature
-hmac: 2ad5620f6ab789b97626eb6eacd6efcfe13f6fac7fcc916a8596ee2a7c6a24a1
+hmac: 555b19d1a0538620f20fe8ee3f2d6903f53ce93a81b94d875f10d517c4448087
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -253,30 +253,13 @@ trigger:
     include:
       - refs/tags/terraform-provider-teleport-v*
 
-workspace:
-  path: /tmp/teleport-plugins/tag-build-terraform-darwin
-
 steps:
-  - name: Clean up exec runner storage (pre)
-    environment:
-      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
+  - name: Build artifacts
     commands:
-      - set -u
-      - rm -rf $WORKSPACE_DIR/go
-      - mkdir -p $WORKSPACE_DIR/go/cache
-      - chmod -R u+rw $WORKSPACE_DIR/go
-
-  - name: Build artifacts (darwin)
-    environment:
-      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
-    commands:
-      - set -u
-      - export GOPATH=$WORKSPACE_DIR/go
-      - export GOCACHE=$WORKSPACE_DIR/go/cache
-      - mkdir -p $WORKSPACE_DIR/build/
+      - mkdir -p build/
       - make release/terraform
-      - find $WORKSPACE_DIR/terraform/ -iname "*.tar.gz" -print -exec cp {} $WORKSPACE_DIR/build/ \;
-      - cd $WORKSPACE_DIR/build
+      - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
+      - cd build
       - pwd
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
       - ls -l .
@@ -290,18 +273,9 @@ steps:
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
-      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
     commands:
-      - set -u
-      - cd $WORKSPACE_DIR/build
+      - cd build
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
-
-  - name: Clean up exec runner storage (post)
-    environment:
-      WORKSPACE_DIR: /tmp/teleport-plugins/tag-build-terraform-darwin
-    commands:
-      - set -u
-      - rm -rf $WORKSPACE_DIR/go
 
 ---
 kind: pipeline
@@ -351,6 +325,6 @@ steps:
 
 ---
 kind: signature
-hmac: f81b0135253be317b90538ea0f6c01618e3df74aa7ed71f69ad66d45dd9651d0
+hmac: 44c8df93eb2f51675aeb6dfe7e84161a25321066ceef56d97c9f6a1837b2dff6
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ access-gitlab:
 access-example:
 	go build -o build/access-example ./access/example
 
+.PHONY: terraform
+terraform:
+	make -C terraform
+
 # Run all tests
 .PHONY: test
 test:
@@ -48,12 +52,16 @@ release/access-pagerduty:
 release/access-gitlab:
 	make -C access/gitlab clean release
 
+.PHONY: release/terraform
+release/terraform:
+	make -C terraform clean release
+
 # Run all releases
 .PHONY: releases
 releases: release/access-slack release/access-jira release/access-mattermost release/access-pagerduty release/access-gitlab
 
 .PHONY: build-all
-build-all: access-slack access-jira access-mattermost access-pagerduty access-gitlab
+build-all: access-slack access-jira access-mattermost access-pagerduty access-gitlab terraform
 
 #
 # Lint the Go code.

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -10,6 +10,8 @@ ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 CGOFLAG ?= CGO_ENABLED=1
 
+RELEASE = access-terraform-v$(VERSION)-$(OS)-$(ARCH)-bin
+
 .PHONY: tfclean
 tfclean:
 	rm -rf $(TFDIR)/terraform.tfstate
@@ -21,15 +23,20 @@ tfclean:
 clean: tfclean
 	rm -rf $(PROVIDER_PATH)*
 	rm -rf $(BUILDDIR)/*
+	rm -rf $(RELEASE).tar.gz
 	go clean
 
 .PHONY: build
 build: clean
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleport $(BUILDFLAGS)
 
+.PHONY: release
+release: build
+	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
+
 .PHONY: apply
 apply: install
-	terraform -chdir=$(TFDIR) init -var-file="vars.tfvars" && terraform -chdir=$(TFDIR) apply -auto-approve -var-file="vars.tfvars" 
+	terraform -chdir=$(TFDIR) init -var-file="vars.tfvars" && terraform -chdir=$(TFDIR) apply -auto-approve -var-file="vars.tfvars"
 
 .PHONY: reapply
 reapply:

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -10,7 +10,7 @@ ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 CGOFLAG ?= CGO_ENABLED=1
 
-RELEASE = access-terraform-v$(VERSION)-$(OS)-$(ARCH)-bin
+RELEASE = terraform-provider-teleport-v$(VERSION)-$(OS)-$(ARCH)-bin
 
 .PHONY: tfclean
 tfclean:


### PR DESCRIPTION
Adds publishing pipelines for `terraform-provider-teleport`, triggered on pushing a tag with the `terraform-provider-teleport-v*` format. Promoting this tag to production will publish both `darwin` and `linux` artifacts.

Example filename formats:
`terraform-provider-teleport-v6.2.1-darwin-amd64-bin.tar.gz`
`terraform-provider-teleport-v6.2.1-linux-amd64-bin.tar.gz`

Still pending work to add these to Houston to make the downloads available.