### PR TITLE
Re-sign pipeline for drone.teleport.dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -324,6 +324,6 @@ steps:
 
 ---
 kind: signature
-hmac: 315bf9d19df8ffe72effa7a6204663c1f95ebedf409e20f7c7a124126f3db8c3
+hmac: db299ec91a910339f9c4bdd6e0dc8e6df82c32a9867c3056c70d43f8dad0506b
 
 ...


### PR DESCRIPTION
Moving from drone.gravitational.io to drone.teleport.dev means that the pipeline's signature needs to be regenerated.