### PR TITLE
Fix typo in the Slack notification

### DIFF
--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -276,7 +276,7 @@ func (b Bot) msgSections(reqID string, reqData RequestData) []BlockItem {
 		msgFieldToBuilder(&builder, "Link", reqURL.String())
 	} else {
 		if resolution.Tag == Unresolved {
-			msgFieldToBuilder(&builder, "Approve", fmt.Sprintf("`tsh request review --aprove %s`", reqID))
+			msgFieldToBuilder(&builder, "Approve", fmt.Sprintf("`tsh request review --approve %s`", reqID))
 			msgFieldToBuilder(&builder, "Deny", fmt.Sprintf("`tsh request review --deny %s`", reqID))
 		}
 	}


### PR DESCRIPTION
Closes #232.

Signed-off-by: Alexander Klizhentas <klizhentas@gmail.com>