### PR TITLE
Release 6.2.6.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,37 @@ releases: release/access-slack release/access-jira release/access-mattermost rel
 .PHONY: build-all
 build-all: access-slack access-jira access-mattermost access-pagerduty access-gitlab terraform event-handler
 
+.PHONY: update-version
+update-version:
+	# Make sure VERSION is set on the command line "make update-version VERSION=x.y.z".
+	@test $(VERSION)
+	sed -i '1s/.*/VERSION=$(VERSION)/' event-handler/Makefile
+	make -C event-handler version.go
+	sed -i '1s/.*/VERSION=$(VERSION)/' access/jira/Makefile
+	make -C access/jira version.go
+	sed -i '1s/.*/VERSION=$(VERSION)/' access/mattermost/Makefile
+	make -C access/mattermost version.go
+	sed -i '1s/.*/VERSION=$(VERSION)/' access/slack/Makefile
+	make -C access/slack version.go
+	sed -i '1s/.*/VERSION=$(VERSION)/' terraform/install.mk
+
+.PHONY: update-tag
+update-tag:
+	# Make sure VERSION is set on the command line "make update-tag VERSION=x.y.z".
+	@test $(VERSION)
+	# Tag all releases first locally.
+	git tag teleport-event-handler-v$(VERSION)
+	git tag teleport-jira-v$(VERSION)
+	git tag teleport-mattermost-v$(VERSION)
+	git tag teleport-slack-v$(VERSION)
+	git tag terraform-provider-teleport-v$(VERSION)
+	# Push all releases to origin.
+	git push origin teleport-event-handler-v$(VERSION)
+	git push origin teleport-jira-v$(VERSION)
+	git push origin teleport-mattermost-v$(VERSION)
+	git push origin teleport-slack-v$(VERSION)
+	git push origin terraform-provider-teleport-v$(VERSION)
+
 #
 # Lint the Go code.
 # By default lint scans the entire repo. Pass GO_LINT_FLAGS='--new' to only scan local

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,4 +1,4 @@
-VERSION=6.2.3
+VERSION=6.2.6
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-jira

--- a/access/jira/version.go
+++ b/access/jira/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "6.2.3"
+	Version = "6.2.6"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,4 +1,4 @@
-VERSION=6.2.3
+VERSION=6.2.6
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-mattermost

--- a/access/mattermost/version.go
+++ b/access/mattermost/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "6.2.3"
+	Version = "6.2.6"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,4 +1,4 @@
-VERSION=6.2.3
+VERSION=6.2.6
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-slack

--- a/access/slack/version.go
+++ b/access/slack/version.go
@@ -3,7 +3,7 @@
 package main
 
 const (
-	Version = "6.2.3"
+	Version = "6.2.6"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.1
+VERSION=6.2.6
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/terraform/install.mk
+++ b/terraform/install.mk
@@ -1,4 +1,4 @@
-VERSION=6.2.3
+VERSION=6.2.6
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)


### PR DESCRIPTION
**Description**

Updated release version to `6.2.6`.

Added two `make` targets to make updating and cutting releases easier.

* `make update-version` to update version of all supported Teleport Plugins.
* `make update-tag` to create and push updated tags to `origin`.