### PR TITLE
[Buddy PR] Add Proxy and SSH services support to testing/integration library + CA Pinning fix

### DIFF
--- a/access/gitlab/gitlab_test.go
+++ b/access/gitlab/gitlab_test.go
@@ -92,7 +92,7 @@ func (s *GitlabSuite) SetupSuite() {
 	require.NoError(t, err)
 	t.Cleanup(teleport.Close)
 
-	auth, err := teleport.NewAuthServer()
+	auth, err := teleport.NewAuthService()
 	require.NoError(t, err)
 	s.StartApp(auth)
 
@@ -184,7 +184,7 @@ func (s *GitlabSuite) SetupSuite() {
 	identityPath, err := teleport.Sign(ctx, auth, s.userNames.plugin)
 	require.NoError(t, err)
 
-	s.teleportConfig.Addr = auth.PublicAddr()
+	s.teleportConfig.Addr = auth.AuthAddr().String()
 	s.teleportConfig.Identity = identityPath
 	s.teleportFeatures = teleportFeatures
 }

--- a/access/jira/jira_test.go
+++ b/access/jira/jira_test.go
@@ -84,7 +84,7 @@ func (s *JiraSuite) SetupSuite() {
 	require.NoError(t, err)
 	t.Cleanup(teleport.Close)
 
-	auth, err := teleport.NewAuthServer()
+	auth, err := teleport.NewAuthService()
 	require.NoError(t, err)
 	s.StartApp(auth)
 
@@ -179,7 +179,7 @@ func (s *JiraSuite) SetupSuite() {
 	identityPath, err := teleport.Sign(ctx, auth, s.userNames.plugin)
 	require.NoError(t, err)
 
-	s.teleportConfig.Addr = auth.PublicAddr()
+	s.teleportConfig.Addr = auth.AuthAddr().String()
 	s.teleportConfig.Identity = identityPath
 	s.teleportFeatures = teleportFeatures
 }

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -67,7 +67,7 @@ func (s *MattermostSuite) SetupSuite() {
 	require.NoError(t, err)
 	t.Cleanup(teleport.Close)
 
-	auth, err := teleport.NewAuthServer()
+	auth, err := teleport.NewAuthService()
 	require.NoError(t, err)
 	s.StartApp(auth)
 
@@ -158,7 +158,7 @@ func (s *MattermostSuite) SetupSuite() {
 	identityPath, err := teleport.Sign(ctx, auth, s.userNames.plugin)
 	require.NoError(t, err)
 
-	s.teleportConfig.Addr = auth.PublicAddr()
+	s.teleportConfig.Addr = auth.AuthAddr().String()
 	s.teleportConfig.Identity = identityPath
 	s.teleportFeatures = teleportFeatures
 }

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -97,7 +97,7 @@ func (s *PagerdutySuite) SetupSuite() {
 	require.NoError(t, err)
 	t.Cleanup(teleport.Close)
 
-	auth, err := teleport.NewAuthServer()
+	auth, err := teleport.NewAuthService()
 	require.NoError(t, err)
 	s.StartApp(auth)
 
@@ -255,7 +255,7 @@ func (s *PagerdutySuite) SetupSuite() {
 	identityPath, err := teleport.Sign(ctx, auth, s.userNames.plugin)
 	require.NoError(t, err)
 
-	s.teleportConfig.Addr = auth.PublicAddr()
+	s.teleportConfig.Addr = auth.AuthAddr().String()
 	s.teleportConfig.Identity = identityPath
 	s.teleportFeatures = teleportFeatures
 }

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -66,7 +66,7 @@ func (s *SlackSuite) SetupSuite() {
 	require.NoError(t, err)
 	t.Cleanup(teleport.Close)
 
-	auth, err := teleport.NewAuthServer()
+	auth, err := teleport.NewAuthService()
 	require.NoError(t, err)
 	s.StartApp(auth)
 
@@ -157,7 +157,7 @@ func (s *SlackSuite) SetupSuite() {
 	identityPath, err := teleport.Sign(ctx, auth, s.userNames.plugin)
 	require.NoError(t, err)
 
-	s.teleportConfig.Addr = auth.PublicAddr()
+	s.teleportConfig.Addr = auth.AuthAddr().String()
 	s.teleportConfig.Identity = identityPath
 	s.teleportFeatures = teleportFeatures
 }

--- a/lib/testing/integration/auth_test.go
+++ b/lib/testing/integration/auth_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type IntegrationAuthSuite struct {
+	IntegrationAuthSetup
+}
+
+func TestIntegrationAuth(t *testing.T) { suite.Run(t, &IntegrationAuthSuite{}) }
+
+func (s *IntegrationAuthSuite) TestBootstrap() {
+	t := s.T()
+
+	var bootstrap Bootstrap
+	role, err := bootstrap.AddRole("foo", types.RoleSpecV4{})
+	require.NoError(t, err)
+	_, err = bootstrap.AddUserWithRoles("vladimir", "admin", role.GetName())
+	require.NoError(t, err)
+	err = s.integration.Bootstrap(s.Context(), s.auth, bootstrap.Resources())
+	require.NoError(t, err)
+}
+
+func (s *IntegrationAuthSuite) TestPing() {
+	t := s.T()
+
+	var bootstrap Bootstrap
+	user, err := bootstrap.AddUserWithRoles("vladimir", "admin")
+	require.NoError(t, err)
+	err = s.integration.Bootstrap(s.Context(), s.auth, bootstrap.Resources())
+	require.NoError(t, err)
+
+	client, err := s.integration.NewClient(s.Context(), s.auth, user.GetName())
+	require.NoError(t, err)
+	_, err = client.Ping(s.Context())
+	require.NoError(t, err)
+}

--- a/lib/testing/integration/download.go
+++ b/lib/testing/integration/download.go
@@ -182,9 +182,10 @@ func getBinaries(ctx context.Context, distStr, outDir string, checksum lib.SHA25
 	existingPaths := BinPaths{
 		Teleport: path.Join(outExtractDir, "teleport"),
 		Tctl:     path.Join(outExtractDir, "tctl"),
+		Tsh:      path.Join(outExtractDir, "tsh"),
 	}
 
-	if fileExists(existingPaths.Teleport) && fileExists(existingPaths.Tctl) {
+	if fileExists(existingPaths.Teleport) && fileExists(existingPaths.Tctl) && fileExists(existingPaths.Tsh) {
 		log.Debugf("Teleport binaries are found in %s. No need to download anything", outExtractDir)
 		return existingPaths, trace.Wrap(outFile.Close())
 	}
@@ -215,9 +216,9 @@ func getBinaries(ctx context.Context, distStr, outDir string, checksum lib.SHA25
 		OutFiles:        make(map[string]string),
 	}
 	if strings.HasPrefix(distStr, "teleport-ent") {
-		tarOptions.Files = []string{"teleport-ent/teleport", "teleport-ent/tctl"}
+		tarOptions.Files = []string{"teleport-ent/teleport", "teleport-ent/tctl", "teleport-ent/tsh"}
 	} else {
-		tarOptions.Files = []string{"teleport/teleport", "teleport/tctl"}
+		tarOptions.Files = []string{"teleport/teleport", "teleport/tctl", "teleport/tsh"}
 	}
 
 	log.Debugf("Extracting Teleport binaries into %s", outExtractDir)
@@ -232,6 +233,7 @@ func getBinaries(ctx context.Context, distStr, outDir string, checksum lib.SHA25
 	return BinPaths{
 		Teleport: tarOptions.OutFiles[tarOptions.Files[0]],
 		Tctl:     tarOptions.OutFiles[tarOptions.Files[1]],
+		Tsh:      tarOptions.OutFiles[tarOptions.Files[2]],
 	}, nil
 }
 

--- a/lib/testing/integration/fileconfig.go
+++ b/lib/testing/integration/fileconfig.go
@@ -19,6 +19,7 @@ package integration
 const teleportAuthYAML = `
 teleport:
   data_dir: {{TELEPORT_DATA_DIR}}
+  auth_token: {{TELEPORT_AUTH_TOKEN}}
   cache:
     enabled: false
   log:
@@ -33,6 +34,8 @@ auth_service:
   enabled: true
   listen_addr: 127.0.0.1:0
   public_addr: localhost
+  tokens:
+  - node,auth,proxy,app:{{TELEPORT_AUTH_TOKEN}}
   authentication:
     type: local
 
@@ -41,4 +44,56 @@ proxy_service:
 
 ssh_service:
   enabled: false
+`
+
+const teleportProxyYAML = `
+teleport:
+  data_dir: {{TELEPORT_DATA_DIR}}
+  auth_servers: ['{{TELEPORT_AUTH_SERVER}}']
+  auth_token: '{{TELEPORT_AUTH_TOKEN}}'
+  cache:
+    enabled: false
+  log:
+    output: stdout
+  storage:
+    type: sqlite
+    poll_stream_period: 50000000
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: true
+  tunnel_public_addr: localhost:{{PROXY_TUN_LISTEN_PORT}}
+  listen_addr: 127.0.0.1:0
+  web_listen_addr: {{PROXY_WEB_LISTEN_ADDR}}
+  tunnel_listen_addr: {{PROXY_TUN_LISTEN_ADDR}}
+
+ssh_service:
+  enabled: false
+`
+
+const teleportSSHYAML = `
+teleport:
+  data_dir: {{TELEPORT_DATA_DIR}}
+  auth_servers: ['{{TELEPORT_AUTH_SERVER}}']
+  auth_token: '{{TELEPORT_AUTH_TOKEN}}'
+  cache:
+    enabled: false
+  log:
+    output: stdout
+  storage:
+    type: sqlite
+    poll_stream_period: 50000000
+
+auth_service:
+  enabled: false
+
+proxy_service:
+  enabled: false
+
+ssh_service:
+  enabled: true
+  listen_addr: {{SSH_LISTEN_ADDR}}
+  public_addr: localhost:{{SSH_LISTEN_PORT}}
 `

--- a/lib/testing/integration/fileconfig.go
+++ b/lib/testing/integration/fileconfig.go
@@ -51,6 +51,7 @@ teleport:
   data_dir: {{TELEPORT_DATA_DIR}}
   auth_servers: ['{{TELEPORT_AUTH_SERVER}}']
   auth_token: '{{TELEPORT_AUTH_TOKEN}}'
+  ca_pin: '{{TELEPORT_AUTH_CA_PIN}}'
   cache:
     enabled: false
   log:
@@ -78,6 +79,7 @@ teleport:
   data_dir: {{TELEPORT_DATA_DIR}}
   auth_servers: ['{{TELEPORT_AUTH_SERVER}}']
   auth_token: '{{TELEPORT_AUTH_TOKEN}}'
+  ca_pin: '{{TELEPORT_AUTH_CA_PIN}}'
   cache:
     enabled: false
   log:

--- a/lib/testing/integration/integration.go
+++ b/lib/testing/integration/integration.go
@@ -18,8 +18,11 @@ package integration
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -33,6 +36,7 @@ import (
 
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/tctl"
+	"github.com/gravitational/teleport-plugins/lib/tsh"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
@@ -52,16 +56,25 @@ type Integration struct {
 	workDir string
 	cleanup []func() error
 	version Version
+	token   string
 }
 
 type BinPaths struct {
 	Teleport string
 	Tctl     string
+	Tsh      string
+}
+
+type Addr struct {
+	Host string
+	Port string
+}
+
+type Auth interface {
+	AuthAddr() Addr
 }
 
 type Service interface {
-	PublicAddr() string
-	ConfigPath() string
 	Run(context.Context) error
 	WaitReady(ctx context.Context) (bool, error)
 	Err() error
@@ -99,6 +112,7 @@ func New(ctx context.Context, paths BinPaths, licenseStr string) (*Integration, 
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to get teleport version")
 	}
+
 	tctlVersion, err := getBinaryVersion(ctx, integration.paths.Tctl)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to get tctl version")
@@ -106,6 +120,15 @@ func New(ctx context.Context, paths BinPaths, licenseStr string) (*Integration, 
 	if !teleportVersion.Equal(tctlVersion.Version) {
 		return nil, trace.Wrap(err, "teleport version %s does not match tctl version %s", teleportVersion.Version, tctlVersion.Version)
 	}
+
+	tshVersion, err := getBinaryVersion(ctx, integration.paths.Tsh)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to get tsh version")
+	}
+	if !teleportVersion.Equal(tshVersion.Version) {
+		return nil, trace.Wrap(err, "teleport version %s does not match tsh version %s", teleportVersion.Version, tshVersion.Version)
+	}
+
 	if teleportVersion.IsEnterprise {
 		if licenseStr == "" {
 			return nil, trace.Errorf("%s appears to be an Enterprise binary but license path is not specified", integration.paths.Teleport)
@@ -134,6 +157,13 @@ func New(ctx context.Context, paths BinPaths, licenseStr string) (*Integration, 
 
 	integration.version = teleportVersion
 
+	tokenBytes := make([]byte, 16)
+	_, err = rand.Read(tokenBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	integration.token = hex.EncodeToString(tokenBytes)
+
 	initialized = true
 	return &integration, nil
 }
@@ -160,6 +190,7 @@ func NewFromEnv(ctx context.Context) (*Integration, error) {
 		paths = BinPaths{
 			Teleport: os.Getenv("TELEPORT_BINARY"),
 			Tctl:     os.Getenv("TELEPORT_BINARY_TCTL"),
+			Tsh:      os.Getenv("TELEPORT_BINARY_TSH"),
 		}
 
 		// Look up binaries either in file system or in PATH.
@@ -175,6 +206,13 @@ func NewFromEnv(ctx context.Context) (*Integration, error) {
 			paths.Tctl = "tctl"
 		}
 		if paths.Tctl, err = exec.LookPath(paths.Tctl); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if paths.Tsh == "" {
+			paths.Tsh = "tsh"
+		}
+		if paths.Tsh, err = exec.LookPath(paths.Tsh); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	} else {
@@ -218,9 +256,9 @@ func (integration *Integration) Version() Version {
 	return integration.version
 }
 
-// NewAuthServer creates a new auth server instance.
-func (integration *Integration) NewAuthServer() (*AuthServer, error) {
-	dataDir, err := integration.tempDir("data-*")
+// NewAuthService creates a new auth server instance.
+func (integration *Integration) NewAuthService() (*AuthService, error) {
+	dataDir, err := integration.tempDir("data-auth-*")
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to initialize data directory")
 	}
@@ -231,6 +269,7 @@ func (integration *Integration) NewAuthServer() (*AuthServer, error) {
 	}
 	yaml := strings.ReplaceAll(teleportAuthYAML, "{{TELEPORT_DATA_DIR}}", dataDir)
 	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_LICENSE_FILE}}", integration.paths.license)
+	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_AUTH_TOKEN}}", integration.token)
 	if _, err := configFile.WriteString(yaml); err != nil {
 		return nil, trace.Wrap(err, "failed to write config file")
 	}
@@ -238,24 +277,100 @@ func (integration *Integration) NewAuthServer() (*AuthServer, error) {
 		return nil, trace.Wrap(err, "failed to write config file")
 	}
 
-	auth := newAuthServer(integration.paths.Teleport, configFile.Name())
+	auth := newAuthService(integration.paths.Teleport, configFile.Name())
 	integration.registerService(auth)
 	return auth, nil
 }
 
-func (integration *Integration) Bootstrap(ctx context.Context, service Service, resources []types.Resource) error {
-	return integration.tctl(service).Create(ctx, resources)
-}
+// NewProxyService creates a new auth server instance.
+func (integration *Integration) NewProxyService(auth Auth) (*ProxyService, error) {
+	dataDir, err := integration.tempDir("data-proxy-*")
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to initialize data directory")
+	}
 
-// Client builds an API client for a given user.
-func (integration *Integration) NewClient(ctx context.Context, service Service, userName string) (*Client, error) {
-	outPath, err := integration.Sign(ctx, service, userName)
+	configFile, err := integration.tempFile("teleport-proxy-*.yaml")
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+	yaml := strings.ReplaceAll(teleportProxyYAML, "{{TELEPORT_DATA_DIR}}", dataDir)
+	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_AUTH_SERVER}}", auth.AuthAddr().String())
+	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_AUTH_TOKEN}}", integration.token)
+	webListenAddr, err := getFreeTCPPort()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	yaml = strings.ReplaceAll(yaml, "{{PROXY_WEB_LISTEN_ADDR}}", webListenAddr.String())
+	yaml = strings.ReplaceAll(yaml, "{{PROXY_WEB_LISTEN_PORT}}", webListenAddr.Port)
+	tunListenAddr, err := getFreeTCPPort()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	yaml = strings.ReplaceAll(yaml, "{{PROXY_TUN_LISTEN_ADDR}}", tunListenAddr.String())
+	yaml = strings.ReplaceAll(yaml, "{{PROXY_TUN_LISTEN_PORT}}", tunListenAddr.Port)
+	if _, err := configFile.WriteString(yaml); err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+	if err := configFile.Close(); err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+
+	proxy := newProxyService(integration.paths.Teleport, configFile.Name())
+	integration.registerService(proxy)
+	return proxy, nil
+}
+
+// NewSSHService creates a new auth server instance.
+func (integration *Integration) NewSSHService(auth Auth) (*SSHService, error) {
+	dataDir, err := integration.tempDir("data-ssh-*")
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to initialize data directory")
+	}
+
+	configFile, err := integration.tempFile("teleport-ssh-*.yaml")
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+	yaml := strings.ReplaceAll(teleportSSHYAML, "{{TELEPORT_DATA_DIR}}", dataDir)
+	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_AUTH_SERVER}}", auth.AuthAddr().String())
+	yaml = strings.ReplaceAll(yaml, "{{TELEPORT_AUTH_TOKEN}}", integration.token)
+	sshListenAddr, err := getFreeTCPPort()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	yaml = strings.ReplaceAll(yaml, "{{SSH_LISTEN_ADDR}}", sshListenAddr.String())
+	yaml = strings.ReplaceAll(yaml, "{{SSH_LISTEN_PORT}}", sshListenAddr.Port)
+	if _, err := configFile.WriteString(yaml); err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+	if err := configFile.Close(); err != nil {
+		return nil, trace.Wrap(err, "failed to write config file")
+	}
+
+	ssh := newSSHService(integration.paths.Teleport, configFile.Name())
+	integration.registerService(ssh)
+	return ssh, nil
+}
+
+func (integration *Integration) Bootstrap(ctx context.Context, auth *AuthService, resources []types.Resource) error {
+	return integration.tctl(auth).Create(ctx, resources)
+}
+
+// NewClient builds an API client for a given user.
+func (integration *Integration) NewClient(ctx context.Context, auth *AuthService, userName string) (*Client, error) {
+	outPath, err := integration.Sign(ctx, auth, userName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return integration.NewSignedClient(ctx, auth, outPath, userName)
+}
+
+// NewSignedClient builds a client for a given user given the identity file.
+func (integration *Integration) NewSignedClient(ctx context.Context, auth Auth, identityPath, userName string) (*Client, error) {
 	apiClient, err := client.New(ctx, client.Config{
-		Addrs:       []string{service.PublicAddr()},
-		Credentials: []client.Credentials{client.LoadIdentityFile(outPath)},
+		InsecureAddressDiscovery: true,
+		Addrs:                    []string{auth.AuthAddr().String()},
+		Credentials:              []client.Credentials{client.LoadIdentityFile(identityPath)},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -265,7 +380,7 @@ func (integration *Integration) NewClient(ctx context.Context, service Service, 
 	return client, nil
 }
 
-func (integration *Integration) MakeAdmin(ctx context.Context, service Service, userName string) (*Client, error) {
+func (integration *Integration) MakeAdmin(ctx context.Context, auth *AuthService, userName string) (*Client, error) {
 	var bootstrap Bootstrap
 	if _, err := bootstrap.AddRole(IntegrationAdminRole, types.RoleSpecV4{
 		Allow: types.RoleConditions{
@@ -282,14 +397,14 @@ func (integration *Integration) MakeAdmin(ctx context.Context, service Service, 
 	if _, err := bootstrap.AddUserWithRoles(userName, IntegrationAdminRole); err != nil {
 		return nil, trace.Wrap(err, fmt.Sprintf("failed to initialize %s user", userName))
 	}
-	if err := integration.Bootstrap(ctx, service, bootstrap.Resources()); err != nil {
+	if err := integration.Bootstrap(ctx, auth, bootstrap.Resources()); err != nil {
 		return nil, trace.Wrap(err, fmt.Sprintf("failed to bootstrap admin user %s", userName))
 	}
-	return integration.NewClient(ctx, service, userName)
+	return integration.NewClient(ctx, auth, userName)
 }
 
-// Sign generates a credentials file for the user.
-func (integration *Integration) Sign(ctx context.Context, service Service, userName string) (string, error) {
+// Sign generates a credentials file for the user and returns an identity file path.
+func (integration *Integration) Sign(ctx context.Context, auth *AuthService, userName string) (string, error) {
 	outFile, err := integration.tempFile(fmt.Sprintf("credentials-%s-*", userName))
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -298,10 +413,20 @@ func (integration *Integration) Sign(ctx context.Context, service Service, userN
 		return "", trace.Wrap(err)
 	}
 	outPath := outFile.Name()
-	if err := integration.tctl(service).Sign(ctx, userName, outPath); err != nil {
+	if err := integration.tctl(auth).Sign(ctx, userName, outPath); err != nil {
 		return "", trace.Wrap(err)
 	}
 	return outPath, nil
+}
+
+// NewTsh makes a new tsh runner.
+func (integration *Integration) NewTsh(proxyAddr, identityPath string) tsh.Tsh {
+	return tsh.Tsh{
+		Path:     integration.paths.Tsh,
+		Proxy:    proxyAddr,
+		Identity: identityPath,
+		Insecure: true,
+	}
 }
 
 func getBinaryVersion(ctx context.Context, binaryPath string) (Version, error) {
@@ -324,11 +449,11 @@ func getBinaryVersion(ctx context.Context, binaryPath string) (Version, error) {
 	return Version{Version: version, IsEnterprise: submatch[1] != ""}, nil
 }
 
-func (integration *Integration) tctl(service Service) tctl.Tctl {
+func (integration *Integration) tctl(auth *AuthService) tctl.Tctl {
 	return tctl.Tctl{
 		Path:       integration.paths.Tctl,
-		AuthServer: service.PublicAddr(),
-		ConfigPath: service.ConfigPath(),
+		AuthServer: auth.AuthAddr().String(),
+		ConfigPath: auth.ConfigPath(),
 	}
 }
 
@@ -362,4 +487,25 @@ func (integration *Integration) tempDir(pattern string) (string, error) {
 	}
 	integration.registerCleanup(func() error { return os.RemoveAll(dir) })
 	return dir, nil
+}
+
+func getFreeTCPPort() (Addr, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return Addr{}, trace.Wrap(err)
+	}
+	if err := listener.Close(); err != nil {
+		return Addr{}, trace.Wrap(err)
+	}
+	addrStr := listener.Addr().String()
+	parts := strings.SplitN(addrStr, ":", 2)
+	return Addr{Host: parts[0], Port: parts[1]}, nil
+}
+
+func (addr Addr) IsEmpty() bool {
+	return addr.Host == "" && addr.Port == ""
+}
+
+func (addr Addr) String() string {
+	return fmt.Sprintf("%s:%s", addr.Host, addr.Port)
 }

--- a/lib/testing/integration/proxyservice.go
+++ b/lib/testing/integration/proxyservice.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/trace"
+)
+
+var regexpWebProxyStarting = regexp.MustCompile(`Web proxy service [^ ]+ is starting on [^ ]+:(\d+)`)
+var regexpSSHProxyStarting = regexp.MustCompile(`SSH proxy service [^ ]+ is starting on [^ ]+:(\d+)`)
+var regexpReverseTunnelStarting = regexp.MustCompile(`Reverse tunnel service [^ ]+ is starting on [^ ]+:(\d+)`)
+
+type ProxyService struct {
+	mu                sync.Mutex
+	teleportPath      string
+	configPath        string
+	webProxyAddr      Addr
+	sshProxyAddr      Addr
+	reverseTunnelAddr Addr
+	isReady           bool
+	readyCh           chan struct{}
+	doneCh            chan struct{}
+	terminate         context.CancelFunc
+	setErr            func(error)
+	setReady          func(bool)
+	error             error
+	stdout            strings.Builder
+	stderr            bytes.Buffer
+}
+
+func newProxyService(teleportPath, configPath string) *ProxyService {
+	var proxy ProxyService
+	var setErrOnce, setReadyOnce sync.Once
+	readyCh := make(chan struct{})
+	proxy = ProxyService{
+		teleportPath: teleportPath,
+		configPath:   configPath,
+		readyCh:      readyCh,
+		doneCh:       make(chan struct{}),
+		terminate:    func() {}, // dummy noop that will be overridden by Run(),
+		setErr: func(err error) {
+			setErrOnce.Do(func() {
+				proxy.mu.Lock()
+				defer proxy.mu.Unlock()
+				proxy.error = err
+			})
+		},
+		setReady: func(isReady bool) {
+			setReadyOnce.Do(func() {
+				proxy.mu.Lock()
+				proxy.isReady = isReady
+				proxy.mu.Unlock()
+				close(readyCh)
+			})
+		},
+	}
+	return &proxy
+}
+
+// Run spawns an proxy service instance.
+func (proxy *ProxyService) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	log := logger.Get(ctx)
+
+	cmd := exec.CommandContext(ctx, proxy.teleportPath, "start", "--debug", "--config", proxy.configPath)
+	log.Debugf("Running Proxy service: %s", cmd)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		err = trace.Wrap(err, "failed to get stdout")
+		proxy.setErr(err)
+		return err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		err = trace.Wrap(err, "failed to get stderr")
+		proxy.setErr(err)
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		err = trace.Wrap(err, "failed to start teleport")
+		proxy.setErr(err)
+		return err
+	}
+
+	ctx, log = logger.WithField(ctx, "pid", cmd.Process.Pid)
+	log.Debug("Proxy service process has been started")
+
+	proxy.mu.Lock()
+	var terminateOnce sync.Once
+	proxy.terminate = func() {
+		terminateOnce.Do(func() {
+			log.Debug("Terminating Proxy service process")
+			// Signal the process to gracefully terminate by sending SIGQUIT.
+			cmd.Process.Signal(syscall.SIGQUIT)
+			// If we're not done in 5 minutes, just kill the process by cancelling its context.
+			go func() {
+				select {
+				case <-proxy.doneCh:
+				case <-time.After(serviceShutdownTimeout):
+					log.Debug("Killing Proxy service process")
+				}
+				// cancel() results in sending SIGKILL to a process if it's still alive.
+				cancel()
+			}()
+		})
+	}
+	proxy.mu.Unlock()
+
+	var ioWork sync.WaitGroup
+	ioWork.Add(2)
+
+	// Parse stdout of a Teleport process.
+	go func() {
+		defer ioWork.Done()
+
+		stdout := bufio.NewReader(stdoutPipe)
+		for {
+			line, err := stdout.ReadString('\n')
+			if line != "" {
+				proxy.saveStdout(line)
+				proxy.parseLine(ctx, line)
+				if !proxy.IsReady() {
+					proxy.mu.Lock()
+					webAddr := proxy.webProxyAddr
+					sshAddr := proxy.sshProxyAddr
+					tunAddr := proxy.reverseTunnelAddr
+					proxy.mu.Unlock()
+					if !webAddr.IsEmpty() && !sshAddr.IsEmpty() && !tunAddr.IsEmpty() {
+						log.WithFields(logger.Fields{
+							"addr_web": webAddr,
+							"addr_ssh": sshAddr,
+							"addr_tun": tunAddr,
+						}).Debugf("Found all addrs of Proxy service process")
+						proxy.setReady(true)
+					}
+				}
+			}
+			if err == io.EOF {
+				return
+			}
+			if err := trace.Wrap(err); err != nil {
+				log.WithError(err).Error("failed to read process stdout")
+				return
+			}
+		}
+	}()
+
+	// Save stderr to a buffer.
+	go func() {
+		defer ioWork.Done()
+
+		stderr := bufio.NewReader(stderrPipe)
+		data := make([]byte, stderr.Size())
+		for {
+			n, err := stderr.Read(data)
+			proxy.saveStderr(data[:n])
+			if err == io.EOF {
+				return
+			}
+			if err := trace.Wrap(err); err != nil {
+				log.WithError(err).Error("failed to read process stderr")
+				return
+			}
+		}
+	}()
+
+	// Wait for process completeness after processing both outputs.
+	go func() {
+		ioWork.Wait()
+		err := trace.Wrap(cmd.Wait())
+		proxy.setErr(err)
+		close(proxy.doneCh)
+	}()
+
+	<-proxy.doneCh
+
+	if !proxy.IsReady() {
+		log.Error("Proxy service is failed to initialize")
+		stdoutLines := strings.Split(proxy.Stdout(), "\n")
+		for _, line := range stdoutLines[len(stdoutLines)-10:] {
+			log.Debug("Proxy service log: ", line)
+		}
+		log.Debugf("Proxy service stderr: %q", proxy.Stderr())
+
+		// If it's still not ready lets signal that it's finally not ready.
+		proxy.setReady(false)
+		// Set an err just in case if it's not set before.
+		proxy.setErr(trace.Errorf("failed to initialize"))
+	}
+
+	return trace.Wrap(proxy.Err())
+}
+
+// AuthAddr returns auth service external address.
+func (proxy *ProxyService) AuthAddr() Addr {
+	return proxy.WebProxyAddr()
+}
+
+// WebProxyAddr returns Web Proxy external address.
+func (proxy *ProxyService) WebProxyAddr() Addr {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.webProxyAddr
+}
+
+// SSHProxyAddr returns SSH Proxy external address.
+func (proxy *ProxyService) SSHProxyAddr() Addr {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.sshProxyAddr
+}
+
+// ReverseTunnelAddr returns reverse tunnel external address.
+func (proxy *ProxyService) ReverseTunnelAddr() Addr {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.reverseTunnelAddr
+}
+
+// WebAndSSHProxyAddr returns string in a format "host:webport/sshport" needed as tsh --proxy option.
+func (proxy *ProxyService) WebAndSSHProxyAddr() string {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return fmt.Sprintf("%s:%s,%s", proxy.webProxyAddr.Host, proxy.webProxyAddr.Port, proxy.sshProxyAddr.Port)
+}
+
+// Err returns proxy service error. It's nil If process is not done yet.
+func (proxy *ProxyService) Err() error {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.error
+}
+
+// Shutdown terminates the proxy service process and waits for its completion.
+func (proxy *ProxyService) Shutdown(ctx context.Context) error {
+	proxy.doTerminate()
+	select {
+	case <-proxy.doneCh:
+		return nil
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	}
+}
+
+// Stdout returns a collected proxy service process stdout.
+func (proxy *ProxyService) Stdout() string {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.stdout.String()
+}
+
+// Stderr returns a collected proxy service process stderr.
+func (proxy *ProxyService) Stderr() string {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.stderr.String()
+}
+
+// WaitReady waits for proxy service initialization.
+func (proxy *ProxyService) WaitReady(ctx context.Context) (bool, error) {
+	select {
+	case <-proxy.readyCh:
+		return proxy.IsReady(), nil
+	case <-ctx.Done():
+		return false, trace.Wrap(ctx.Err(), "proxy service is not ready")
+	}
+}
+
+// IsReady indicates if proxy service is initialized properly.
+func (proxy *ProxyService) IsReady() bool {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	return proxy.isReady
+}
+
+func (proxy *ProxyService) doTerminate() {
+	proxy.mu.Lock()
+	terminate := proxy.terminate
+	proxy.mu.Unlock()
+	terminate()
+}
+
+func (proxy *ProxyService) parseLine(ctx context.Context, line string) {
+	if submatch := regexpWebProxyStarting.FindStringSubmatch(line); submatch != nil {
+		proxy.mu.Lock()
+		defer proxy.mu.Unlock()
+		proxy.webProxyAddr = Addr{Host: "localhost", Port: submatch[1]}
+		return
+	}
+
+	if submatch := regexpSSHProxyStarting.FindStringSubmatch(line); submatch != nil {
+		proxy.mu.Lock()
+		defer proxy.mu.Unlock()
+		proxy.sshProxyAddr = Addr{Host: "127.0.0.1", Port: submatch[1]}
+		return
+	}
+
+	if submatch := regexpReverseTunnelStarting.FindStringSubmatch(line); submatch != nil {
+		proxy.mu.Lock()
+		defer proxy.mu.Unlock()
+		proxy.reverseTunnelAddr = Addr{Host: "localhost", Port: submatch[1]}
+		return
+	}
+}
+
+func (proxy *ProxyService) saveStdout(line string) {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	proxy.stdout.WriteString(line)
+}
+
+func (proxy *ProxyService) saveStderr(chunk []byte) {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+	proxy.stderr.Write(chunk)
+}

--- a/lib/testing/integration/setup_test.go
+++ b/lib/testing/integration/setup_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
+	. "github.com/gravitational/teleport-plugins/lib/testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type IntegrationSetup struct {
+	Suite
+	integration *Integration
+}
+
+type IntegrationAuthSetup struct {
+	IntegrationSetup
+	auth *AuthService
+}
+
+type IntegrationProxySetup struct {
+	IntegrationAuthSetup
+	proxy *ProxyService
+}
+
+type IntegrationSSHSetup struct {
+	IntegrationProxySetup
+	ssh *SSHService
+}
+
+func (s *IntegrationSetup) SetupSuite() {
+	logger.Init()
+	logger.Setup(logger.Config{Severity: "debug"})
+}
+
+func (s *IntegrationSetup) SetupTest() {
+	t := s.T()
+	var err error
+
+	// We set such a big timeout because integration.NewFromEnv could start
+	// downloading a Teleport *-bin.tar.gz file which can take a long time.
+	ctx := s.SetContextTimeout(2 * time.Minute)
+	integration, err := NewFromEnv(ctx)
+	require.NoError(t, err)
+	t.Cleanup(integration.Close)
+	s.integration = integration
+
+	s.SetContextTimeout(time.Second * 15)
+}
+
+func (s *IntegrationAuthSetup) SetupSuite() {
+	s.IntegrationSetup.SetupSuite()
+}
+
+func (s *IntegrationAuthSetup) SetupTest() {
+	s.IntegrationSetup.SetupTest()
+	t := s.T()
+	auth, err := s.integration.NewAuthService()
+	require.NoError(t, err)
+	s.StartApp(auth)
+	s.auth = auth
+}
+
+func (s *IntegrationProxySetup) SetupSuite() {
+	s.IntegrationAuthSetup.SetupSuite()
+}
+
+func (s *IntegrationProxySetup) SetupTest() {
+	s.IntegrationAuthSetup.SetupTest()
+	t := s.T()
+	proxy, err := s.integration.NewProxyService(s.auth)
+	require.NoError(t, err)
+	s.StartApp(proxy)
+	s.proxy = proxy
+}
+
+func (s *IntegrationSSHSetup) SetupSuite() {
+	s.IntegrationProxySetup.SetupSuite()
+}
+
+func (s *IntegrationSSHSetup) SetupTest() {
+	s.IntegrationProxySetup.SetupTest()
+	t := s.T()
+	ssh, err := s.integration.NewSSHService(s.auth)
+	require.NoError(t, err)
+	s.StartApp(ssh)
+	s.ssh = ssh
+}

--- a/lib/testing/integration/setup_test.go
+++ b/lib/testing/integration/setup_test.go
@@ -76,6 +76,10 @@ func (s *IntegrationAuthSetup) SetupTest() {
 	require.NoError(t, err)
 	s.StartApp(auth)
 	s.auth = auth
+
+	// Set CA Pin so that Proxy and SSH can register to auth securely.
+	err = s.integration.SetCAPin(s.Context(), s.auth)
+	require.NoError(t, err)
 }
 
 func (s *IntegrationProxySetup) SetupSuite() {

--- a/lib/testing/integration/ssh_test.go
+++ b/lib/testing/integration/ssh_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os/user"
+	"testing"
+
+	"github.com/gravitational/teleport-plugins/lib/tsh"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type IntegrationSSHSuite struct {
+	IntegrationSSHSetup
+}
+
+func TestIntegrationSSH(t *testing.T) { suite.Run(t, &IntegrationSSHSuite{}) }
+
+func (s *IntegrationSSHSuite) TestBench() {
+	t := s.T()
+	me, err := user.Current()
+	require.NoError(t, err)
+	var bootstrap Bootstrap
+	role, err := bootstrap.AddRole(me.Username, types.RoleSpecV4{Allow: types.RoleConditions{Logins: []string{me.Username}}})
+	require.NoError(t, err)
+	user, err := bootstrap.AddUserWithRoles(me.Username, role.GetName())
+	require.NoError(t, err)
+	err = s.integration.Bootstrap(s.Context(), s.auth, bootstrap.Resources())
+	require.NoError(t, err)
+	identityPath, err := s.integration.Sign(s.Context(), s.auth, user.GetName())
+	require.NoError(t, err)
+	tshCmd := s.integration.NewTsh(s.proxy.WebAndSSHProxyAddr(), identityPath)
+	result, err := tshCmd.Bench(s.Context(), tsh.BenchFlags{}, user.GetName()+"@localhost", "ls")
+	require.NoError(t, err)
+	assert.Positive(t, result.RequestsOriginated)
+	assert.Zero(t, result.RequestsFailed)
+}

--- a/lib/testing/integration/sshservice.go
+++ b/lib/testing/integration/sshservice.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/trace"
+)
+
+var regexpSSHStarting = regexp.MustCompile(`Service [^ ]+ is starting on [^ ]+:(\d+)`)
+
+type SSHService struct {
+	mu           sync.Mutex
+	teleportPath string
+	configPath   string
+	sshAddr      Addr
+	isReady      bool
+	readyCh      chan struct{}
+	doneCh       chan struct{}
+	terminate    context.CancelFunc
+	setErr       func(error)
+	setReady     func(bool)
+	error        error
+	stdout       strings.Builder
+	stderr       bytes.Buffer
+}
+
+func newSSHService(teleportPath, configPath string) *SSHService {
+	var ssh SSHService
+	var setErrOnce, setReadyOnce sync.Once
+	readyCh := make(chan struct{})
+	ssh = SSHService{
+		teleportPath: teleportPath,
+		configPath:   configPath,
+		readyCh:      readyCh,
+		doneCh:       make(chan struct{}),
+		terminate:    func() {}, // dummy noop that will be overridden by Run(),
+		setErr: func(err error) {
+			setErrOnce.Do(func() {
+				ssh.mu.Lock()
+				defer ssh.mu.Unlock()
+				ssh.error = err
+			})
+		},
+		setReady: func(isReady bool) {
+			setReadyOnce.Do(func() {
+				ssh.mu.Lock()
+				ssh.isReady = isReady
+				ssh.mu.Unlock()
+				close(readyCh)
+			})
+		},
+	}
+	return &ssh
+}
+
+// Run spawns an ssh service instance.
+func (ssh *SSHService) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	log := logger.Get(ctx)
+
+	cmd := exec.CommandContext(ctx, ssh.teleportPath, "start", "--debug", "--config", ssh.configPath)
+	log.Debugf("Running SSH service: %s", cmd)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		err = trace.Wrap(err, "failed to get stdout")
+		ssh.setErr(err)
+		return err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		err = trace.Wrap(err, "failed to get stderr")
+		ssh.setErr(err)
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		err = trace.Wrap(err, "failed to start teleport")
+		ssh.setErr(err)
+		return err
+	}
+
+	ctx, log = logger.WithField(ctx, "pid", cmd.Process.Pid)
+	log.Debug("SSH service process has been started")
+
+	ssh.mu.Lock()
+	var terminateOnce sync.Once
+	ssh.terminate = func() {
+		terminateOnce.Do(func() {
+			log.Debug("Terminating SSH service process")
+			// Signal the process to gracefully terminate by sending SIGQUIT.
+			cmd.Process.Signal(syscall.SIGQUIT)
+			// If we're not done in 5 minutes, just kill the process by cancelling its context.
+			go func() {
+				select {
+				case <-ssh.doneCh:
+				case <-time.After(serviceShutdownTimeout):
+					log.Debug("Killing SSH service process")
+				}
+				// cancel() results in sending SIGKILL to a process if it's still alive.
+				cancel()
+			}()
+		})
+	}
+	ssh.mu.Unlock()
+
+	var ioWork sync.WaitGroup
+	ioWork.Add(2)
+
+	// Parse stdout of a Teleport process.
+	go func() {
+		defer ioWork.Done()
+
+		stdout := bufio.NewReader(stdoutPipe)
+		for {
+			line, err := stdout.ReadString('\n')
+			if line != "" {
+				ssh.saveStdout(line)
+				ssh.parseLine(ctx, line)
+				if !ssh.IsReady() {
+					if addr := ssh.Addr(); !addr.IsEmpty() {
+						log.Debugf("Found addr of SSH service process: %v", addr)
+						ssh.setReady(true)
+					}
+				}
+			}
+			if err == io.EOF {
+				return
+			}
+			if err := trace.Wrap(err); err != nil {
+				log.WithError(err).Error("failed to read process stdout")
+				return
+			}
+		}
+	}()
+
+	// Save stderr to a buffer.
+	go func() {
+		defer ioWork.Done()
+
+		stderr := bufio.NewReader(stderrPipe)
+		data := make([]byte, stderr.Size())
+		for {
+			n, err := stderr.Read(data)
+			ssh.saveStderr(data[:n])
+			if err == io.EOF {
+				return
+			}
+			if err := trace.Wrap(err); err != nil {
+				log.WithError(err).Error("failed to read process stderr")
+				return
+			}
+		}
+	}()
+
+	// Wait for process completeness after processing both outputs.
+	go func() {
+		ioWork.Wait()
+		err := trace.Wrap(cmd.Wait())
+		ssh.setErr(err)
+		close(ssh.doneCh)
+	}()
+
+	<-ssh.doneCh
+
+	if !ssh.IsReady() {
+		log.Error("SSH service is failed to initialize")
+		stdoutLines := strings.Split(ssh.Stdout(), "\n")
+		for _, line := range stdoutLines[len(stdoutLines)-10:] {
+			log.Debug("SSH service log: ", line)
+		}
+		log.Debugf("SSH service stderr: %q", ssh.Stderr())
+
+		// If it's still not ready lets signal that it's finally not ready.
+		ssh.setReady(false)
+		// Set an err just in case if it's not set before.
+		ssh.setErr(trace.Errorf("failed to initialize"))
+	}
+
+	return trace.Wrap(ssh.Err())
+}
+
+// Addr returns SSH external address.
+func (ssh *SSHService) Addr() Addr {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	return ssh.sshAddr
+}
+
+// Err returns ssh service error. It's nil If process is not done yet.
+func (ssh *SSHService) Err() error {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	return ssh.error
+}
+
+// Shutdown terminates the ssh service process and waits for its completion.
+func (ssh *SSHService) Shutdown(ctx context.Context) error {
+	ssh.doTerminate()
+	select {
+	case <-ssh.doneCh:
+		return nil
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	}
+}
+
+// Stdout returns a collected ssh service process stdout.
+func (ssh *SSHService) Stdout() string {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	return ssh.stdout.String()
+}
+
+// Stderr returns a collected ssh service process stderr.
+func (ssh *SSHService) Stderr() string {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	return ssh.stderr.String()
+}
+
+// WaitReady waits for ssh service initialization.
+func (ssh *SSHService) WaitReady(ctx context.Context) (bool, error) {
+	select {
+	case <-ssh.readyCh:
+		return ssh.IsReady(), nil
+	case <-ctx.Done():
+		return false, trace.Wrap(ctx.Err(), "ssh service is not ready")
+	}
+}
+
+// IsReady indicates if ssh service is initialized properly.
+func (ssh *SSHService) IsReady() bool {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	return ssh.isReady
+}
+
+func (ssh *SSHService) doTerminate() {
+	ssh.mu.Lock()
+	terminate := ssh.terminate
+	ssh.mu.Unlock()
+	terminate()
+}
+
+func (ssh *SSHService) parseLine(ctx context.Context, line string) {
+	if submatch := regexpSSHStarting.FindStringSubmatch(line); submatch != nil {
+		ssh.mu.Lock()
+		defer ssh.mu.Unlock()
+		ssh.sshAddr = Addr{Host: "127.0.0.1", Port: submatch[1]}
+		return
+	}
+}
+
+func (ssh *SSHService) saveStdout(line string) {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	ssh.stdout.WriteString(line)
+}
+
+func (ssh *SSHService) saveStderr(chunk []byte) {
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	ssh.stderr.Write(chunk)
+}

--- a/lib/tsh/tsh.go
+++ b/lib/tsh/tsh.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tsh
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/trace"
+)
+
+// Tsh is a runner of tsh command.
+type Tsh struct {
+	Path     string
+	Proxy    string
+	Identity string
+	Insecure bool
+}
+
+var (
+	regexpRequestsOriginated = regexp.MustCompile(`(?m)^\* Requests originated: (\d+)$`)
+	regexpRequestsFailed     = regexp.MustCompile(`(?m)^\* Requests failed: (\d+)$`)
+)
+
+// BenchFlags is an options for `tsh bench` command.
+type BenchFlags struct {
+	Interactive bool
+	Login       string
+	Rate        int
+	Duration    time.Duration
+}
+
+// BenchResult is a result of running `tsh bench` command.
+type BenchResult struct {
+	Output             string
+	RequestsOriginated int
+	RequestsFailed     int
+}
+
+// CheckExecutable checks if `tsh` executable exists in the system.
+func (tsh Tsh) CheckExecutable() error {
+	_, err := exec.LookPath(tsh.cmd())
+	return trace.Wrap(err, "tsh executable is not found")
+}
+
+func (tsh Tsh) Bench(ctx context.Context, flags BenchFlags, userHost, command string) (BenchResult, error) {
+	log := logger.Get(ctx)
+	args := append(tsh.baseArgs(), "bench")
+	if flags.Interactive {
+		args = append(args, "--interactive")
+	}
+	if flags.Rate > 0 {
+		args = append(args, strconv.Itoa(flags.Rate))
+	}
+	if flags.Duration > 0 {
+		args = append(args, flags.Duration.String())
+	}
+	args = append(args, userHost, command)
+	cmd := exec.CommandContext(ctx, tsh.cmd(), args...)
+	log.Debugf("Running %s", cmd)
+	outputBytes, err := cmd.CombinedOutput()
+	output := string(outputBytes)
+	result := BenchResult{Output: output}
+	if err != nil {
+		return result, trace.Wrap(err)
+	}
+
+	if submatch := regexpRequestsOriginated.FindStringSubmatch(output); len(submatch) > 0 {
+		result.RequestsOriginated, err = strconv.Atoi(submatch[1])
+		if err != nil {
+			return result, trace.Wrap(err)
+		}
+	} else {
+		return result, trace.Errorf("failed to parse tsh bench result")
+	}
+
+	if submatch := regexpRequestsFailed.FindStringSubmatch(output); len(submatch) > 0 {
+		result.RequestsFailed, err = strconv.Atoi(submatch[1])
+		if err != nil {
+			return result, trace.Wrap(err)
+		}
+	} else {
+		return result, trace.Errorf("failed to parse tsh bench result")
+	}
+
+	return result, nil
+}
+
+func (tsh Tsh) cmd() string {
+	if tsh.Path != "" {
+		return tsh.Path
+	}
+	return "tsh"
+}
+
+func (tsh Tsh) baseArgs() (args []string) {
+	if tsh.Insecure {
+		args = append(args, "--insecure")
+	}
+	if tsh.Identity != "" {
+		args = append(args, "--identity", tsh.Identity)
+	}
+	if tsh.Proxy != "" {
+		args = append(args, "--proxy", tsh.Proxy)
+	}
+	return
+}


### PR DESCRIPTION
This is a buddy PR for [this commit](https://github.com/gravitational/teleport-plugins/pull/329/commits/b721d1e955ce407d1ae065e9b56ec3d16966a8d0) which was included in [this PR](https://github.com/gravitational/teleport-plugins/pull/317).

This PR also adds support for CA-pinning in the integration tests, which fixes an issue with the darwin drone tests caused by insecure teleport process registration. For further clarification, the darwin drone test was trying to `lstat /private/var/lib/teleport/ca.cert`, which fails due to the permissions of the `/private` directory.