### PR TITLE
Skip events that don't have an ID.

### DIFF
--- a/event-handler/teleport_client.go
+++ b/event-handler/teleport_client.go
@@ -134,6 +134,18 @@ func (t *TeleportClient) fetch(latestID string) error {
 	// Mark position as unresolved (the page is empty)
 	t.pos = -1
 
+	// Filter out any events that don't have an ID.
+	n := 0
+	for _, v := range batch {
+		if v.GetID() != "" {
+			batch[n] = v
+			n++
+		} else {
+			log.WithFields(log.Fields{"type": v.GetType()}).Warn("Event has no ID. Skipping...")
+		}
+	}
+	batch = batch[:n]
+
 	log.WithFields(log.Fields{"cursor": t.cursor, "next": nextCursor, "len": len(batch)}).Info("Fetched page")
 
 	// Page is empty: do nothing, return


### PR DESCRIPTION
Not all events will necessarily have an ID either [on purpose](https://github.com/gravitational/teleport/blob/9b8b9d6d0c115d43d31d53c47db3050e27edbc4a/lib/events/emitter.go#L187), or possibly  [on accident](https://github.com/gravitational/teleport/issues/8413) this change will skip over events that don't have an ID rather than try to upload them endlessly.

The new behaviour will be to print a WARN level message:
```
INFO[11018] Skipping last known event                     id=5b9732ae-8f84-4564-8c35-e0c592ebac86 new_pos=11
DEBU[11018] Idling                                        timeout=10s
WARN[11029] Event has no ID. Skipping...                  type=session.upload
WARN[11029] Event has no ID. Skipping...                  type=session.upload
WARN[11029] Event has no ID. Skipping...                  type=session.upload
INFO[11029] Fetched page                                  cursor="{\"date\":\"2021-09-28\",\"iterator\":{\"CreatedAt\":{\"B\":null,\"BOOL\":null,\"BS\":null,\"L\":null,\"M\":null,\"N\":\"1632813549\",\"NS\":null,\"NULL\":null,\"S\":null,\"SS\":null},\"CreatedAtDate\":{\"B\":null,\"BOOL\":null,\"BS\":null,\"L\":null,\"M\":null,\"N\":null,\"NS\":null,\"NULL\":null,\"S\":\"2021-09-28\",\"SS\":null},\"EventIndex\":{\"B\":null,\"BOOL\":null,\"BS\":null,\"L\":null,\"M\":null,\"N\":\"2147483646\",\"NS\":null,\"NULL\":null,\"S\":null,\"SS\":null},\"SessionID\":{\"B\":null,\"BOOL\":null,\"BS\":null,\"L\":null,\"M\":null,\"N\":null,\"NS\":null,\"NULL\":null,\"S\":\"a51b22a3-ed66-4cde-a707-bdbd0a8aa417\",\"SS\":null}}}" len=11 next=
INFO[11029] Skipping last known event                     id=5b9732ae-8f84-4564-8c35-e0c592ebac86 new_pos=11
DEBU[11029] Idling                                        timeout=10s
```

The current behaviour attempts to upload the same event over and over (see https://github.com/gravitational/teleport-plugins/issues/271 for this in action)

I've also added a test case for it (and made the tests table-driven)