### PR TITLE
Dump session events to stdout by default in fluentd

### DIFF
--- a/event-handler/fluentd_client.go
+++ b/event-handler/fluentd_client.go
@@ -84,8 +84,8 @@ func getCertPool(c *FluentdConfig) (*x509.CertPool, error) {
 }
 
 // Send sends event to fluentd
-func (f *FluentdClient) Send(ctx context.Context, url string, obj interface{}, relaxed bool) error {
-	b, err := lib.FastMarshal(obj, relaxed)
+func (f *FluentdClient) Send(ctx context.Context, url string, obj interface{}) error {
+	b, err := lib.FastMarshal(obj)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/event-handler/lib/json.go
+++ b/event-handler/lib/json.go
@@ -21,22 +21,9 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-// configFastestRelaxed represents jsoniter config which encodes all message fields, even those which are marked as jsontag:"-"
-var configFastestRelaxed = jsoniter.Config{
-	EscapeHTML:                    false,
-	MarshalFloatWith6Digits:       true,
-	ObjectFieldMustBeSimpleString: true,
-	TagKey:                        "-", // This forces jsoniter to serialize all event fields, use with caution
-}.Froze()
-
 // FastMarshal serializes given interface to json
-func FastMarshal(v interface{}, relaxed bool) ([]byte, error) {
-	c := jsoniter.ConfigFastest
-	if relaxed {
-		c = configFastestRelaxed
-	}
-
-	data, err := c.Marshal(v)
+func FastMarshal(v interface{}) ([]byte, error) {
+	data, err := jsoniter.ConfigFastest.Marshal(v)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
What's inside:
- [x] Default generated configuration now includes fluentd session endpoint
- [x] Print events are serialised including Data field