### PR TITLE
Remove active incidents check in PagerDuty

### DIFF
--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -115,7 +115,7 @@ spec:
 
 ### Setting up auto-approval behavior
 
-If given sufficient permissions, Pagerduty plugin can auto-approve new access requests if they come from a user who is currently on-call and has at least one active incident assigned to her. More specifically, it works like this:
+If given sufficient permissions, Pagerduty plugin can auto-approve new access requests if they come from a user who is currently on-call. More specifically, it works like this:
 
 - Access plugin has an access to submit access reviews:
 ```yaml
@@ -145,11 +145,8 @@ spec:
 - There's a Teleport user with name `alice@example.com` and role `challenger`.
 - There's also a Pagerduty user with e-mail `alice@example.com`
 - That user is currently on-call in a service "service 1" or "service 2" or in both of them.
-- There's at least one active incident assigned to `alice@example.com` in a service where she's currently on-call.
 - `alice@example.com` requests a role `champion`.
 - Then pagerduty plugin **submits an approval** of Alice's request.
-
-*NOTE* that `pagerduty_services` and `pagerduty_notify_service` annotations should not overlap. You cannot use the same service to post notifications in and be on-call in that service. If `pagerduty_services` and `pagerduty_notify_service` overlap then there'll always be an active incident assigned to user - the notification itself is an incident. So the plugin will auto-approve an access every time which is not actually desired.
 
 ## Install
 

--- a/access/pagerduty/fake_pagerduty_test.go
+++ b/access/pagerduty/fake_pagerduty_test.go
@@ -75,7 +75,6 @@ func (q QueryValues) GetAsSet(name string) stringset.StringSet {
 
 type fakeServiceByNameKey string
 type fakeUserByEmailKey string
-type fakeOnCallsByPolicyKey string
 
 type FakeIncidentNote struct {
 	IncidentID string

--- a/access/pagerduty/fake_pagerduty_test.go
+++ b/access/pagerduty/fake_pagerduty_test.go
@@ -75,6 +75,7 @@ func (q QueryValues) GetAsSet(name string) stringset.StringSet {
 
 type fakeServiceByNameKey string
 type fakeUserByEmailKey string
+type fakeOnCallsByPolicyKey string
 
 type FakeIncidentNote struct {
 	IncidentID string
@@ -291,11 +292,25 @@ func NewFakePagerduty(concurrency int) *FakePagerduty {
 		err := json.NewDecoder(r.Body).Decode(&body)
 		panicIf(err)
 
+		service, found := pagerduty.GetService(body.Incident.Service.ID)
+		if !found {
+			rw.WriteHeader(http.StatusNotFound)
+			err := json.NewEncoder(rw).Encode(&ErrorResult{Message: "Service not found"})
+			panicIf(err)
+			return
+		}
+
+		var assignments []IncidentAssignment
+		for _, onCall := range pagerduty.GetOnCallsByEscalationPolicy(service.EscalationPolicy.ID) {
+			assignments = append(assignments, IncidentAssignment{Assignee: onCall.User})
+		}
+
 		incident := pagerduty.StoreIncident(Incident{
 			IncidentKey: body.Incident.IncidentKey,
 			Title:       body.Incident.Title,
 			Status:      "triggered",
 			Service:     body.Incident.Service,
+			Assignments: assignments,
 			Body:        body.Incident.Body,
 		})
 		pagerduty.newIncidents <- incident
@@ -490,6 +505,24 @@ func (s *FakePagerduty) StoreOnCall(onCall OnCall) OnCall {
 	id := fmt.Sprintf("oncall-%v", atomic.AddUint64(&s.onCallIDCounter, 1))
 	s.objects.Store(id, onCall)
 	return onCall
+}
+
+func (s *FakePagerduty) GetOnCallsByEscalationPolicy(policyID string) []OnCall {
+	var result []OnCall
+	s.objects.Range(func(key, value interface{}) bool {
+		if key, ok := key.(string); !ok || !strings.HasPrefix(key, "oncall-") {
+			return true
+		}
+		onCall, ok := value.(OnCall)
+		if !ok {
+			return true
+		}
+		if onCall.EscalationPolicy.ID == policyID {
+			result = append(result, onCall)
+		}
+		return true
+	})
+	return result
 }
 
 func (s *FakePagerduty) CheckNewExtension(ctx context.Context) (Extension, error) {

--- a/access/pagerduty/types.go
+++ b/access/pagerduty/types.go
@@ -138,13 +138,6 @@ type IncidentResult struct {
 	Incident Incident `json:"incident"`
 }
 
-type ListIncidentsQuery struct {
-	PaginationQuery
-	UserIDs    []string `url:"user_ids,omitempty,brackets"`
-	Statuses   []string `url:"statuses,omitempty,brackets"`
-	ServiceIDs []string `url:"service_ids,omitempty,brackets"`
-}
-
 type ListIncidentsResult struct {
 	PaginationResult
 	Incidents []Incident `json:"incidents"`


### PR DESCRIPTION
Had a talk with @klizhentas after the #360 and it was decided to remove the check for active incidents from PagerDuty plugin. This check showed itself ambiguous for users and nobody really needed it.

Also remove "Failed to ..." in debug messages. Using such wording is generally a bad idea and it misleads the users.
