### PR TITLE
Don't use %q verb in error formatting

### DIFF
--- a/access/email/app.go
+++ b/access/email/app.go
@@ -177,7 +177,7 @@ func (a *App) checkTeleportVersion(ctx context.Context) (proto.PingResponse, err
 // onWatcherEvent processes new incoming access request
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()

--- a/access/gitlab/app.go
+++ b/access/gitlab/app.go
@@ -262,7 +262,7 @@ func (a *App) setup(ctx context.Context, projectID IntID) error {
 
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()
@@ -434,7 +434,7 @@ func (a *App) onWebhookEvent(ctx context.Context, hook Webhook) error {
 	case state.IsDenied():
 		resolution.Tag = ResolvedDenied
 	default:
-		return trace.BadParameter("unknown request state %v (%q)", state, state)
+		return trace.BadParameter("unknown request state %v (%s)", state, state)
 	}
 
 	return trace.Wrap(a.resolveIssue(ctx, reqID, resolution))

--- a/access/gitlab/client.go
+++ b/access/gitlab/client.go
@@ -143,7 +143,7 @@ func (g Gitlab) HealthCheck(ctx context.Context, projectIDOrPath string) (IntID,
 	}
 	if resp.IsError() {
 		if contentType := resp.Header().Get("Content-Type"); contentType != "application/json" {
-			return 0, trace.Errorf("wrong content_type=%q", contentType)
+			return 0, trace.Errorf("wrong content type %s", contentType)
 		}
 		if code := resp.StatusCode(); code == http.StatusUnauthorized {
 			return 0, trace.Errorf("got %v from API endpoint, perhaps GitLab credentials are not configured well", code)

--- a/access/gitlab/gitlab_test.go
+++ b/access/gitlab/gitlab_test.go
@@ -882,7 +882,7 @@ func (s *GitlabSuite) TestRace() {
 				return setRaceErr(trace.Errorf("wrong labels size. expected %v, obtained %v", expected, obtained))
 			}
 			if obtained, expected := LabelName(issue.Labels[0]).Reduced(), "pending"; obtained != expected {
-				return setRaceErr(trace.Errorf("wrong label. expected %q, obtained %q", expected, obtained))
+				return setRaceErr(trace.Errorf("wrong label. expected %s, obtained %s", expected, obtained))
 			}
 
 			oldIssue := issue
@@ -917,7 +917,7 @@ func (s *GitlabSuite) TestRace() {
 				return setRaceErr(err)
 			}
 			if obtained, expected := issue.State, "closed"; obtained != expected {
-				return setRaceErr(trace.Errorf("wrong issue state. expected %q, obtained %q", expected, obtained))
+				return setRaceErr(trace.Errorf("wrong issue state. expected %s, obtained %s", expected, obtained))
 			}
 			return nil
 		})

--- a/access/jira/app.go
+++ b/access/jira/app.go
@@ -219,7 +219,7 @@ func (a *App) checkTeleportVersion(ctx context.Context) (proto.PingResponse, err
 
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()
@@ -302,7 +302,7 @@ func (a *App) onJiraWebhook(ctx context.Context, webhook Webhook) error {
 		log.Debug("Issue has expired status, ignoring it")
 		return nil
 	case statusName != "approved" && statusName != "denied":
-		return trace.BadParameter("unknown Jira status %q", statusName)
+		return trace.BadParameter("unknown Jira status %s", statusName)
 	}
 
 	reqID, err := GetRequestID(issue)
@@ -378,7 +378,7 @@ func (a *App) onJiraWebhook(ctx context.Context, webhook Webhook) error {
 	case state.IsDenied():
 		resolution.Tag = ResolvedDenied
 	default:
-		return trace.BadParameter("unknown request state %v (%q)", state, state)
+		return trace.BadParameter("unknown request state %v (%s)", state, state)
 	}
 
 	return trace.Wrap(a.resolveIssue(ctx, reqID, resolution))

--- a/access/jira/issues.go
+++ b/access/jira/issues.go
@@ -32,7 +32,7 @@ type IssueUpdate struct {
 func GetRequestID(issue Issue) (string, error) {
 	reqID, ok := issue.Properties[RequestIDPropertyKey].(string)
 	if !ok {
-		return "", trace.Errorf("got non-string %q field", RequestIDPropertyKey)
+		return "", trace.Errorf("got non-string %s field", RequestIDPropertyKey)
 	}
 	return reqID, nil
 }
@@ -60,7 +60,7 @@ func GetLastUpdate(issue Issue, status string) (IssueUpdate, error) {
 		}
 	}
 	if update == nil {
-		return IssueUpdate{}, trace.Errorf("cannot find a %q status update in changelog", status)
+		return IssueUpdate{}, trace.Errorf("cannot find a %s status update in changelog", status)
 	}
 	return *update, nil
 }
@@ -72,5 +72,5 @@ func GetTransition(issue Issue, status string) (IssueTransition, error) {
 			return transition, nil
 		}
 	}
-	return IssueTransition{}, trace.Errorf("cannot find a %q status among possible transitions", status)
+	return IssueTransition{}, trace.Errorf("cannot find a %s status among possible transitions", status)
 }

--- a/access/jira/jira_test.go
+++ b/access/jira/jira_test.go
@@ -741,7 +741,7 @@ func (s *JiraSuite) TestRace() {
 				return setRaceErr(err)
 			}
 			if obtained, expected := issue.Fields.Status.Name, "Pending"; obtained != expected {
-				return setRaceErr(trace.Errorf("wrong issue status. expected %q, obtained %q", expected, obtained))
+				return setRaceErr(trace.Errorf("wrong issue status. expected %s, obtained %s", expected, obtained))
 			}
 			s.fakeJira.TransitionIssue(issue, "Approved")
 

--- a/access/mattermost/app.go
+++ b/access/mattermost/app.go
@@ -168,7 +168,7 @@ func (a *App) checkTeleportVersion(ctx context.Context) (proto.PingResponse, err
 
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -622,7 +622,7 @@ func (s *MattermostSuite) TestRace() {
 
 				directChannel, ok := s.fakeMattermost.GetDirectChannel(post.ChannelID)
 				if !ok {
-					return setRaceErr(trace.Errorf("direct channel %q not found", post.ChannelID))
+					return setRaceErr(trace.Errorf("direct channel %s not found", post.ChannelID))
 				}
 
 				var userID string
@@ -633,7 +633,7 @@ func (s *MattermostSuite) TestRace() {
 				}
 				user, ok := s.fakeMattermost.GetUser(userID)
 				if !ok {
-					return setRaceErr(trace.Errorf("user %q not found", userID))
+					return setRaceErr(trace.Errorf("user %s not found", userID))
 				}
 
 				if err = s.clients[user.Email].SubmitAccessRequestReview(ctx, reqID, types.AccessReview{
@@ -702,7 +702,7 @@ func parsePostField(post Post, field string) (string, error) {
 	text := post.Message
 	matches := msgFieldRegexp.FindAllStringSubmatch(text, -1)
 	if matches == nil {
-		return "", trace.Errorf("cannot parse fields from text %q", text)
+		return "", trace.Errorf("cannot parse fields from text %s", text)
 	}
 	var fields []string
 	for _, match := range matches {
@@ -711,5 +711,5 @@ func parsePostField(post Post, field string) (string, error) {
 		}
 		fields = append(fields, match[1])
 	}
-	return "", trace.Errorf("cannot find field %q in %v", field, fields)
+	return "", trace.Errorf("cannot find field %s in %v", field, fields)
 }

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -184,7 +184,7 @@ func (a *App) checkTeleportVersion(ctx context.Context) (proto.PingResponse, err
 
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()
@@ -293,14 +293,14 @@ func (a *App) getNotifyServiceName(req types.AccessRequest) (string, error) {
 	annotationKey := a.conf.Pagerduty.RequestAnnotations.NotifyService
 	slice, ok := req.GetSystemAnnotations()[annotationKey]
 	if !ok {
-		return "", trace.Errorf("request annotation %q is missing", annotationKey)
+		return "", trace.Errorf("request annotation %s is missing", annotationKey)
 	}
 	var serviceName string
 	if len(slice) > 0 {
 		serviceName = slice[0]
 	}
 	if serviceName == "" {
-		return "", trace.Errorf("request annotation %q is empty", annotationKey)
+		return "", trace.Errorf("request annotation %s is empty", annotationKey)
 	}
 	return serviceName, nil
 }

--- a/access/pagerduty/client.go
+++ b/access/pagerduty/client.go
@@ -254,7 +254,7 @@ func (p Pagerduty) FindUserByEmail(ctx context.Context, userEmail string) (User,
 		logger.Get(ctx).Warningf("PagerDuty returned too many results when querying by email %q", userEmail)
 	}
 
-	return User{}, trace.NotFound("failed to find pagerduty user by email %q", userEmail)
+	return User{}, trace.NotFound("failed to find pagerduty user by email %s", userEmail)
 }
 
 // FindServiceByName finds a service by its name (case-insensitive).
@@ -281,7 +281,7 @@ func (p Pagerduty) FindServiceByName(ctx context.Context, serviceName string) (S
 		}
 	}
 
-	return Service{}, trace.NotFound("failed to find pagerduty service by name %q", serviceName)
+	return Service{}, trace.NotFound("failed to find pagerduty service by name %s", serviceName)
 }
 
 // FindServicesByNames finds a bunch of services by its names making a query for each service.

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -889,14 +889,14 @@ func (s *PagerdutySuite) TestRace() {
 				return setRaceErr(trace.Wrap(err))
 			}
 			if obtained, expected := incident.Status, "triggered"; obtained != expected {
-				return setRaceErr(trace.Errorf("wrong incident status. expected %q, obtained %q", expected, obtained))
+				return setRaceErr(trace.Errorf("wrong incident status. expected %s, obtained %s", expected, obtained))
 			}
 			reqID, err := getIncidentRequestID(incident)
 			if err != nil {
 				return setRaceErr(trace.Wrap(err))
 			}
 			if _, loaded := incidentIDs.LoadOrStore(incident.ID, struct{}{}); loaded {
-				return setRaceErr(trace.Errorf("incident %q has already been stored", incident.ID))
+				return setRaceErr(trace.Errorf("incident %s has already been stored", incident.ID))
 			}
 			atomic.AddInt32(&incidentsCount, 1)
 			req, err := s.ruler().GetAccessRequest(ctx, reqID)
@@ -933,7 +933,7 @@ func (s *PagerdutySuite) TestRace() {
 				return setRaceErr(err)
 			}
 			if obtained, expected := incident.Status, "resolved"; obtained != expected {
-				return setRaceErr(trace.Errorf("wrong incident status. expected %q, obtained %q", expected, obtained))
+				return setRaceErr(trace.Errorf("wrong incident status. expected %s, obtained %s", expected, obtained))
 			}
 			return nil
 		})
@@ -1005,7 +1005,7 @@ func (s *PagerdutySuite) TestRace() {
 func getIncidentRequestID(incident Incident) (string, error) {
 	prefix := pdIncidentKeyPrefix + "/"
 	if !strings.HasPrefix(incident.IncidentKey, prefix) {
-		return "", trace.Errorf("failed to parse incident_key %q", incident.IncidentKey)
+		return "", trace.Errorf("failed to parse incident_key %s", incident.IncidentKey)
 	}
 	return incident.IncidentKey[len(prefix):], nil
 }

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -167,7 +167,7 @@ func (a *App) checkTeleportVersion(ctx context.Context) (proto.PingResponse, err
 
 func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	if kind := event.Resource.GetKind(); kind != types.KindAccessRequest {
-		return trace.Errorf("unexpected kind %q", kind)
+		return trace.Errorf("unexpected kind %s", kind)
 	}
 	op := event.Type
 	reqID := event.Resource.GetName()

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -206,7 +206,7 @@ func (b Bot) UpdateMessages(ctx context.Context, reqID string, reqData RequestDa
 		if err != nil {
 			switch err.Error() {
 			case "message_not_found":
-				err = trace.Wrap(err, "cannot find message with timestamp %q in channel %q", msg.Timestamp, msg.ChannelID)
+				err = trace.Wrap(err, "cannot find message with timestamp %s in channel %s", msg.Timestamp, msg.ChannelID)
 			default:
 				err = trace.Wrap(err)
 			}
@@ -241,7 +241,7 @@ func (b Bot) Respond(ctx context.Context, reqID string, reqData RequestData, res
 	}
 
 	if !resp.IsSuccess() {
-		return trace.Errorf("unexpected http status %q", resp.Status())
+		return trace.Errorf("unexpected http status %s", resp.Status())
 	}
 
 	if !result.Ok {

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -639,7 +639,7 @@ func (s *SlackSuite) TestRace() {
 
 				user, ok := s.fakeSlack.GetUser(msg.Channel)
 				if !ok {
-					return setRaceErr(trace.Errorf("user %q is not found", msg.Channel))
+					return setRaceErr(trace.Errorf("user %s is not found", msg.Channel))
 				}
 
 				reqID, err := parseMessageField(msg, "ID")
@@ -723,7 +723,7 @@ func parseMessageField(msg Msg, field string) (string, error) {
 	text := sectionBlock.Text.GetText()
 	matches := msgFieldRegexp.FindAllStringSubmatch(text, -1)
 	if matches == nil {
-		return "", trace.Errorf("cannot parse fields from text %q", text)
+		return "", trace.Errorf("cannot parse fields from text %s", text)
 	}
 	var fields []string
 	for _, match := range matches {
@@ -732,7 +732,7 @@ func parseMessageField(msg Msg, field string) (string, error) {
 		}
 		fields = append(fields, match[1])
 	}
-	return "", trace.Errorf("cannot find field %q in %v", field, fields)
+	return "", trace.Errorf("cannot find field %s in %v", field, fields)
 }
 
 func getStatusLine(msg Msg) (string, error) {


### PR DESCRIPTION
When you log errors using `.WithError(err)` then the quote characters
in error text are being quoted themselves so the log message look ugly:

```
error:[
ERROR REPORT:
Original Error: *errors.errorString this is some error &#34;and this is something quoted&#34;
Stack Trace:
	/Users/vladimirkocnev/code/go/teleport-plugins/access/slack/app.go:79 main.(*App).run
	/Users/vladimirkocnev/code/go/teleport-plugins/lib/process.go:216 github.com/gravitational/teleport-plugins/lib.NewServiceJob.func1
	/Users/vladimirkocnev/code/go/teleport-plugins/lib/process.go:237 github.com/gravitational/teleport-plugins/lib.(*serviceJob).DoJob
	/Users/vladimirkocnev/code/go/teleport-plugins/lib/process.go:83 github.com/gravitational/teleport-plugins/lib.NewProcess.func2.1
	/usr/local/Cellar/go@1.16/1.16.9/libexec/src/runtime/asm_amd64.s:1371 runtime.goexit
User Message: this is some error &#34;and this is something quoted&#34;]
```

It's okay to use `%q` in log messages but not in the error texts unfortunately.
