### PR TITLE
Remove Drone CI tasks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,89 +1,6 @@
 ---
 kind: pipeline
 type: kubernetes
-name: test-linux
-
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
-
-workspace:
-  path: /go/src/github.com/gravitational/teleport-plugins
-
-steps:
-  - name: Run linter
-    image: golangci/golangci-lint:v1.39.0
-    commands:
-      - make lint
-
-  - name: Run tests
-    image: golang:1.16.2
-    environment:
-      TELEPORT_ENTERPRISE_LICENSE:
-        from_secret: TELEPORT_ENTERPRISE_LICENSE
-      TELEPORT_GET_VERSION: v7.1.1
-    commands:
-      - echo Testing plugins against Teleport $TELEPORT_GET_VERSION
-      - make test
-
----
-kind: pipeline
-type: exec
-name: test-darwin
-
-concurrency:
-  limit: 1
-
-platform:
-  os: darwin
-  arch: amd64
-
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
-
-workspace:
-  path: /tmp/teleport-plugins/test-darwin
-
-steps:
-  - name: Clean up exec runner storage
-    commands:
-      # This will remove subdirectories under pkg/mod which 0400 permissions.
-      # See for more details: https://github.com/golang/go/issues/27455
-      - go clean -modcache
-      - rm -rf /tmp/teleport-plugins/test-darwin/go
-      - mkdir -p /tmp/teleport-plugins/test-darwin/go
-
-  - name: Run tests
-    environment:
-      TELEPORT_ENTERPRISE_LICENSE:
-        from_secret: TELEPORT_ENTERPRISE_LICENSE
-      TELEPORT_GET_VERSION: v7.1.1
-      GOPATH: /tmp/teleport-plugins/test-darwin/go
-      GOCACHE: /tmp/teleport-plugins/test-darwin/go/cache
-    commands:
-      - go version
-      - make test
-
----
-kind: pipeline
-type: kubernetes
 name: build-on-push-linux
 
 trigger:
@@ -415,6 +332,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7d92a4296bbb567054d4b181fe7f0309c98201336772d7f7d8c780d4a4fbc99d
+hmac: 742413d0f6a6de667ad9bd39e8533730efbaa88aecaa38c79751afa4d0eee1e5
 
 ...


### PR DESCRIPTION
Removes CI tasks from the drone build file, as they are no longer necessary.

In order to actually allow this to pass I have _also_ manually remove Drone from the `required` checks on the `master` branch. If there is an automated place to do this, please point me at it!
