### PR TITLE
Restore drone tasks & delete drone triggers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,6 @@ trigger:
   event:
     include:
       - push
-      - pull_request
   repo:
     include:
       - gravitational/*
@@ -53,7 +52,6 @@ trigger:
   event:
     include:
       - push
-      - pull_request
   repo:
     include:
       - gravitational/*
@@ -415,6 +413,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7d92a4296bbb567054d4b181fe7f0309c98201336772d7f7d8c780d4a4fbc99d
+hmac: 4f25cf95faaad6e50bdcf7b22fc9db79ef8adaa97e1bb765f770cdecd2eee196
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,17 +3,7 @@ kind: pipeline
 type: kubernetes
 name: test-linux
 
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
+trigger: []
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -46,17 +36,7 @@ platform:
   os: darwin
   arch: amd64
 
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
+trigger: []
 
 workspace:
   path: /tmp/teleport-plugins/test-darwin
@@ -415,6 +395,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7d92a4296bbb567054d4b181fe7f0309c98201336772d7f7d8c780d4a4fbc99d
+hmac: 10a3ed9358eec5f73f8d4b679d5a98d77da74ba28fb8ddd79198822d5aa3e31b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,17 @@ kind: pipeline
 type: kubernetes
 name: test-linux
 
-trigger: []
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go/src/github.com/gravitational/teleport-plugins
@@ -36,7 +46,17 @@ platform:
   os: darwin
   arch: amd64
 
-trigger: []
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /tmp/teleport-plugins/test-darwin
@@ -395,6 +415,6 @@ steps:
 
 ---
 kind: signature
-hmac: 10a3ed9358eec5f73f8d4b679d5a98d77da74ba28fb8ddd79198822d5aa3e31b
+hmac: 7d92a4296bbb567054d4b181fe7f0309c98201336772d7f7d8c780d4a4fbc99d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,89 @@
 ---
 kind: pipeline
 type: kubernetes
+name: test-linux
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
+
+workspace:
+  path: /go/src/github.com/gravitational/teleport-plugins
+
+steps:
+  - name: Run linter
+    image: golangci/golangci-lint:v1.39.0
+    commands:
+      - make lint
+
+  - name: Run tests
+    image: golang:1.16.2
+    environment:
+      TELEPORT_ENTERPRISE_LICENSE:
+        from_secret: TELEPORT_ENTERPRISE_LICENSE
+      TELEPORT_GET_VERSION: v7.1.1
+    commands:
+      - echo Testing plugins against Teleport $TELEPORT_GET_VERSION
+      - make test
+
+---
+kind: pipeline
+type: exec
+name: test-darwin
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
+
+workspace:
+  path: /tmp/teleport-plugins/test-darwin
+
+steps:
+  - name: Clean up exec runner storage
+    commands:
+      # This will remove subdirectories under pkg/mod which 0400 permissions.
+      # See for more details: https://github.com/golang/go/issues/27455
+      - go clean -modcache
+      - rm -rf /tmp/teleport-plugins/test-darwin/go
+      - mkdir -p /tmp/teleport-plugins/test-darwin/go
+
+  - name: Run tests
+    environment:
+      TELEPORT_ENTERPRISE_LICENSE:
+        from_secret: TELEPORT_ENTERPRISE_LICENSE
+      TELEPORT_GET_VERSION: v7.1.1
+      GOPATH: /tmp/teleport-plugins/test-darwin/go
+      GOCACHE: /tmp/teleport-plugins/test-darwin/go/cache
+    commands:
+      - go version
+      - make test
+
+---
+kind: pipeline
+type: kubernetes
 name: build-on-push-linux
 
 trigger:
@@ -332,6 +415,6 @@ steps:
 
 ---
 kind: signature
-hmac: 742413d0f6a6de667ad9bd39e8533730efbaa88aecaa38c79751afa4d0eee1e5
+hmac: 7d92a4296bbb567054d4b181fe7f0309c98201336772d7f7d8c780d4a4fbc99d
 
 ...


### PR DESCRIPTION
Removing the drone triggers entirely broke some post-build workflows, so this PR restores them and just removes the `pull_request` trigger event.