### PR TITLE
Escape and truncate request, resolution and review reasons in access-slack and access-mattermost

### DIFF
--- a/access/mattermost/bot.go
+++ b/access/mattermost/bot.go
@@ -347,7 +347,7 @@ func (b Bot) buildPostText(reqID string, reqData RequestData) (string, error) {
 		reqData.RequestReason = lib.MarkdownEscape(reqData.RequestReason, 500)
 	}
 	if reqData.Resolution.Reason != "" {
-		reqData.Resolution.Reason = lib.MarkdownEscape(reqData.RequestReason, 500)
+		reqData.Resolution.Reason = lib.MarkdownEscape(reqData.Resolution.Reason, 500)
 	}
 
 	var statusEmoji string

--- a/access/mattermost/bot.go
+++ b/access/mattermost/bot.go
@@ -333,6 +333,17 @@ func (b Bot) UpdatePosts(ctx context.Context, reqID string, reqData RequestData,
 func (b Bot) buildPostText(reqID string, reqData RequestData) (string, error) {
 	resolutionTag := reqData.Resolution.Tag
 
+	// Slack has a 4000 character recommendation (with a more generous 40000
+	// hard limit), Mattermost has either 4000 or 16k depending on the version;
+	// let's just be very conservative and limit request reason and resolution
+	// reason to 500 each
+	if reqData.RequestReason != "" {
+		reqData.RequestReason = lib.MarkdownEscape(reqData.RequestReason, 500)
+	}
+	if reqData.Resolution.Reason != "" {
+		reqData.Resolution.Reason = lib.MarkdownEscape(reqData.RequestReason, 500)
+	}
+
 	var statusEmoji string
 	status := string(resolutionTag)
 	switch resolutionTag {

--- a/access/mattermost/bot.go
+++ b/access/mattermost/bot.go
@@ -28,7 +28,8 @@ var postTextTemplate = template.Must(template.New("description").Parse(
 **Roles**: {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}}
 **Request ID**: {{.ID}}
 **Reason**: {{.RequestReason}}
-**Status**: {{.StatusEmoji}} {{.Status}}{{if .Resolution.Reason}} ({{.Resolution.Reason}}){{end}}
+**Status**: {{.StatusEmoji}} {{.Status}}
+{{if .Resolution.Reason}}**Resolution reason**: {{.Resolution.Reason}}{{end}}
 {{if .RequestLink}}**Link**: [{{.RequestLink}}]({{.RequestLink}})
 {{else if eq .Status "PENDING"}}**Approve**: ` + "`tsh request review --approve {{.ID}}`" + `
 **Deny**: ` + "`tsh request review --deny {{.ID}}`" + `{{end}}`,
@@ -213,6 +214,11 @@ func (b Bot) Broadcast(ctx context.Context, channels []string, reqID string, req
 }
 
 func (b Bot) PostReviewComment(ctx context.Context, channelID, rootID string, review types.AccessReview) error {
+	// see reasoning in buildPostText
+	if review.Reason != "" {
+		review.Reason = lib.MarkdownEscape(review.Reason, 500)
+	}
+
 	var proposedStateEmoji string
 	switch review.ProposedState {
 	case types.RequestState_APPROVED:

--- a/access/mattermost/bot.go
+++ b/access/mattermost/bot.go
@@ -27,7 +27,7 @@ var postTextTemplate = template.Must(template.New("description").Parse(
 **User**: {{.User}}
 **Roles**: {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}}
 **Request ID**: {{.ID}}
-**Reason**: {{.RequestReason}}
+{{if .RequestReason}}**Reason**: {{.RequestReason}}{{end}}
 **Status**: {{.StatusEmoji}} {{.Status}}
 {{if .Resolution.Reason}}**Resolution reason**: {{.Resolution.Reason}}{{end}}
 {{if .RequestLink}}**Link**: [{{.RequestLink}}]({{.RequestLink}})

--- a/access/mattermost/fake_mattermost_test.go
+++ b/access/mattermost/fake_mattermost_test.go
@@ -164,6 +164,11 @@ func NewFakeMattermost(botUser User, concurrency int) *FakeMattermost {
 		err := json.NewDecoder(r.Body).Decode(&post)
 		panicIf(err)
 
+		if len(post.Message) > 4000 {
+			rw.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
 		post = mattermost.StorePost(post)
 		mattermost.newPosts <- post
 

--- a/access/mattermost/fake_mattermost_test.go
+++ b/access/mattermost/fake_mattermost_test.go
@@ -164,6 +164,9 @@ func NewFakeMattermost(botUser User, concurrency int) *FakeMattermost {
 		err := json.NewDecoder(r.Body).Decode(&post)
 		panicIf(err)
 
+		// message size limit as per
+		// https://github.com/mattermost/mattermost-server/blob/3d412b14af49701d842e72ef208f0ec0a35ce063/model/post.go#L54
+		// (current master at time of writing)
 		if len(post.Message) > 4000 {
 			rw.WriteHeader(http.StatusBadRequest)
 			return

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*\*([a-zA-Z ]+)\*\*:\ +(.+)$`)
-var requestReasonRegexp = regexp.MustCompile(`(?im)^\*\*Reason\*\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
-var resolutionReasonRegexp = regexp.MustCompile(`(?im)^\*\*Resolution reason\*\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
+var requestReasonRegexp = regexp.MustCompile("(?im)^\\*\\*Reason\\*\\*:\\ ```\\n(.*?)```(.*?)$")
+var resolutionReasonRegexp = regexp.MustCompile("(?im)^\\*\\*Resolution reason\\*\\*:\\ ```\\n(.*?)```(.*?)$")
 
 type MattermostSuite struct {
 	Suite

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,8 @@ import (
 )
 
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*\*([a-zA-Z ]+)\*\*:\ +(.+)$`)
+var requestReasonRegexp = regexp.MustCompile(`(?im)^\*\*Reason\*\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
+var resolutionReasonRegexp = regexp.MustCompile(`(?im)^\*\*Resolution reason\*\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
 
 type MattermostSuite struct {
 	Suite
@@ -219,7 +222,7 @@ func (s *MattermostSuite) newAccessRequest(reviewers []User) types.AccessRequest
 
 	req, err := types.NewAccessRequest(uuid.New().String(), s.userNames.requestor, "editor")
 	require.NoError(t, err)
-	req.SetRequestReason("because of")
+	req.SetRequestReason("because of " + strings.Repeat("A", 5000))
 	var suggestedReviewers []string
 	for _, user := range reviewers {
 		suggestedReviewers = append(suggestedReviewers, user.Email)
@@ -294,9 +297,11 @@ func (s *MattermostSuite) TestMattermostMessagePosting() {
 	require.NoError(t, err)
 	assert.Equal(t, s.userNames.requestor, username)
 
-	reason, err := parsePostField(post, "Reason")
-	require.NoError(t, err)
-	assert.Equal(t, "because of", reason)
+	matches := requestReasonRegexp.FindAllStringSubmatch(post.Message, -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "because of "+strings.Repeat("A", 489), matches[0][1])
+	assert.Equal(t, " (truncated)", matches[0][2])
 
 	statusLine, err := parsePostField(post, "Status")
 	require.NoError(t, err)
@@ -325,7 +330,13 @@ func (s *MattermostSuite) TestApproval() {
 
 	statusLine, err := parsePostField(postUpdate, "Status")
 	require.NoError(t, err)
-	assert.Equal(t, "✅ APPROVED (okay)", statusLine)
+	assert.Equal(t, "✅ APPROVED", statusLine)
+
+	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "okay", matches[0][1])
+	assert.Equal(t, "", matches[0][2])
 }
 
 func (s *MattermostSuite) TestDenial() {
@@ -341,7 +352,7 @@ func (s *MattermostSuite) TestDenial() {
 	directChannelID := s.fakeMattermost.GetDirectChannelFor(s.fakeMattermost.GetBotUser(), reviewer).ID
 	assert.Equal(t, directChannelID, post.ChannelID)
 
-	s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay")
+	s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay "+strings.Repeat("A", 10000))
 
 	postUpdate, err := s.fakeMattermost.CheckPostUpdate(s.Context())
 	require.NoError(t, err, "no messages updated")
@@ -350,7 +361,13 @@ func (s *MattermostSuite) TestDenial() {
 
 	statusLine, err := parsePostField(postUpdate, "Status")
 	require.NoError(t, err)
-	assert.Equal(t, "❌ DENIED (not okay)", statusLine)
+	assert.Equal(t, "❌ DENIED", statusLine)
+
+	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "not okay "+strings.Repeat("A", 491), matches[0][1])
+	assert.Equal(t, " (truncated)", matches[0][2])
 }
 
 func (s *MattermostSuite) TestReviewComments() {
@@ -388,7 +405,7 @@ func (s *MattermostSuite) TestReviewComments() {
 	assert.Equal(t, post.ID, comment.RootID)
 	assert.Contains(t, comment.Message, s.userNames.reviewer1+" reviewed the request", "comment must contain a review author")
 	assert.Contains(t, comment.Message, "Resolution: ✅ APPROVED", "comment must contain a proposed state")
-	assert.Contains(t, comment.Message, "Reason: okay", "comment must contain a reason")
+	assert.Contains(t, comment.Message, "Reason: ```\nokay```", "comment must contain a reason")
 
 	err = s.reviewer2().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer2,
@@ -404,7 +421,7 @@ func (s *MattermostSuite) TestReviewComments() {
 	assert.Equal(t, post.ID, comment.RootID)
 	assert.Contains(t, comment.Message, s.userNames.reviewer2+" reviewed the request", "comment must contain a review author")
 	assert.Contains(t, comment.Message, "Resolution: ❌ DENIED", "comment must contain a proposed state")
-	assert.Contains(t, comment.Message, "Reason: not okay", "comment must contain a reason")
+	assert.Contains(t, comment.Message, "Reason: ```\nnot okay```", "comment must contain a reason")
 }
 
 func (s *MattermostSuite) TestApprovalByReview() {
@@ -459,7 +476,13 @@ func (s *MattermostSuite) TestApprovalByReview() {
 
 	statusLine, err := parsePostField(postUpdate, "Status")
 	require.NoError(t, err)
-	assert.Equal(t, "✅ APPROVED (finally okay)", statusLine)
+	assert.Equal(t, "✅ APPROVED", statusLine)
+
+	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "finally okay", matches[0][1])
+	assert.Equal(t, "", matches[0][2])
 }
 
 func (s *MattermostSuite) TestDenialByReview() {
@@ -514,7 +537,13 @@ func (s *MattermostSuite) TestDenialByReview() {
 
 	statusLine, err := parsePostField(postUpdate, "Status")
 	require.NoError(t, err)
-	assert.Equal(t, "❌ DENIED (finally not okay)", statusLine)
+	assert.Equal(t, "❌ DENIED", statusLine)
+
+	matches := resolutionReasonRegexp.FindAllStringSubmatch(postUpdate.Message, -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "finally not okay", matches[0][1])
+	assert.Equal(t, "", matches[0][2])
 }
 
 func (s *MattermostSuite) TestExpiration() {

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -141,6 +141,11 @@ func (b Bot) Broadcast(ctx context.Context, channels []string, reqID string, req
 }
 
 func (b Bot) PostReviewReply(ctx context.Context, channelID, timestamp string, review types.AccessReview) error {
+	// see reasoning in msgSections
+	if review.Reason != "" {
+		review.Reason = lib.MarkdownEscape(review.Reason, 500)
+	}
+
 	var proposedStateEmoji string
 	switch review.ProposedState {
 	case types.RequestState_APPROVED:

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -26,6 +26,15 @@ Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
 
+// Slack has a 4000 character limit for message texts and 3000 character limit
+// for message section texts so we truncate all reasons to a generous but
+// conservative limit
+const (
+	requestReasonLimit = 500
+	resolutionReasonLimit
+	reviewReasonLimit
+)
+
 // Bot is a slack client that works with access.Request.
 // It's responsible for formatting and posting a message on Slack when an
 // action occurs with an access request: a new request popped up, or a
@@ -141,9 +150,8 @@ func (b Bot) Broadcast(ctx context.Context, channels []string, reqID string, req
 }
 
 func (b Bot) PostReviewReply(ctx context.Context, channelID, timestamp string, review types.AccessReview) error {
-	// see reasoning in msgSections
 	if review.Reason != "" {
-		review.Reason = lib.MarkdownEscape(review.Reason, 500)
+		review.Reason = lib.MarkdownEscape(review.Reason, reviewReasonLimit)
 	}
 
 	var proposedStateEmoji string
@@ -273,11 +281,7 @@ func (b Bot) msgSections(reqID string, reqData RequestData) []BlockItem {
 		msgFieldToBuilder(&builder, "Role(s)", strings.Join(reqData.Roles, ","))
 	}
 	if reqData.RequestReason != "" {
-		// Slack has a 4000 character recommendation (with a more generous 40000
-		// hard limit), Mattermost has either 4000 or 16k depending on the
-		// version; let's just be very conservative and limit request reason and
-		// resolution reason to 500 each
-		msgFieldToBuilder(&builder, "Reason", lib.MarkdownEscape(reqData.RequestReason, 500))
+		msgFieldToBuilder(&builder, "Reason", lib.MarkdownEscape(reqData.RequestReason, requestReasonLimit))
 	}
 	if b.webProxyURL != nil {
 		reqURL := *b.webProxyURL
@@ -306,8 +310,7 @@ func (b Bot) msgSections(reqID string, reqData RequestData) []BlockItem {
 
 	statusText := fmt.Sprintf("*Status:* %s %s", statusEmoji, status)
 	if resolution.Reason != "" {
-		// see above for the limit reasoning
-		statusText += fmt.Sprintf("\n*Resolution reason*: %s", lib.MarkdownEscape(resolution.Reason, 500))
+		statusText += fmt.Sprintf("\n*Resolution reason*: %s", lib.MarkdownEscape(resolution.Reason, resolutionReasonLimit))
 	}
 
 	sections := []BlockItem{

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -268,7 +268,13 @@ func (b Bot) msgSections(reqID string, reqData RequestData) []BlockItem {
 		msgFieldToBuilder(&builder, "Role(s)", strings.Join(reqData.Roles, ","))
 	}
 	if reqData.RequestReason != "" {
-		msgFieldToBuilder(&builder, "Reason", reqData.RequestReason)
+		// as per https://api.slack.com/methods/chat.postMessage#formatting the
+		// whole message /should/ be around 4000 characters at most, so we give
+		// 1000 to the request reason and 1000 to the resolution reason, to have
+		// some headroom for the rest of the message; it's unclear if the limit
+		// is in bytes, codepoints or grapheme clusters, but as the hard limit
+		// is actually 40000 we should be fine
+		msgFieldToBuilder(&builder, "Reason", markdownEscape(reqData.RequestReason, 1500))
 	}
 	if b.webProxyURL != nil {
 		reqURL := *b.webProxyURL
@@ -297,7 +303,8 @@ func (b Bot) msgSections(reqID string, reqData RequestData) []BlockItem {
 
 	statusText := fmt.Sprintf("*Status:* %s %s", statusEmoji, status)
 	if resolution.Reason != "" {
-		statusText += fmt.Sprintf(" (%s)", resolution.Reason)
+		// see above for the limit reasoning
+		statusText += fmt.Sprintf("\n*Resolution reason*: %s", markdownEscape(resolution.Reason, 1500))
 	}
 
 	sections := []BlockItem{
@@ -323,4 +330,26 @@ func msgFieldToBuilder(b *strings.Builder, field, value string) {
 	b.WriteString("*: ")
 	b.WriteString(value)
 	b.WriteString("\n")
+}
+
+// markdownEscape wraps some text `t` in triple backticks (escaping any backtick
+// inside the message), limiting the length of the message to `n` runes.
+func markdownEscape(t string, n int) string {
+	var b strings.Builder
+	b.WriteString("```")
+	for i, r := range t {
+		if i >= n {
+			b.WriteString("``` (truncated)")
+			return b.String()
+		}
+		b.WriteRune(r)
+		if r == '`' {
+			// byte order mark, as a zero width no-break space; seems to result
+			// in escaped backticks with no spurious characters in the message
+			b.WriteRune('\ufeff')
+			n -= 1
+		}
+	}
+	b.WriteString("```")
+	return b.String()
 }

--- a/access/slack/fake_slack_test.go
+++ b/access/slack/fake_slack_test.go
@@ -56,13 +56,16 @@ func NewFakeSlack(botUser User, concurrency int) *FakeSlack {
 		err := json.NewDecoder(r.Body).Decode(&payload)
 		panicIf(err)
 
+		// text limit and block text limit as per
+		// https://api.slack.com/methods/chat.postMessage and
+		// https://api.slack.com/reference/block-kit/blocks#section
 		if len(payload.Text) > 4000 || func() bool {
 			for _, block := range payload.BlockItems {
 				sectionBlock, ok := block.Block.(SectionBlock)
 				if !ok {
 					continue
 				}
-				if len(sectionBlock.Text.GetText()) > 3000 { // https://api.slack.com/reference/block-kit/blocks#section
+				if len(sectionBlock.Text.GetText()) > 3000 {
 					return true
 				}
 			}

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,7 @@ import (
 )
 
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*([a-zA-Z ]+)\*: (.+)$`)
+var requestReasonRegexp = regexp.MustCompile(`(?im)^\*Reason\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
 
 type SlackSuite struct {
 	Suite
@@ -213,7 +215,7 @@ func (s *SlackSuite) newAccessRequest(reviewers []User) types.AccessRequest {
 
 	req, err := types.NewAccessRequest(uuid.New().String(), s.userNames.requestor, "editor")
 	require.NoError(t, err)
-	req.SetRequestReason("because of")
+	req.SetRequestReason("because of " + strings.Repeat("A", 5000))
 	var suggestedReviewers []string
 	for _, user := range reviewers {
 		suggestedReviewers = append(suggestedReviewers, user.Profile.Email)
@@ -281,9 +283,14 @@ func (s *SlackSuite) TestMessagePosting() {
 	require.NoError(t, err)
 	assert.Equal(t, s.userNames.requestor, msgUser)
 
-	msgReason, err := parseMessageField(messages[0], "Reason")
-	require.NoError(t, err)
-	assert.Equal(t, "because of", msgReason)
+	block, ok := messages[0].BlockItems[1].Block.(SectionBlock)
+	require.True(t, ok)
+	t.Logf("%q", block.Text.GetText())
+	matches := requestReasonRegexp.FindAllStringSubmatch(block.Text.GetText(), -1)
+	require.Equal(t, 1, len(matches))
+	require.Equal(t, 3, len(matches[0]))
+	assert.Equal(t, "because of "+strings.Repeat("A", 489), matches[0][1])
+	assert.Equal(t, " (truncated)", matches[0][2])
 
 	statusLine, err := getStatusLine(messages[0])
 	require.NoError(t, err)
@@ -353,7 +360,7 @@ func (s *SlackSuite) TestApproval() {
 
 	statusLine, err := getStatusLine(msgUpdate)
 	require.NoError(t, err)
-	assert.Equal(t, "*Status:* ✅ APPROVED (okay)", statusLine)
+	assert.Equal(t, "*Status:* ✅ APPROVED\n*Resolution reason*: ```\nokay```", statusLine)
 }
 
 func (s *SlackSuite) TestDenial() {
@@ -368,7 +375,7 @@ func (s *SlackSuite) TestDenial() {
 	require.NoError(t, err)
 	assert.Equal(t, reviewer.ID, msg.Channel)
 
-	s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay")
+	s.ruler().DenyAccessRequest(s.Context(), req.GetName(), "not okay "+strings.Repeat("A", 10000))
 
 	msgUpdate, err := s.fakeSlack.CheckMessageUpdateByAPI(s.Context())
 	require.NoError(t, err)
@@ -377,7 +384,7 @@ func (s *SlackSuite) TestDenial() {
 
 	statusLine, err := getStatusLine(msgUpdate)
 	require.NoError(t, err)
-	assert.Equal(t, "*Status:* ❌ DENIED (not okay)", statusLine)
+	assert.Equal(t, "*Status:* ❌ DENIED\n*Resolution reason*: ```\nnot okay "+strings.Repeat("A", 491)+"``` (truncated)", statusLine)
 }
 
 func (s *SlackSuite) TestReviewReplies() {
@@ -414,7 +421,7 @@ func (s *SlackSuite) TestReviewReplies() {
 	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
 	assert.Contains(t, reply.Text, s.userNames.reviewer1+" reviewed the request", "reply must contain a review author")
 	assert.Contains(t, reply.Text, "Resolution: ✅ APPROVED", "reply must contain a proposed state")
-	assert.Contains(t, reply.Text, "Reason: okay", "reply must contain a reason")
+	assert.Contains(t, reply.Text, "Reason: ```\nokay```", "reply must contain a reason")
 
 	err = s.reviewer2().SubmitAccessRequestReview(s.Context(), req.GetName(), types.AccessReview{
 		Author:        s.userNames.reviewer2,
@@ -430,7 +437,7 @@ func (s *SlackSuite) TestReviewReplies() {
 	assert.Equal(t, msg.Timestamp, reply.ThreadTs)
 	assert.Contains(t, reply.Text, s.userNames.reviewer2+" reviewed the request", "reply must contain a review author")
 	assert.Contains(t, reply.Text, "Resolution: ❌ DENIED", "reply must contain a proposed state")
-	assert.Contains(t, reply.Text, "Reason: not okay", "reply must contain a reason")
+	assert.Contains(t, reply.Text, "Reason: ```\nnot okay```", "reply must contain a reason")
 }
 
 func (s *SlackSuite) TestApprovalByReview() {
@@ -484,7 +491,7 @@ func (s *SlackSuite) TestApprovalByReview() {
 
 	statusLine, err := getStatusLine(msgUpdate)
 	require.NoError(t, err)
-	assert.Equal(t, "*Status:* ✅ APPROVED (finally okay)", statusLine)
+	assert.Equal(t, "*Status:* ✅ APPROVED\n*Resolution reason*: ```\nfinally okay```", statusLine)
 }
 
 func (s *SlackSuite) TestDenialByReview() {
@@ -538,7 +545,7 @@ func (s *SlackSuite) TestDenialByReview() {
 
 	statusLine, err := getStatusLine(msgUpdate)
 	require.NoError(t, err)
-	assert.Equal(t, "*Status:* ❌ DENIED (finally not okay)", statusLine)
+	assert.Equal(t, "*Status:* ❌ DENIED\n*Resolution reason*: ```\nfinally not okay```", statusLine)
 }
 
 func (s *SlackSuite) TestExpiration() {

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*([a-zA-Z ]+)\*: (.+)$`)
-var requestReasonRegexp = regexp.MustCompile(`(?im)^\*Reason\*:\ ` + "```\\n" + `(.*?)` + "```" + `(.*?)$`)
+var requestReasonRegexp = regexp.MustCompile("(?im)^\\*Reason\\*:\\ ```\\n(.*?)```(.*?)$")
 
 type SlackSuite struct {
 	Suite

--- a/lib/escape.go
+++ b/lib/escape.go
@@ -8,10 +8,10 @@ import "strings"
 // runes for the purpose of the truncation.
 func MarkdownEscape(t string, n int) string {
 	var b strings.Builder
-	b.WriteString("```")
+	b.WriteString("```\n")
 	for i, r := range t {
 		if i >= n {
-			b.WriteString("``` (truncated)")
+			b.WriteString("\n``` (truncated)")
 			return b.String()
 		}
 		b.WriteRune(r)

--- a/lib/escape.go
+++ b/lib/escape.go
@@ -19,7 +19,7 @@ func MarkdownEscape(t string, n int) string {
 			// byte order mark, as a zero width no-break space; seems to result
 			// in escaped backticks with no spurious characters in the message
 			b.WriteRune('\ufeff')
-			n -= 1
+			n--
 		}
 	}
 	b.WriteString("```")

--- a/lib/escape.go
+++ b/lib/escape.go
@@ -1,0 +1,27 @@
+package lib
+
+import "strings"
+
+// MarkdownEscape wraps some text `t` in triple backticks (escaping any backtick
+// inside the message), limiting the length of the message to `n` runes (inside
+// the single preformatted block). Backticks are escaped and thus count as two
+// runes for the purpose of the truncation.
+func MarkdownEscape(t string, n int) string {
+	var b strings.Builder
+	b.WriteString("```")
+	for i, r := range t {
+		if i >= n {
+			b.WriteString("``` (truncated)")
+			return b.String()
+		}
+		b.WriteRune(r)
+		if r == '`' {
+			// byte order mark, as a zero width no-break space; seems to result
+			// in escaped backticks with no spurious characters in the message
+			b.WriteRune('\ufeff')
+			n -= 1
+		}
+	}
+	b.WriteString("```")
+	return b.String()
+}

--- a/lib/escape.go
+++ b/lib/escape.go
@@ -4,9 +4,14 @@ import "strings"
 
 // MarkdownEscape wraps some text `t` in triple backticks (escaping any backtick
 // inside the message), limiting the length of the message to `n` runes (inside
-// the single preformatted block). Backticks are escaped and thus count as two
-// runes for the purpose of the truncation.
+// the single preformatted block). The text is trimmed before escaping.
+// Backticks are escaped and thus count as two runes for the purpose of the
+// truncation.
 func MarkdownEscape(t string, n int) string {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return "(empty)"
+	}
 	var b strings.Builder
 	b.WriteString("```\n")
 	for i, r := range t {

--- a/lib/escape.go
+++ b/lib/escape.go
@@ -11,7 +11,7 @@ func MarkdownEscape(t string, n int) string {
 	b.WriteString("```\n")
 	for i, r := range t {
 		if i >= n {
-			b.WriteString("\n``` (truncated)")
+			b.WriteString("``` (truncated)")
 			return b.String()
 		}
 		b.WriteRune(r)

--- a/lib/escape_test.go
+++ b/lib/escape_test.go
@@ -1,0 +1,15 @@
+package lib
+
+import "fmt"
+
+func ExampleMarkdownEscape() {
+	fmt.Printf("%q\n", MarkdownEscape("     ", 1000))
+	fmt.Printf("%q\n", MarkdownEscape("abc", 1000))
+	fmt.Printf("%q\n", MarkdownEscape("`foo` `bar`", 1000))
+	fmt.Printf("%q\n", MarkdownEscape("  123456789012345  ", 10))
+
+	// Output: "(empty)"
+	// "```\nabc```"
+	// "```\n`\ufefffoo`\ufeff `\ufeffbar`\ufeff```"
+	// "```\n1234567890``` (truncated)"
+}


### PR DESCRIPTION
Because of the way "markdown" (I use this term loosely here) works in Slack and Mattermost, escaping arbitrary strings is somewhat tricky:

- there's no way to escape backticks within single backticks, so we must use triple backticks; escaping backticks within triple backticks can be done by abusing `U+FEFF` as a zero-width no-break space
- triple backticks interact strangely with whitespace in Mattermost, to the extent that a double newline will result in the code block not actually being parsed
- we must add a newline right after the opening backticks, or Mattermost might interpret the first word as a syntax highlighting directive

In addition to the message escaping, with this we also conservatively truncate all the potentially user-provided text to stay well within the service limits; said service limits are now somewhat reflected in our mocks of Slack and Mattermost, which will return a 400 for overlong messages. The limits there are also more conservative than what the actual services allow.

This fixes TEL-Q321-1 and TEL-Q321-6.