### PR TITLE
Fix integration tests when migrating to the new Teleport version

### DIFF
--- a/lib/testing/integration/auth_test.go
+++ b/lib/testing/integration/auth_test.go
@@ -41,7 +41,7 @@ func (s *IntegrationAuthSuite) TestBootstrap() {
 	var bootstrap Bootstrap
 	role, err := bootstrap.AddRole("foo", types.RoleSpecV4{})
 	require.NoError(t, err)
-	_, err = bootstrap.AddUserWithRoles("vladimir", "admin", role.GetName())
+	_, err = bootstrap.AddUserWithRoles("vladimir", role.GetName())
 	require.NoError(t, err)
 	err = s.Integration.Bootstrap(s.Context(), s.Auth, bootstrap.Resources())
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func (s *IntegrationAuthSuite) TestPing() {
 	t := s.T()
 
 	var bootstrap Bootstrap
-	user, err := bootstrap.AddUserWithRoles("vladimir", "admin")
+	user, err := bootstrap.AddUserWithRoles("vladimir", "editor")
 	require.NoError(t, err)
 	err = s.Integration.Bootstrap(s.Context(), s.Auth, bootstrap.Resources())
 	require.NoError(t, err)

--- a/lib/testing/integration/integration_test.go
+++ b/lib/testing/integration/integration_test.go
@@ -39,9 +39,9 @@ func (s *IntegrationSuite) SetupTest() {
 func (s *IntegrationSuite) TestVersion() {
 	t := s.T()
 
-	versionMin, err := version.NewVersion("v6.2.7")
+	versionMin, err := version.NewVersion("v7.0.0")
 	require.NoError(t, err)
-	versionMax, err := version.NewVersion("v8")
+	versionMax, err := version.NewVersion("v9")
 	require.NoError(t, err)
 
 	assert.True(t, s.Integration.Version().GreaterThanOrEqual(versionMin))

--- a/lib/testing/integration/proxy_test.go
+++ b/lib/testing/integration/proxy_test.go
@@ -37,7 +37,7 @@ func (s *IntegrationProxySuite) TestPing() {
 	t := s.T()
 
 	var bootstrap Bootstrap
-	user, err := bootstrap.AddUserWithRoles("vladimir", "admin")
+	user, err := bootstrap.AddUserWithRoles("vladimir", "editor")
 	require.NoError(t, err)
 	err = s.Integration.Bootstrap(s.Context(), s.Auth, bootstrap.Resources())
 	require.NoError(t, err)


### PR DESCRIPTION
Related to #393.
