### PR TITLE
Read api tokens from files for all of the access services

### DIFF
--- a/access/gitlab/config.go
+++ b/access/gitlab/config.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
@@ -92,6 +93,12 @@ func LoadConfig(filepath string) (*Config, error) {
 	conf := &Config{}
 	if err := t.Unmarshal(conf); err != nil {
 		return nil, trace.Wrap(err)
+	}
+	if strings.HasPrefix(conf.Gitlab.Token, "/") {
+		conf.Gitlab.Token, err = lib.ReadPassword(conf.Gitlab.Token)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/access/jira/config.go
+++ b/access/jira/config.go
@@ -94,6 +94,12 @@ func LoadConfig(filepath string) (*Config, error) {
 	if err := t.Unmarshal(conf); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if strings.HasPrefix(conf.Jira.APIToken, "/") {
+		conf.Jira.APIToken, err = lib.ReadPassword(conf.Jira.APIToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/access/mattermost/config.go
+++ b/access/mattermost/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
@@ -54,6 +56,12 @@ func LoadConfig(filepath string) (*Config, error) {
 	conf := &Config{}
 	if err := t.Unmarshal(conf); err != nil {
 		return nil, trace.Wrap(err)
+	}
+	if strings.HasPrefix(conf.Mattermost.Token, "/") {
+		conf.Mattermost.Token, err = lib.ReadPassword(conf.Mattermost.Token)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"strings"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
@@ -77,6 +79,12 @@ func LoadConfig(filepath string) (*Config, error) {
 	conf := &Config{}
 	if err := t.Unmarshal(conf); err != nil {
 		return nil, trace.Wrap(err)
+	}
+	if strings.HasPrefix(conf.Pagerduty.APIKey, "/") {
+		conf.Pagerduty.APIKey, err = lib.ReadPassword(conf.Pagerduty.APIKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/access/slack/config.go
+++ b/access/slack/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"strings"
 
 	"github.com/gravitational/teleport-plugins/lib"
@@ -65,11 +64,10 @@ func LoadConfig(filepath string) (*Config, error) {
 		return nil, trace.Wrap(err)
 	}
 	if strings.HasPrefix(conf.Slack.Token, "/") {
-		tokenBytes, err := ioutil.ReadFile(conf.Slack.Token)
+		conf.Slack.Token, err = lib.ReadPassword(conf.Slack.Token)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		conf.Slack.Token = string(tokenBytes)
 	}
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Read tokens using the existing lib.ReadPassword and update access/slack to use ReadPassword instead as well.

#246 