### PR TITLE
Prevent linter from running on dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,6 @@ output:
 
 run:
   skip-dirs:
-    - go/pkg/mod
+    - pkg/mod
   skip-dirs-use-default: false
   timeout: 5m


### PR DESCRIPTION
In https://github.com/gravitational/teleport-plugins/pull/408, I mistakenly updated `.golangcli.yml` `skip-dirs` to `go/pkg/mod`, which only works locally where my $GOPATH is `.../go`. This PR changes this to `pkg/mod` so it will work universally.