### PR TITLE
Update api dependency to v8.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible
 	github.com/gravitational/protoc-gen-terraform v0.0.0-20211108170245-3b37ff28d21e // protoc-gen-terraform master (#13)
-	github.com/gravitational/teleport/api v0.0.0-20220110180007-3dc269bef5ea // tag v8.1.0
+	github.com/gravitational/teleport/api v0.0.0-20220216032207-d7ae31ced755 // tag v8.3.0
 	github.com/gravitational/trace v1.1.16-0.20210609220119-4855e69c89fc
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0
@@ -38,7 +38,7 @@ require (
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	google.golang.org/genproto v0.0.0-20210223151946-22b48be4551b // indirect
-	google.golang.org/grpc v1.32.0
+	google.golang.org/grpc v1.43.0
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/resty.v1 v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRY
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
@@ -98,6 +99,7 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1U
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -107,6 +109,11 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -126,6 +133,8 @@ github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
@@ -253,8 +262,8 @@ github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf h1:MQ4e8X
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gravitational/protoc-gen-terraform v0.0.0-20211108170245-3b37ff28d21e h1:/Ms5L4meqz2d/CJYwx/H87xrqRBwxiwOTrtnBl+0i48=
 github.com/gravitational/protoc-gen-terraform v0.0.0-20211108170245-3b37ff28d21e/go.mod h1:joQIhLuq9Ofk7i7zLuPfUrPJE0NfsEMrQUEGSmg/HS8=
-github.com/gravitational/teleport/api v0.0.0-20220110180007-3dc269bef5ea h1:i5MGAnQGzjPS5QmNJA3M0OZoSozV7BFMTEgmE66aJX8=
-github.com/gravitational/teleport/api v0.0.0-20220110180007-3dc269bef5ea/go.mod h1:o7AX31/8Wv6bnXLr+ke32HYuXGKzhH0kChfEu5Iv/yA=
+github.com/gravitational/teleport/api v0.0.0-20220216032207-d7ae31ced755 h1:AW8bInhSQ5Cw0tTaljqeGNjYdU/5UGNGKLHJ5X6sIH0=
+github.com/gravitational/teleport/api v0.0.0-20220216032207-d7ae31ced755/go.mod h1:ZDzUfriizIHwsJodilSSdoe/l83y7g8Hq+M2GzZNhPE=
 github.com/gravitational/trace v1.1.14/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/trace v1.1.15/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/trace v1.1.16-0.20210609220119-4855e69c89fc h1:WirIpaGWhwmNkPEvhF5h51UyxhKxAnl6KvPqz8ozhNI=
@@ -262,6 +271,7 @@ github.com/gravitational/trace v1.1.16-0.20210609220119-4855e69c89fc/go.mod h1:R
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.10.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.7.0/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn6r2DXKhuDNFg=
 github.com/hashicorp/consul/sdk v0.6.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -474,6 +484,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rw-access/httprouter v1.3.1-0.20210321233808-98e93175c124 h1:HiiqjwsUvob18HsTIQgf4YH7Emph9aH37IwmaCykShQ=
 github.com/rw-access/httprouter v1.3.1-0.20210321233808-98e93175c124/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -539,6 +550,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -624,6 +636,7 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -806,6 +819,7 @@ google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
@@ -824,8 +838,11 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -860,6 +877,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/terraform/gen_teleport.yaml
+++ b/terraform/gen_teleport.yaml
@@ -14,7 +14,7 @@ types:
     - "types.ClusterNetworkingConfigV2"
     - "types.DatabaseV3"
     - "types.GithubConnectorV3"
-    - "types.OIDCConnectorV2"
+    - "types.OIDCConnectorV3"
     - "types.ProvisionTokenV2"    
     - "types.RoleV4"
     - "types.SAMLConnectorV2"
@@ -92,9 +92,9 @@ computed_fields:
     - "types.GithubConnectorV3.Metadata.Namespace"
 
     # OIDC connector
-    - "types.OIDCConnectorV2.Version"
-    - "types.OIDCConnectorV2.Kind"
-    - "types.OIDCConnectorV2.Metadata.Namespace"
+    - "types.OIDCConnectorV3.Version"
+    - "types.OIDCConnectorV3.Kind"
+    - "types.OIDCConnectorV3.Metadata.Namespace"
 
     # Provision Token
     - "types.ProvisionTokenV2.Kind"
@@ -171,7 +171,7 @@ required_fields:
     - "types.GithubConnectorV3.Spec.TeamsToLogins.Logins"
 
     # OIDC connector
-    - "types.OIDCConnectorV2.Spec"
+    - "types.OIDCConnectorV3.Spec"
 
     # Provision token
     - "types.ProvisionTokenV2.Spec"
@@ -216,8 +216,8 @@ sensitive:
     - "types.SAMLConnectorV2.Spec.EncryptionKeyPair.PrivateKey"
     - "types.SAMLConnectorV2.Spec.EntityDescriptor"    
     - "types.GithubConnectorV3.Spec.ClientSecret"
-    - "types.OIDCConnectorV2.Spec.ClientSecret"
-    - "types.OIDCConnectorV2.Spec.GoogleServiceAccount"
+    - "types.OIDCConnectorV3.Spec.ClientSecret"
+    - "types.OIDCConnectorV3.Spec.GoogleServiceAccount"
 
 # These funcs will be used as a state funcs for a fields
 state_func:

--- a/terraform/provider/data_source_teleport_oidc_connector.go
+++ b/terraform/provider/data_source_teleport_oidc_connector.go
@@ -30,7 +30,7 @@ import (
 func dataSourceTeleportOIDCConnector() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceTeleportOIDCConnectorRead,
-		Schema:      tfschema.SchemaOIDCConnectorV2,
+		Schema:      tfschema.SchemaOIDCConnectorV3,
 	}
 }
 
@@ -48,12 +48,12 @@ func dataSourceTeleportOIDCConnectorRead(ctx context.Context, d *schema.Resource
 		return diagFromErr(describeErr(err, "oidc"))
 	}
 
-	o2, ok := o.(*types.OIDCConnectorV2)
+	o2, ok := o.(*types.OIDCConnectorV3)
 	if !ok {
-		return diagFromErr(trace.Errorf("can not convert %T to *types.OIDCConnectorV2", o))
+		return diagFromErr(trace.Errorf("can not convert %T to *types.OIDCConnectorV3", o))
 	}
 
-	err = tfschema.ToTerraformOIDCConnectorV2(o2, d)
+	err = tfschema.ToTerraformOIDCConnectorV3(o2, d)
 	if err != nil {
 		return diagFromErr(err)
 	}

--- a/terraform/provider/resource_teleport_oidc_connector.go
+++ b/terraform/provider/resource_teleport_oidc_connector.go
@@ -36,7 +36,7 @@ func resourceTeleportOIDCConnector() *schema.Resource {
 		UpdateContext: resourceOIDCConnectorUpdate,
 		DeleteContext: resourceOIDCConnectorDelete,
 
-		Schema:        tfschema.SchemaOIDCConnectorV2,
+		Schema:        tfschema.SchemaOIDCConnectorV3,
 		SchemaVersion: 2,
 
 		Importer: &schema.ResourceImporter{
@@ -68,9 +68,9 @@ func resourceOIDCConnectorCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diagFromErr(describeErr(err, "oidc"))
 	}
 
-	cn := types.OIDCConnectorV2{}
+	cn := types.OIDCConnectorV3{}
 
-	err = tfschema.FromTerraformOIDCConnectorV2(d, &cn)
+	err = tfschema.FromTerraformOIDCConnectorV3(d, &cn)
 	if err != nil {
 		return diagFromErr(err)
 	}
@@ -109,12 +109,12 @@ func resourceOIDCConnectorRead(ctx context.Context, d *schema.ResourceData, m in
 		return diagFromErr(describeErr(err, "oidc"))
 	}
 
-	cnV2, ok := cn.(*types.OIDCConnectorV2)
+	cnV2, ok := cn.(*types.OIDCConnectorV3)
 	if !ok {
-		return diagFromErr(fmt.Errorf("failed to convert created user to types.OIDCConnectorV2 from %T", cn))
+		return diagFromErr(fmt.Errorf("failed to convert created user to types.OIDCConnectorV3 from %T", cn))
 	}
 
-	err = tfschema.ToTerraformOIDCConnectorV2(cnV2, d)
+	err = tfschema.ToTerraformOIDCConnectorV3(cnV2, d)
 	if err != nil {
 		return diagFromErr(err)
 	}
@@ -136,12 +136,12 @@ func resourceOIDCConnectorUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diagFromErr(err)
 	}
 
-	cnV2, ok := cn.(*types.OIDCConnectorV2)
+	cnV2, ok := cn.(*types.OIDCConnectorV3)
 	if !ok {
-		return diagFromErr(fmt.Errorf("failed to convert created oidc connector to types.OIDCConnectorV2 from %T", cn))
+		return diagFromErr(fmt.Errorf("failed to convert created oidc connector to types.OIDCConnectorV3 from %T", cn))
 	}
 
-	err = tfschema.FromTerraformOIDCConnectorV2(d, cnV2)
+	err = tfschema.FromTerraformOIDCConnectorV3(d, cnV2)
 	if err != nil {
 		return diagFromErr(err)
 	}


### PR DESCRIPTION
Changes:
 - Update api dependency to v8.3.0 
 - run `make -C terraform gen-schema`

teleport/api v8.3.0 introduces a fix to an inconsistency in `types.proto` where a proto field was not capitalized.

Closes https://github.com/gravitational/teleport-plugins/issues/427
Closes https://github.com/gravitational/teleport-plugins/issues/429
Closes https://github.com/gravitational/teleport-plugins/issues/428