### PR TITLE
Push Access Plugins and Event Handler Docker Images to ECR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -201,6 +201,36 @@ steps:
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
 
+  - name: Build and push to ECR
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make aws-cli
+      - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - make docker-push-access-${PLUGIN_TYPE}
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
 ---
 kind: pipeline
 type: kubernetes
@@ -323,6 +353,35 @@ steps:
       target: teleport-plugins/tag/${DRONE_TAG}
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/build
 
+  - name: Build and push to ECR
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make aws-cli
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - make docker-push-event-handler
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
 ---
 kind: pipeline
 type: exec
@@ -364,6 +423,33 @@ steps:
     commands:
       - cd build
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
+
+  - name: Build and push to ECR
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - make docker-push-event-handler
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 
 ---
 kind: pipeline
@@ -413,6 +499,6 @@ steps:
 
 ---
 kind: signature
-hmac: c427752b53eaa9eb47bf95e1c3aed04b4c8273f930ba4ab83c67f12052d37821
+hmac: 2689c47ad6a3d8bf75c85c2486e80b0d767a93e927e14b6f092c080bf94fc186
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,19 @@ docker-build-access-plugins: docker-build-access-email \
  docker-build-access-pagerduty \
  docker-build-access-slack
 
+# Push specific access plugin with docker to ECR
+.PHONY: docker-push-access-%
+docker-push-access-%: docker-build-access-%
+	$(MAKE) -C access/$* docker-push
+
 # Build event-handler plugin with docker
 .PHONY: docker-build-event-handler
 docker-build-event-handler:
 	$(MAKE) -C event-handler docker-build
+
+.PHONY: docker-push-event-handler
+docker-push-event-handler: docker-build-event-handler
+	$(MAKE) -C event-handler docker-push
 
 .PHONY: terraform
 terraform:

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -56,6 +56,10 @@ release: clean $(VERSRC) $(BINARY)
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../..
 
+.PHONY: docker-push
+docker-push: 
+	docker push ${DOCKER_IMAGE}
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/access/gitlab/Makefile
+++ b/access/gitlab/Makefile
@@ -56,6 +56,10 @@ release: clean $(VERSRC) $(BINARY)
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../..
 
+.PHONY: docker-push
+docker-push: 
+	docker push ${DOCKER_IMAGE}
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -56,6 +56,10 @@ release: clean $(VERSRC) $(BINARY)
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../..
 
+.PHONY: docker-push
+docker-push: 
+	docker push ${DOCKER_IMAGE}
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -56,6 +56,10 @@ release: clean $(VERSRC) $(BINARY)
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../..
 
+.PHONY: docker-push
+docker-push: 
+	docker push ${DOCKER_IMAGE}
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -56,6 +56,10 @@ release: clean $(VERSRC) $(BINARY)
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ../Dockerfile ../..
 
+.PHONY: docker-push
+docker-push: 
+	docker push ${DOCKER_IMAGE}
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -43,6 +43,10 @@ clean:
 docker-build: ## Build docker image with the plugin.
 	docker build ${DOCKER_BUILD_ARGS} -t ${DOCKER_IMAGE} -f ./Dockerfile ../
 
+.PHONY: docker-push
+docker-push:
+	docker push ${DOCKER_IMAGE}
+
 .PHONY: install
 install: build
 	go install


### PR DESCRIPTION
This PR is a part of https://github.com/gravitational/teleport-plugins/issues/438

This adds `docker push` make targets.

Additionally it adds additional steps in the tag event pipelines in the drone file. 

## Questions
Will the MacOS build target have docker installed in it in order to run builds. Additionally, do I actually need to run these builds? Docker for Desktop, MacOS images on intel (which I believe the builder here is that) get tagged as linux + amd64, which would be the same as the kubernetes builds. 

## Testing
Tested that the new Makefile targets work properly by running them locally. 

The drone changes were not tested locally due to not being able to run `drone exec` with kubernetes pipelines. I am open to suggestions on testing drone pipeline changes before merging to master. 