### PR TITLE
Update versioning for build systems

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,6 +106,66 @@ steps:
     image: golang:1.17.5
     commands:
       - make build-all
+---
+kind: pipeline
+type: kubernetes
+name: build-and-push-images-on-push-linux
+
+trigger:
+  branch:
+    - master
+  event:
+    include:
+      - push
+
+depends_on:
+  - test-linux
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+
+  - name: build images
+    image: docker:git
+    environment:
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - make docker-build-access-plugins
+      - make docker-build-event-handler
+
+  - name: push to ECR
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make aws-cli
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - make docker-push-event-handler
+      - make docker-push-access-plugins
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 
 ---
 kind: pipeline
@@ -509,6 +569,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7381b82e23954f22b26d90324d9219d7b1f2c0d81a4b9e2b27f868674beec197
+hmac: ede0e0312d72f7cb7f00e4278b27c1d4668d9399ded92ae6957fffde092ed8c5
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,9 @@ access-pagerduty:
 access-gitlab:
 	make -C access/gitlab
 
-.PHONY: access-example
-access-example:
-	go build -o build/access-example ./access/example
-
 .PHONY: access-email
 access-email:
-	go build -o build/access-email ./access/email
+	make -C access/email
 
 # Build specific access plugin with docker
 .PHONY: docker-build-access-%
@@ -108,31 +104,19 @@ releases: release/access-slack release/access-jira release/access-mattermost rel
 .PHONY: build-all
 build-all: access-slack access-jira access-mattermost access-pagerduty access-gitlab access-email terraform event-handler
 
-.PHONY: update-version
-update-version:
-	# Make sure VERSION is set on the command line "make update-version VERSION=x.y.z".
-	@test $(VERSION)
-	sed -i '1s/.*/VERSION=$(VERSION)/' event-handler/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' access/jira/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' access/mattermost/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' access/slack/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' access/pagerduty/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' access/email/Makefile
-	sed -i '1s/.*/VERSION=$(VERSION)/' terraform/install.mk
-
 .PHONY: update-tag
 update-tag:
 	# Make sure VERSION is set on the command line "make update-tag VERSION=x.y.z".
 	@test $(VERSION)
 	# Tag all releases first locally.
-	git tag teleport-event-handler-v$(VERSION)
-	git tag teleport-jira-v$(VERSION)
-	git tag teleport-mattermost-v$(VERSION)
-	git tag teleport-slack-v$(VERSION)
-	git tag teleport-pagerduty-v$(VERSION)
-	git tag teleport-email-v$(VERSION)
-	git tag terraform-provider-teleport-v$(VERSION)
-	git tag v$(VERSION)
+	git tag --sign --message "Teleport Event Handler Plugin $(VERSION)" teleport-event-handler-v$(VERSION)
+	git tag --sign --message "Teleport Access Jira Plugin $(VERSION)" teleport-jira-v$(VERSION)
+	git tag --sign --message "Teleport Access Mattermost Plugin $(VERSION)" teleport-mattermost-v$(VERSION)
+	git tag --sign --message "Teleport Access Slack Plugin $(VERSION)" teleport-slack-v$(VERSION)
+	git tag --sign --message "Teleport Access Pagerduty $(VERSION)" teleport-pagerduty-v$(VERSION)
+	git tag --sign --message "Teleport Access Email $(VERSION)" teleport-email-v$(VERSION)
+	git tag --sign --message "Teleport Terraform Provider $(VERSION)" terraform-provider-teleport-v$(VERSION)
+	git tag --sign --message "Teleport Plugins $(VERSION)" v$(VERSION)
 	# Push all releases to origin.
 	git push origin teleport-event-handler-v$(VERSION)
 	git push origin teleport-jira-v$(VERSION)
@@ -152,3 +136,7 @@ update-tag:
 lint: GO_LINT_FLAGS ?=
 lint:
 	golangci-lint run -c .golangci.yml $(GO_LINT_FLAGS)
+
+.PHONY: print-version
+print-version:
+	@./version.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+# Release Documentation
+
+This document contains instructions to help maintainers ensure consistent releases.
+
+## Release Instructions
+
+### Select the commit that will become the release
+
+```code
+$ git checkout master
+```
+
+### Check that desired changes are committed
+
+Use `git log` to check that all changes have been commited.
+
+### Tag and push
+
+```code
+$ make update-tag VERSION=x.y.z
+```
+
+The above target creates and pushes a tag for each plugin.
+
+Run `make print-version` to double check that the build system will correctly pick up the tag

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../../version.sh)
 GO_VERSION=1.17.8
 
 BUILDDIR ?= build

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../../version.sh)
 GO_VERSION=1.17.8
 
 BUILDDIR ?= build

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../../version.sh)
 GO_VERSION=1.17.8
 
 BUILDDIR ?= build

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../../version.sh)
 GO_VERSION=1.17.8
 
 BUILDDIR ?= build

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../../version.sh)
 GO_VERSION=1.17.8
 
 BUILDDIR ?= build

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../version.sh)
 GO_VERSION=1.17.8
 
 OS ?= $(shell go env GOOS)

--- a/terraform/install.mk
+++ b/terraform/install.mk
@@ -1,4 +1,4 @@
-VERSION=9.0.1
+VERSION=$(shell ../version.sh)
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Copyright 2022 Gravitational, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this versioning algo:
+#  - if on a tagged commit, use the tag with any preceding 'v' stripped
+#    e.g. 6.2.18 (for the commit tagged v6.2.18)
+#  - if last tag was a regular release, bump the minor version, make a it a 'dev' pre-release, and append # of commits since tag
+#    e.g. 5.5.38-dev.5 (for 5 commits after v5.5.37)
+#  - if last tag was a pre-release tag (e.g. alpha, beta, rc), append number of commits since the tag
+#    e.g. 7.0.0-alpha.1.5 (for 5 commits after v7.0.0-alpha.1)
+
+
+increment_patch() {
+    # increment_patch returns x.y.(z+1) given valid x.y.z semver.
+    # If we need to robustly handle this, it is probably worth
+    # looking at https://github.com/davidaurelio/shell-semver/
+    # or moving this logic to a 'real' programming language -- 2020-03 walt
+    major=$(echo $1 | cut -d'.' -f1)
+    minor=$(echo $1 | cut -d'.' -f2)
+    patch=$(echo $1 | cut -d'.' -f3)
+    patch=$((patch + 1))
+    echo "${major}.${minor}.${patch}"
+}
+
+
+SHORT_TAG=`git describe --abbrev=0 --tags --match "v*"`
+LONG_TAG=`git describe --tags --match "v*"`
+COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference ${SHORT_TAG}`
+COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
+BUILD_METADATA=`git rev-parse --short=8 HEAD`
+DIRTY_AFFIX=$(git diff --quiet || echo '-dirty')
+
+# strip leading v from git tag, see:
+#   https://github.com/golang/go/issues/32945
+#   https://semver.org/#is-v123-a-semantic-version
+if echo "$SHORT_TAG" | grep -Eq '^v'; then
+    SEMVER_TAG=$(echo "$SHORT_TAG" | cut -c2-)
+else
+    SEMVER_TAG="${SHORT_TAG}"
+fi
+
+if [ -z "$SEMVER_TAG" ]; then # no git tags found, cannot determine version
+    exit 1
+fi
+
+if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
+    echo "${SEMVER_TAG}${DIRTY_AFFIX}"
+elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current ref is a descendant of a pre-release version (e.g. rc, alpha, or beta)
+    echo "$SEMVER_TAG.${COMMITS_SINCE_LAST_TAG}+${BUILD_METADATA}${DIRTY_AFFIX}"
+else   # the current ref is a descendant of a regular version
+    SEMVER_TAG=$(increment_patch ${SEMVER_TAG})
+    echo "$SEMVER_TAG-dev.${COMMITS_SINCE_LAST_TAG}+${BUILD_METADATA}${DIRTY_AFFIX}"
+fi


### PR DESCRIPTION
This PR updates teleport-plugin versioning in order to _shift left_ the build and push of development images for the teleport plugins oci images. 

**NOTE**: This PR is currently in draft mode while I await the merging of https://github.com/gravitational/teleport-plugins/pull/456 and https://github.com/gravitational/teleport-plugins/pull/454