### PR TITLE
Add promotion step to drone pipeline for pushing to quay

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -508,7 +508,116 @@ steps:
       strip_prefix: /go/src/github.com/gravitational/teleport-plugins/
 
 ---
+kind: pipeline
+type: kubernetes
+name: publish-access-images
+
+trigger:
+  event:
+    - promote
+  target:
+    - production
+    - publish-images
+    - publish-access-images
+  ref:
+    include:
+      - refs/tags/teleport-jira-v*
+      - refs/tags/teleport-mattermost-v*
+      - refs/tags/teleport-pagerduty-v*
+      - refs/tags/teleport-slack-v*
+      - refs/tags/teleport-email-v*
+
+clone:
+  disable: true
+
+steps:
+  - name: Promote image
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make aws-cli
+      - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
+      - make docker-promote-access-${PLUGIN_TYPE}
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-event-handler-image
+
+trigger:
+  event:
+    - promote
+  target:
+    - production
+    - publish-images
+    - publish-event-handler-image
+  ref:
+    include:
+      - refs/tags/teleport-event-handler-v*
+
+clone:
+  disable: true
+
+steps:
+  - name: Promote image
+    image: docker:git
+    environment:
+      QUAYIO_DOCKER_USERNAME:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      QUAYIO_DOCKER_PASSWORD:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+      AWS_ACCESS_KEY_ID:
+        from_secret: PLUGIN_DRONE_ECR_KEY
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PLUGIN_DRONE_ECR_SECRET
+      AWS_DEFAULT_REGION: us-west-2
+      DOCKER_BUILDKIT: 1
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make aws-cli
+      - aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
+      - make docker-promote-event-handler
+
+services:
+  - name: start docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
 kind: signature
-hmac: 7381b82e23954f22b26d90324d9219d7b1f2c0d81a4b9e2b27f868674beec197
+hmac: 13986f1874a8bb684f4bcab719979df3fa83b310643b056850302f01eac7b584
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -534,6 +534,10 @@ steps:
   - name: Promote image
     image: docker:git
     environment:
+      QUAYIO_DOCKER_USERNAME:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      QUAYIO_DOCKER_PASSWORD:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
       AWS_ACCESS_KEY_ID:
         from_secret: PLUGIN_DRONE_ECR_KEY
       AWS_SECRET_ACCESS_KEY:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ docker-build-access-plugins: docker-build-access-email \
 docker-push-access-%: docker-build-access-%
 	$(MAKE) -C access/$* docker-push
 
+# Pulls and pushes image from ECR to quay.
+.PHONY: docker-promote-access-%
+docker-promote-access-%:
+	$(MAKE) -C access/$* docker-promote 
+
 # Build event-handler plugin with docker
 .PHONY: docker-build-event-handler
 docker-build-event-handler:
@@ -53,6 +58,10 @@ docker-build-event-handler:
 .PHONY: docker-push-event-handler
 docker-push-event-handler: docker-build-event-handler
 	$(MAKE) -C event-handler docker-push
+
+.PHONY: docker-promote-event-handler
+docker-promote-event-handler:
+	$(MAKE) -C event-handler docker-promote
 
 .PHONY: terraform
 terraform:

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -62,6 +62,6 @@ docker-push:
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -18,6 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = access-plugin-email
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=email
 
 .PHONY: $(BINARY)
@@ -58,3 +59,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: 
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -18,6 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = access-plugin-jira
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=jira
 
 .PHONY: $(BINARY)
@@ -58,3 +59,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: 
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -62,6 +62,6 @@ docker-push:
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -62,6 +62,6 @@ docker-push:
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -18,6 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME=access-plugin-mattermost
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=mattermost
 
 .PHONY: $(BINARY)
@@ -58,3 +59,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: 
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -62,6 +62,6 @@ docker-push:
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -18,6 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME=access-plugin-pagerduty
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=pagerduty
 
 .PHONY: $(BINARY)
@@ -58,3 +59,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: 
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -62,6 +62,6 @@ docker-push: ## Push docker image with the plugin.
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -18,6 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME=access-plugin-slack
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=slack
 
 .PHONY: $(BINARY)
@@ -58,3 +59,9 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push: ## Push docker image with the plugin.
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -51,8 +51,8 @@ docker-push:
 
 .PHONY: docker-promote
 docker-promote:
-	docker pull ${DOCKER_IMAGE}
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker pull ${DOCKER_IMAGE} && \
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
 	docker push ${DOCKER_IMAGE_QUAY}
 
 .PHONY: install

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -24,6 +24,7 @@ IDENTITY_FILE=example/keys/identity
 
 DOCKER_NAME=event-handler-plugin
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION}
 
 RELEASE = teleport-event-handler-v$(VERSION)-$(OS)-$(ARCH)-bin
@@ -47,6 +48,12 @@ docker-build: ## Build docker image with the plugin.
 .PHONY: docker-push
 docker-push:
 	docker push ${DOCKER_IMAGE}
+
+.PHONY: docker-promote
+docker-promote:
+	docker pull ${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY}
+	docker push ${DOCKER_IMAGE_QUAY}
 
 .PHONY: install
 install: build


### PR DESCRIPTION
As a part of https://github.com/gravitational/teleport-plugins/issues/438, this PR adds additional pipelines to `.drone.yml` file in order to promote internally staged docker images to their public registry with quay.io. 

The current promotion workflow occurs on a per tag basis. This means that for every tag created by the `make update-tag` target, a teleport employee triggers a promotion step for this tag. 

This workflow is reflected in the additional promotion steps added in this PR. Therefore, no change to the procedure in which a tag is promoted will occur in order for the images to be promoted to Quay.io.

## Testing
The promotion step was confirmed through local manual testing. 