### PR TITLE
TF SAML Connector: require any of (EntityDescriptor, EntityDescriptorURL)

### DIFF
--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -317,7 +317,7 @@ validators:
   SAMLConnectorV2.Version:
     - UseVersionBetween(2,2)
   SAMLConnectorV2.Spec:
-    - UseOneOfValidator("entity_descriptor", "entity_descriptor_url")
+    - UseAnyOfValidator("entity_descriptor", "entity_descriptor_url")
   SessionRecordingConfigV2.Version:
     - UseVersionBetween(2,2)
   SessionRecordingConfigV2.Metadata.Labels:

--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -251,7 +251,6 @@ required_fields:
     # SAML connector
     - "SAMLConnectorV2.Spec"
     - "SAMLConnectorV2.Spec.AssertionConsumerService"
-    - "SAMLConnectorV2.Spec.EntityDescriptor"
     - "SAMLConnectorV2.Spec.AttributesToRoles"
     - "SAMLConnectorV2.Metadata.Name"    
 
@@ -317,6 +316,8 @@ validators:
     - UseVersionBetween(3,5)
   SAMLConnectorV2.Version:
     - UseVersionBetween(2,2)
+  SAMLConnectorV2.Spec:
+    - UseOneOfValidator("entity_descriptor", "entity_descriptor_url")
   SessionRecordingConfigV2.Version:
     - UseVersionBetween(2,2)
   SessionRecordingConfigV2.Metadata.Labels:

--- a/terraform/test/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
+++ b/terraform/test/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
@@ -1,0 +1,20 @@
+resource "teleport_saml_connector" "test" {
+    metadata = {
+        name    = "test"
+        expires = "2022-10-12T07:20:50Z"
+        labels  = {
+            example = "yes"
+        }
+    }
+
+    spec = {
+        attributes_to_roles = [{
+            name = "groups"
+            roles = ["admin"]
+            value = "okta-admin"
+        }]
+        
+        acs = "https://example.com/v1/webapi/saml/acs"
+        entity_descriptor_url = "https://dev-84961217.okta.com/app/exk4d7tmnz9DEaEw85d7/sso/saml/metadata"
+    }
+}

--- a/terraform/test/fixtures/saml_connector_0_create_without_entitydescriptor.tf
+++ b/terraform/test/fixtures/saml_connector_0_create_without_entitydescriptor.tf
@@ -1,0 +1,19 @@
+resource "teleport_saml_connector" "test" {
+    metadata = {
+        name    = "test"
+        expires = "2022-10-12T07:20:50Z"
+        labels  = {
+            example = "yes"
+        }
+    }
+
+    spec = {
+        attributes_to_roles = [{
+            name = "groups"
+            roles = ["admin"]
+            value = "okta-admin"
+        }]
+
+        acs = "https://example.com/v1/webapi/saml/acs"
+    }
+}

--- a/terraform/test/saml_connector_test.go
+++ b/terraform/test/saml_connector_test.go
@@ -126,3 +126,14 @@ func (s *TerraformSuite) TestImportSAMLConnector() {
 		},
 	})
 }
+
+func (s *TerraformSuite) TestSAMLConnectorWithEntityDescriptorURL() {
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("saml_connector_0_create_with_entitydescriptorurl.tf"),
+			},
+		},
+	})
+}

--- a/terraform/test/saml_connector_test.go
+++ b/terraform/test/saml_connector_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package test
 
 import (
+	"regexp"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -133,6 +135,18 @@ func (s *TerraformSuite) TestSAMLConnectorWithEntityDescriptorURL() {
 		Steps: []resource.TestStep{
 			{
 				Config: s.getFixture("saml_connector_0_create_with_entitydescriptorurl.tf"),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestSAMLConnectorWithoutEntityDescriptor() {
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      s.getFixture("saml_connector_0_create_without_entitydescriptor.tf"),
+				ExpectError: regexp.MustCompile("OneOf 'entity_descriptor, entity_descriptor_url' keys must be present"),
 			},
 		},
 	})

--- a/terraform/test/saml_connector_test.go
+++ b/terraform/test/saml_connector_test.go
@@ -146,7 +146,7 @@ func (s *TerraformSuite) TestSAMLConnectorWithoutEntityDescriptor() {
 		Steps: []resource.TestStep{
 			{
 				Config:      s.getFixture("saml_connector_0_create_without_entitydescriptor.tf"),
-				ExpectError: regexp.MustCompile("OneOf 'entity_descriptor, entity_descriptor_url' keys must be present"),
+				ExpectError: regexp.MustCompile("AnyOf 'entity_descriptor, entity_descriptor_url' keys must be present"),
 			},
 		},
 	})

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -1989,7 +1989,7 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 				},
 				"entity_descriptor": {
 					Description: "EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.",
-					Required:    true,
+					Optional:    true,
 					Sensitive:   true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -2050,6 +2050,7 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 			}),
 			Description: "Spec is an SAML connector specification.",
 			Required:    true,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseOneOfValidator("entity_descriptor", "entity_descriptor_url")},
 		},
 		"sub_kind": {
 			Description: "SubKind is an optional resource sub kind, used in some resources.",

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -2050,7 +2050,7 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 			}),
 			Description: "Spec is an SAML connector specification.",
 			Required:    true,
-			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseOneOfValidator("entity_descriptor", "entity_descriptor_url")},
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseAnyOfValidator("entity_descriptor", "entity_descriptor_url")},
 		},
 		"sub_kind": {
 			Description: "SubKind is an optional resource sub kind, used in some resources.",

--- a/terraform/tfschema/validators.go
+++ b/terraform/tfschema/validators.go
@@ -165,30 +165,30 @@ OUTER:
 
 }
 
-// OneOfValidator validates that at least one of the attributes is set (known and not null)
-type OneOfValidator struct {
+// AnyOfValidator validates that at least one of the attributes is set (known and not null)
+type AnyOfValidator struct {
 	Keys []string
 }
 
-// UseOneOfValidator creates OneOfValidator
-func UseOneOfValidator(keys ...string) tfsdk.AttributeValidator {
-	return OneOfValidator{
+// UseAnyOfValidator creates AnyOfValidator
+func UseAnyOfValidator(keys ...string) tfsdk.AttributeValidator {
+	return AnyOfValidator{
 		Keys: keys,
 	}
 }
 
 // Description returns validator description
-func (v OneOfValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("OneOf '%s' attributes must be present", strings.Join(v.Keys, ", "))
+func (v AnyOfValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("AnyOf '%s' attributes must be present", strings.Join(v.Keys, ", "))
 }
 
 // MarkdownDescription returns validator markdown description
-func (v OneOfValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("OneOf `%s` attributes must be present", strings.Join(v.Keys, ", "))
+func (v AnyOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("AnyOf `%s` attributes must be present", strings.Join(v.Keys, ", "))
 }
 
 // Validate performs the validation.
-func (v OneOfValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+func (v AnyOfValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 	if req.AttributeConfig == nil {
 		return
 	}
@@ -196,7 +196,7 @@ func (v OneOfValidator) Validate(ctx context.Context, req tfsdk.ValidateAttribut
 	value, ok := req.AttributeConfig.(types.Object)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"OneOf Object validation error",
+			"AnyOf Object validation error",
 			fmt.Sprintf("Attribute %v can not be converted to Object", req.AttributePath.String()),
 		)
 		return
@@ -212,7 +212,7 @@ func (v OneOfValidator) Validate(ctx context.Context, req tfsdk.ValidateAttribut
 			tfVal, err := attr.ToTerraformValue(ctx)
 			if err != nil {
 				resp.Diagnostics.AddError(
-					"OneOf keys validation error",
+					"AnyOf keys validation error",
 					fmt.Sprintf("Failed to convert ToTerraformValue attribute with key '%s': %v", key, err),
 				)
 				return
@@ -224,7 +224,7 @@ func (v OneOfValidator) Validate(ctx context.Context, req tfsdk.ValidateAttribut
 	}
 
 	resp.Diagnostics.AddError(
-		"OneOf keys validation error",
-		fmt.Sprintf("OneOf '%s' keys must be present", strings.Join(v.Keys, ", ")),
+		"AnyOf keys validation error",
+		fmt.Sprintf("AnyOf '%s' keys must be present", strings.Join(v.Keys, ", ")),
 	)
 }

--- a/terraform/tfschema/validators_test.go
+++ b/terraform/tfschema/validators_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright 2022 Gravitational, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tfschema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func getObjectWithTwoKeys() types.Object {
+	return types.Object{
+		Attrs: map[string]attr.Value{
+			"key1": types.String{
+				Value:   "val1",
+				Null:    false,
+				Unknown: false,
+			},
+			"key2": types.Int64{
+				Value:   12,
+				Null:    false,
+				Unknown: false,
+			},
+		},
+	}
+}
+
+func TestOneOfValidator(t *testing.T) {
+	type testCase struct {
+		input       types.Object
+		oneOfValues []string
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"one-of-two": {
+			input:       getObjectWithTwoKeys(),
+			oneOfValues: []string{"key1"},
+			expectError: false,
+		},
+		"two-of-two": {
+			input:       getObjectWithTwoKeys(),
+			oneOfValues: []string{"key1", "key2"},
+			expectError: false,
+		},
+		"none-of-two": {
+			input:       getObjectWithTwoKeys(),
+			oneOfValues: []string{"key3"},
+			expectError: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			resp := &tfsdk.ValidateAttributeResponse{
+				Diagnostics: make(diag.Diagnostics, 0),
+			}
+
+			req := tfsdk.ValidateAttributeRequest{
+				AttributeConfig: test.input,
+			}
+			UseOneOfValidator(test.oneOfValues...).Validate(ctx, req, resp)
+			require.Equal(t, test.expectError, resp.Diagnostics.HasError())
+		})
+	}
+}

--- a/terraform/tfschema/validators_test.go
+++ b/terraform/tfschema/validators_test.go
@@ -41,6 +41,10 @@ func getObjectWithTwoKeys() types.Object {
 				Unknown: false,
 			},
 		},
+		AttrTypes: map[string]attr.Type{
+			"key1": types.StringType,
+			"key2": types.StringType,
+		},
 	}
 }
 

--- a/terraform/tfschema/validators_test.go
+++ b/terraform/tfschema/validators_test.go
@@ -48,26 +48,26 @@ func getObjectWithTwoKeys() types.Object {
 	}
 }
 
-func TestOneOfValidator(t *testing.T) {
+func TestAnyOfValidator(t *testing.T) {
 	type testCase struct {
 		input       types.Object
-		oneOfValues []string
+		anyOfValues []string
 		expectError bool
 	}
 	tests := map[string]testCase{
 		"one-of-two": {
 			input:       getObjectWithTwoKeys(),
-			oneOfValues: []string{"key1"},
+			anyOfValues: []string{"key1"},
 			expectError: false,
 		},
 		"two-of-two": {
 			input:       getObjectWithTwoKeys(),
-			oneOfValues: []string{"key1", "key2"},
+			anyOfValues: []string{"key1", "key2"},
 			expectError: false,
 		},
 		"none-of-two": {
 			input:       getObjectWithTwoKeys(),
-			oneOfValues: []string{"key3"},
+			anyOfValues: []string{"key3"},
 			expectError: true,
 		},
 	}
@@ -83,7 +83,7 @@ func TestOneOfValidator(t *testing.T) {
 			req := tfsdk.ValidateAttributeRequest{
 				AttributeConfig: test.input,
 			}
-			UseOneOfValidator(test.oneOfValues...).Validate(ctx, req, resp)
+			UseAnyOfValidator(test.anyOfValues...).Validate(ctx, req, resp)
 			require.Equal(t, test.expectError, resp.Diagnostics.HasError())
 		})
 	}


### PR DESCRIPTION
For Terraform SAML Connector, at least one of the following Spec attributes must exist:
- EntityDescriptor
- EntityDescriptorURL

However, we were always requiring the EntityDescriptor
We removed this field as required

Things would work out because the server would validate that either one of them is present.
The server returns an error if both are empty.

However, to improve the UX we added a `AnyOf` validation to the terraform side
It will validate before hitting the server

Fixes #448