### PR TITLE
Update teleport-plugin docs with OCI information

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ sendind webhooks when a new request is created, or a request state is changed,
 and it allows optionally listening for the 3rd party app callbacks to facilitate
 the approval workdlow. See more in the [access/webhooks/README.md](/access/webhooks/README.md)
 
+## Event Handler
+
+The [Teleport Event Handler Plugin](./event-handler) is used to export audit log events to a fluentd service. For more information, visit the Fluentd setup guide at [goteleport.com](https://goteleport.com/docs/setup/guides/fluentd/) or checkout the [README](./event-handler/README.md).
+
 ## Terraform Provider
 
 The [Teleport Terraform Provider](./terraform) makes it easy to create resources using

--- a/access/README.md
+++ b/access/README.md
@@ -1,3 +1,9 @@
+# Access Plugins
+
+The various plugins within this directory allow teleport users the ability to intergrate access request notifications and approval workflows with third party technologies. They also serve as examples for building your own integration. For more information on the plugins available visit the `README.md` within each plugins respective directory.
+
+For more information on Access Requests with Teleport, check out this [blog post](https://goteleport.com/blog/access-requests/)
+
 ### Access API
 
 The Teleport Access API has been moved into the main Teleport repo, and can be imported from `github.com/gravitational/teleport/api`. To see examples of how to get started with the Teleport API, take a look at our [go-client example](https://github.com/gravitational/teleport/tree/master/examples/go-client) or read the [API docs](https://goteleport.com/docs/api/introduction/).

--- a/access/email/README.md
+++ b/access/email/README.md
@@ -2,11 +2,17 @@
 
 The plugin allows teams to receive email notifications about new access requests.
 
-## Setup
+## Install the plugin
 
-### Install the plugin
+There are several methods to installing and using the Teleport Email Plugin:
 
-Get the plugin distribution.
+1. Use a [precompiled binary](#precompiled-binary)
+
+2. Use a [docker image](#docker-image)
+
+3. Install from [source](#building-from-source)
+
+### Precompiled Binary
 
 ```bash
 $ curl -L https://get.gravitational.com/teleport-access-email-v7.1.0-linux-amd64-bin.tar.gz
@@ -15,11 +21,34 @@ $ cd teleport-access-email
 $ ./install
 ```
 
-### Teleport User and Role
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/access-plugin-email:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/access-plugin-email:9.0.2 version
+teleport-email v9.0.2 git:teleport-email-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-email?tab=tags)
+
+### Building from source
+
+To build the plugin from source you need Go >= 1.16 and `make`.
+
+```bash
+$ git clone https://github.com/gravitational/teleport-plugins.git
+$ cd teleport-plugins/access/email
+$ make
+$ ./build/teleport-email start
+```
+
+## Teleport User and Role
 
 Using Web UI or `tctl` CLI utility, create the role `access-email` and the user `access-email` belonging to the role `access-email`. You may use the following YAML declarations.
 
-#### Role
+### Role
 
 ```yaml
 kind: role
@@ -33,7 +62,7 @@ spec:
 version: v4
 ```
 
-#### User
+### User
 
 ```yaml
 kind: user
@@ -44,7 +73,7 @@ spec:
 version: v2
 ```
 
-### Generate the certificate
+## Generate the certificate
 
 For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:
 
@@ -54,7 +83,7 @@ $ tctl auth sign --auth-server=AUTH-SERVER:PORT --format=file --user=access-emai
 
 Here, `AUTH-SERVER:PORT` could be `localhost:3025`, `your-in-cluster-auth.example.com:3025`, `your-remote-proxy.example.com:3080` or `your-teleport-cloud.teleport.sh:443`. For non-localhost connections, you might want to pass the `--identity=...` option to authenticate yourself to Auth Server.
 
-### Save configuration file
+## Save configuration file
 
 By default, configuration file is expected to be at `/etc/teleport-email.toml`.
 
@@ -88,21 +117,17 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-### Run the plugin
+## Run the plugin
 
 ```bash
-teleport-email start
+$ teleport-email start
+```
+
+or with docker:
+
+```bash
+$ docker run -v <path/to/config>:/etc/teleport-email.toml quay.io/gravitational/access-plugin-email:9.0.2 start
 ```
 
 If something bad happens, try to run it with `-d` option i.e. `teleport-email start -d` and attach the stdout output to the issue you are going to create.
 
-## Building from source
-
-To build the plugin from source you need Go >= 1.16 and `make`.
-
-```bash
-git clone https://github.com/gravitational/teleport-plugins.git
-cd teleport-plugins/access/email
-make
-./build/teleport-email start
-```

--- a/access/email/README.md
+++ b/access/email/README.md
@@ -59,7 +59,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 ### User

--- a/access/email/README.md
+++ b/access/email/README.md
@@ -35,7 +35,7 @@ For a list of available tags, visit [https://quay.io/](https://quay.io/repositor
 
 ### Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 $ git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/gitlab/README.md
+++ b/access/gitlab/README.md
@@ -117,7 +117,7 @@ If for some reason you want to disable TLS termination in the plugin and deploy 
 
 ## Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/gitlab/README.md
+++ b/access/gitlab/README.md
@@ -44,7 +44,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 #### User

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -75,7 +75,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 ### User

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -39,7 +39,7 @@ For a list of available tags, visit [https://quay.io/](https://quay.io/repositor
 
 ### Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 $ git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -4,9 +4,17 @@ This package provides Teleport <-> Jira integration that allows teams to approve
 or deny Access Requests on a Jira Project Board. It works with both Jira Cloud
 and Jira Server 8.
 
-## Setup
+## Install the plugin
 
-### Install the plugin
+There are several methods to installing and using the Teleport Jira Plugin:
+
+1. Use a [precompiled binary](#precompiled-binary)
+
+2. Use a [docker image](#docker-image)
+
+3. Install from [source](#building-from-source)
+
+### Precompiled Binary
 
 Get the plugin distribution.
 
@@ -17,7 +25,30 @@ $ cd teleport-access-jira
 $ ./install
 ```
 
-### Set up Jira board
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/access-plugin-jira:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/access-plugin-jira:9.0.2 version
+teleport-jira v9.0.2 git:teleport-jira-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-jira?tab=tags)
+
+### Building from source
+
+To build the plugin from source you need Go >= 1.16 and `make`.
+
+```bash
+$ git clone https://github.com/gravitational/teleport-plugins.git
+$ cd teleport-plugins/access/jira
+$ make
+$ ./build/teleport-jira start
+```
+
+## Set up Jira board
 
 - [See detailed setup instructions for Jira Cloud on the website](https://goteleport.com/teleport/docs/enterprise/workflow/ssh_approval_jira_cloud/)
 - [See detailed setup instructions for Jira Server on the website](https://goteleport.com/teleport/docs/enterprise/workflow/ssh_approval_jira_server/)
@@ -29,11 +60,11 @@ Setup process is different for the Jira Cloud and Jira Server editions:
 - Jira Server getting started guide:
   [INSTALL-JIRA-SERVER.md](./INSTALL-JIRA-SERVER.md)
 
-### Teleport User and Role
+## Teleport User and Role
 
 Using Web UI or `tctl` CLI utility, create the role `access-jira` and the user `access-jira` belonging to the role `access-jira`. You may use the following YAML declarations.
 
-#### Role
+### Role
 
 ```yaml
 kind: role
@@ -47,7 +78,7 @@ spec:
 version: v4
 ```
 
-#### User
+### User
 
 ```yaml
 kind: user
@@ -58,7 +89,7 @@ spec:
 version: v2
 ```
 
-### Generate the certificate
+## Generate the certificate
 
 For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:
 
@@ -68,7 +99,7 @@ $ tctl auth sign --auth-server=AUTH-SERVER:PORT --format=file --user=access-jira
 
 Here, `AUTH-SERVER:PORT` could be `localhost:3025`, `your-in-cluster-auth.example.com:3025`, `your-remote-proxy.example.com:3080` or `your-teleport-cloud.teleport.sh:443`. For non-localhost connections, you might want to pass the `--identity=...` option to authenticate yourself to Auth Server.
 
-### Save configuration file
+## Save configuration file
 
 By default, configuration file is expected to be at `/etc/teleport-jira.toml`.
 
@@ -113,24 +144,20 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-### Run the plugin
+## Run the plugin
 
 ```bash
-teleport-jira start
+$ teleport-jira start
+```
+
+or with docker:
+
+```bash
+$ docker run -v <path/to/config>:/etc/teleport-jira.toml quay.io/gravitational/access-plugin-jira:9.0.2 start
 ```
 
 If something bad happens, try to run it with `-d` option i.e. `teleport-jira start -d` and attach the stdout output to the issue you are going to create.
 
 If for some reason you want to disable TLS termination in the plugin and deploy it somewhere else e.g. on some reverse proxy, you may want to run the plugin with `--insecure-no-tls` option. With `--insecure-no-tls` option, plugin's webhook server will talk plain HTTP protocol.
 
-## Building from source
-
-To build the plugin from source you need Go >= 1.16 and `make`.
-
-```bash
-git clone https://github.com/gravitational/teleport-plugins.git
-cd teleport-plugins/access/jira
-make
-./build/teleport-jira start
-```
 

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -48,7 +48,7 @@ For a list of available tags, visit [https://quay.io/](https://quay.io/repositor
 
 ### Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 $ git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -3,11 +3,9 @@
 This package provides Teleport <-> Mattermost integrataion that allows teams to
 get notified about new access requests in Mattermost.
 
-## Setup
-
 [See setup instructions on Teleport's website](https://goteleport.com/teleport/docs/enterprise/workflow/ssh_approval_mattermost/)
 
-### Prerequisites
+## Prerequisites
 
 This guide assumes that you have:
 
@@ -15,7 +13,51 @@ This guide assumes that you have:
 - Admin privileges with access to `tctl`
 - Mattermost account with admin privileges.
 
-#### Setting up a sandbox Mattermost instance for testing
+## Install the plugin
+
+There are several methods to installing and using the Teleport Mattermost Plugin:
+
+1. Use a [precompiled binary](#precompiled-binary)
+
+2. Use a [docker image](#docker-image)
+
+3. Install from [source](#building-from-source)
+
+### Precompiled Binary
+
+Get the plugin distribution.
+
+```bash
+$ curl -L https://get.gravitational.com/teleport-access-mattermost-v7.0.2-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-mattermost-v7.0.2-linux-amd64-bin.tar.gz
+$ cd teleport-access-mattermost
+$ ./install
+```
+
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/access-plugin-mattermost:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/access-plugin-mattermost:9.0.2 version
+teleport-mattermost v9.0.2 git:teleport-mattermost-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-mattermost?tab=tags)
+
+### Building from source
+
+To build the plugin from source you need Go >= 1.16 and `make`.
+
+```bash
+$ git clone https://github.com/gravitational/teleport-plugins.git
+$ cd teleport-plugins/access/mattermost
+$ make
+$ ./build/teleport-mattermost start
+```
+
+## Setting up a sandbox Mattermost instance for testing
 
 If you want to build the plugin and test it with Mattermost, the easiest way to
 get Mattermost running is with the docker image:
@@ -27,7 +69,7 @@ docker run --name mattermost-preview -d --publish 8065:8065 --add-host dockerhos
 Check out
 [more documentation on running Mattermost](https://docs.mattermost.com/install/docker-local-machine.html).
 
-#### Setting up Mattermost to work with the plugin
+### Setting up Mattermost to work with the plugin
 
 In Mattermost, go to System Console -> Integrations -> Enable Bot Account
 Creation -> Set to True. This will allow us to create a new bot account that the
@@ -40,100 +82,52 @@ The new bot account will need Post All permission.
 The confirmation screen after you've created the bot will give you the access
 token. We'll use this in the config later.
 
-#### Create an access-plugin role and user within Teleport
+## Teleport User and Role
 
-First off, using an existing Teleport Cluster, we are going to create a new
-Teleport User and Role to access Teleport.
+Using Web UI or `tctl` CLI utility, create the role `access-mattermost` and the user `access-mattermost` belonging to the role `access-mattermost`. You may use the following YAML declarations.
 
-#### Create User and Role for access.
+### Role
 
-Log into Teleport Authentication Server, this is where you normally run `tctl`.
-Don't change the username and the role name, it should be `access-plugin` for
-the plugin to work correctly.
-
-```bash
-$ cat > rscs.yaml <<EOF
-kind: user
-metadata:
-  name: access-plugin
-spec:
-  roles: ['access-plugin']
-version: v2
----
+```yaml
 kind: role
 metadata:
-  name: access-plugin
+  name: access-mattermost
 spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list', 'read']
-      - resources: ['access_plugin_data']
-        verbs: ['update']
-    # teleport currently refuses to issue certs for a user with 0 logins,
-    # this restriction may be lifted in future versions.
-    logins: ['access-plugin']
-version: v3
-EOF
-
-# ...
-$ tctl create -f rscs.yaml
+        verbs: ['list', 'read', 'update']
+version: v4
 ```
 
-#### Export access-plugin Certificate
+### User
 
-Teleport Plugin uses the `access-plugin` role and user to peform the approval. We
-export the identify files, using
-[`tctl auth sign`](https://goteleport.com/teleport/docs/cli-docs/#tctl-auth-sign).
+```yaml
+kind: user
+metadata:
+  name: access-mattermost
+spec:
+  roles: ['access-mattermost']
+version: v2
+```
+
+## Generate the certificate
+
+For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:
 
 ```bash
-$ tctl auth sign --format=tls --user=access-plugin --out=auth --ttl=8760h
-# ...
+$ tctl auth sign --auth-server=AUTH-SERVER:PORT --format=file --user=access-mattermost --out=/var/lib/teleport/plugins/mattermost/auth_id --ttl=8760h
 ```
 
-The above sequence should result in three PEM encoded files being generated:
-auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs
-respectively). We'll reference these later in the bot config, and move them to
-an appropriate directory.
+Here, `AUTH-SERVER:PORT` could be `localhost:3025`, `your-in-cluster-auth.example.com:3025`, `your-remote-proxy.example.com:3080` or `your-teleport-cloud.teleport.sh:443`. For non-localhost connections, you might want to pass the `--identity=...` option to authenticate yourself to Auth Server.
 
-_Note: by default, tctl auth sign produces certificates with a relatively short
-lifetime. For production deployments, the --ttl flag can be used to ensure a
-more practical certificate lifetime. --ttl=8760h exports a 1 year token_
-
-#### Export access-plugin Certificate for use with Teleport Cloud
-
-Connection to Teleport Cloud is only possible with reverse tunnel. For this reason,
-we need the identity signed in a different format called `file` which exports
-SSH keys too.
-
-```bash
-$ tctl auth sign --auth-server=yourproxy.teleport.sh:443 --format=file --user=access-plugin --out=auth --ttl=8760h
-# ...
-```
-
-## Downloading and installing the plugin
-
-[See our Mattermost plugin docs for [download links](https://goteleport.com/docs/enterprise/workflow/ssh-approval-mattermost/#downloading-and-installing-the-plugin).
-
-### Building from source
-
-```bash
-
-# Checkout teleport-plugins
-git clone git@github.com:gravitational/teleport-plugins.git
-cd teleport-plugins
-
-cd access/mattermost
-make
-```
-
-### Configuring Mattermost Plugin
+## Configuring Mattermost Plugin
 
 Mattermost Plugin uses a config file in TOML format. Generate a boilerplate config
 by running the following command:
 
 ```
-teleport-mattermost configure > /etc/teleport-mattermost.yml
+$ teleport-mattermost configure > /etc/teleport-mattermost.yml
 ```
 
 Then, edit the config as needed.
@@ -141,10 +135,21 @@ Then, edit the config as needed.
 ```TOML
 # example mattermost configuration TOML file
 [teleport]
-addr = "example.com:3025" # Teleport Auth Server GRPC API address
-client_key = "/var/lib/teleport/plugins/mattermost/auth.key" # Teleport GRPC client secret key
-client_crt = "/var/lib/teleport/plugins/mattermost/auth.crt" # Teleport GRPC client certificate
-root_cas = "/var/lib/teleport/plugins/mattermost/auth.cas"   # Teleport cluster CA certs
+# Teleport Auth/Proxy Server address.
+#
+# Should be port 3025 for Auth Server and 3080 or 443 for Proxy.
+# For Teleport Cloud, should be in the form "your-account.teleport.sh:443".
+addr = "example.com:3025"
+
+# Credentials.
+#
+# When using --format=file:
+# identity = "/var/lib/teleport/plugins/mattermost/auth_id"    # Identity file
+#
+# When using --format=tls:
+# client_key = "/var/lib/teleport/plugins/mattermost/auth.key" # Teleport TLS secret key
+# client_crt = "/var/lib/teleport/plugins/mattermost/auth.crt" # Teleport TLS certificate
+# root_cas = "/var/lib/teleport/plugins/mattermost/auth.cas"   # Teleport CA certs
 
 [mattermost]
 url = "https://mattermost.example.com" # Mattermost Server URL
@@ -155,22 +160,23 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-To use with Teleport Cloud, you should set a path to identity file exported with `--format=file` option.
-
-```TOML
-[teleport]
-addr = "yourproxy.teleport.sh:443"                     # Teleport proxy address
-identity = "/var/lib/teleport/plugins/mattermost/auth" # Teleport identity file
-```
-
-### Running the plugin
+## Running the plugin
 
 With the config above, you should be able to run the bot invoking
-`teleport-mattermost start`
 
-### The Workflow
+```bash
+$ teleport-mattermost start
+```
 
-#### Create an access request
+or with docker:
+
+```bash
+$ docker run -v <path/to/config>:/etc/teleport-mattermost.toml quay.io/gravitational/access-plugin-mattermost:9.0.2 start
+```
+
+## The Workflow
+
+### Create an access request
 
 You can create an access request using Web UI going to
 `https://your-proxy.example.com/web/requests/new` where your-proxy.example.com
@@ -180,11 +186,11 @@ Check that you see a request message on Mattermost.
 
 It should look like this: %image%
 
-#### Review the request
+### Review the request
 
 Open the Link in message and choose to either approve or deny the request. The messages should automatically get updated to reflect the action you just did.
 
-### Teleport OSS edition
+## Teleport OSS edition
 
 Currently, Teleport OSS edition does not have an "Access Requests" page at Web UI. Alternatively, you can create an access request using tsh:
 

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -97,7 +97,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 ### User

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -49,7 +49,7 @@ For a list of available tags, visit [https://quay.io/](https://quay.io/repositor
 
 ### Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 $ git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -14,48 +14,77 @@ This guide assumes you have
 - Teleport Enterprise 6.1 or newer with admin permissions and access to `tctl`
 - Pagerduty account already set, with access to creating a new API token.
 
-### Create an access-plugin role and user within Teleport
+## Install the plugin
 
-First off, using an existing Teleport Cluster, we are going to create a new
-Teleport User and Role to access Teleport.
+There are several methods to installing and using the Teleport Pagerduty Plugin:
 
-#### Create User and Role for access.
+1. Use a [precompiled binary](#precompiled-binary)
 
-Log into Teleport Authent Server, this is where you normally run `tctl`. Don't
-change the username and the role name, it should be `access-plugin` for the
-plugin to work correctly.
+2. Use a [docker image](#docker-image)
 
-_Note: if you're using other plugins, you might want to create different users
-and roles for different plugins_.
+3. Install from [source](#building-from-source)
 
+### Precompiled Binary
+
+Get the plugin distribution.
+
+```bash
+$ curl -L https://get.gravitational.com/teleport-access-pagerduty-v7.0.2-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-pagerduty-v7.0.2-linux-amd64-bin.tar.gz
+$ cd teleport-access-pagerduty
+$ ./install
 ```
-$ cat > rscs.yaml <<EOF
-kind: user
-metadata:
-  name: access-plugin
-spec:
-  roles: ['access-plugin']
-version: v2
----
+
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/access-plugin-pagerduty:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/access-plugin-pagerduty:9.0.2 version
+teleport-pagerduty v9.0.2 git:teleport-pagerduty-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-pagerduty?tab=tags)
+
+### Building from source
+
+To build the plugin from source you need Go >= 1.16 and `make`.
+
+```bash
+$ git clone https://github.com/gravitational/teleport-plugins.git
+$ cd teleport-plugins/access/pagerduty
+$ make
+$ ./build/teleport-pagerduty start
+```
+
+## Teleport User and Role
+
+Using Web UI or `tctl` CLI utility, create the role `access-pagerduty` and the user `access-pagerduty` belonging to the role `access-pagerduty`. You may use the following YAML declarations.
+
+### Role
+
+```yaml
 kind: role
 metadata:
-  name: access-plugin
+  name: access-pagerduty
 spec:
   allow:
     rules:
       - resources: ['access_request']
-        verbs: ['list','read']
-      - resources: ['access_plugin_data']
-        verbs: ['update']
-    # if you want to enable auto-approve feature
-    review_requests:
-      roles: ...
-      where: ... 
-version: v3
-EOF
+        verbs: ['list', 'read', 'update']
+version: v4
+```
 
-# ...
-$ tctl create -f rscs.yaml
+### User
+
+```yaml
+kind: user
+metadata:
+  name: access-pagerduty
+spec:
+  roles: ['access-pagerduty']
+version: v2
 ```
 
 #### Export access-plugin Certificate
@@ -89,15 +118,28 @@ $ tctl auth sign --auth-server=yourproxy.teleport.sh:443 --format=file --user=ac
 # ...
 ```
 
-### Setting up Pagerduty API key
+
+
+
+## Generate the certificate
+
+For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:
+
+```bash
+$ tctl auth sign --auth-server=AUTH-SERVER:PORT --format=file --user=access-pagerduty --out=/var/lib/teleport/plugins/pagerduty/auth_id --ttl=8760h
+```
+
+Here, `AUTH-SERVER:PORT` could be `localhost:3025`, `your-in-cluster-auth.example.com:3025`, `your-remote-proxy.example.com:3080` or `your-teleport-cloud.teleport.sh:443`. For non-localhost connections, you might want to pass the `--identity=...` option to authenticate yourself to Auth Server.
+
+## Setting up Pagerduty API key
 
 In your Pagerduty dashboard, go to **Configuration -> API Access -> Create New
 API Key**, add a key description, and save the key. We'll use the key in the
 plugin config file later.
 
-### Setting up Pagerduty notification alerts
+## Setting up Pagerduty notification alerts
 
-Once a new access request has been created, plugin creates an incident in a Pagerduty service. In order to know what service to post the notification in, the service name must be set up in a request annotation of a role of a user who requests an access.
+Once a new access request has been created, the plugin creates an incident in a Pagerduty service. In order to know what service to post the notification in, the service name must be set up in a request annotation of a role of a user who requests an access.
 
 Suppose you created a Pagerduty service called "Teleport Notifications" and want it to be notified about all new access requests from users under role `challenger`. Then you should set up a request annotation called `pagerduty_notify_service` containing a list with an only element `["Teleport notifications"]`.
 
@@ -113,7 +155,7 @@ spec:
         pagerduty_notify_service: ["teleport notifications"]
 ```
 
-### Setting up auto-approval behavior
+## Setting up auto-approval behavior
 
 If given sufficient permissions, Pagerduty plugin can auto-approve new access requests if they come from a user who is currently on-call. More specifically, it works like this:
 
@@ -148,42 +190,18 @@ spec:
 - `alice@example.com` requests a role `champion`.
 - Then pagerduty plugin **submits an approval** of Alice's request.
 
-## Install
 
-### Installing
-
-```bash
-
-# Check out the repo
-git clone https://github.com/gravitational/teleport-plugins.git
-cd teleport-plugins
-
-# Build the bot
-make access-pagerduty
-
-# Configure the plugin
-./access/pagerduty/build/teleport-pagerduty configure > teleport-pagertudy.toml
-
-# Run the plugin, assuming you have teleport running:
-./build/teleport-pagerduty start
-```
-
-The teleport-pagerduty executable should be placed onto a server that can access
-the auth server address.
-
-### Config file
+## Configuring Pagerduty Plugin
 
 Teleport Pagerduty plugin has its own configuration file in TOML format. Before
 starting the plugin for the first time, you'll need to generate and edit that
 config file.
 
 ```bash
-teleport-pagerduty configure > /etc/teleport-pagerduty.toml
+$ teleport-pagerduty configure > /etc/teleport-pagerduty.toml
 ```
 
-#### Editing the config file
-
-Afger generating the config, edit it as follows:
+Then, edit the config as needed.
 
 ```TOML
 # example teleport-pagerduty configuration TOML file
@@ -202,11 +220,17 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 ```
 
-### Running the plugin
-
-```
-teleport-pagerduty start
-```
+## Running the plugin
 
 By default, `teleport-pagerduty` will assume it's config is in
 `/etc/teleport-pagerduty.toml`, but you can override it with `--config` option.
+
+```
+$ teleport-pagerduty start
+```
+
+or with docker:
+
+```bash
+$ docker run -v <path/to/config>:/etc/teleport-pagerduty.toml quay.io/gravitational/access-plugin-pagerduty:9.0.2 start
+```

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -73,7 +73,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 ### User

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -87,40 +87,6 @@ spec:
 version: v2
 ```
 
-#### Export access-plugin Certificate
-
-Teleport Plugin uses the `access-plugin`role and user to perform the approval.
-We export the identify files, using
-[`tctl auth sign`](https://goteleport.com/teleport/docs/cli-docs/#tctl-auth-sign).
-
-```
-$ tctl auth sign --format=tls --user=access-plugin --out=auth --ttl=8760h
-# ...
-```
-
-The above sequence should result in three PEM encoded files being generated:
-auth.crt, auth.key, and auth.cas (certificate, private key, and CA certs
-respectively). We'll reference these later in the Pagerduty integration config
-file.
-
-_Note: by default, tctl auth sign produces certificates with a relatively short
-lifetime. For production deployments, the --ttl flag can be used to ensure a
-more practical certificate lifetime. --ttl=8760h exports a 1 year token_
-
-#### Export access-plugin Certificate for use with Teleport Cloud
-
-Connection to Teleport Cloud is only possible with reverse tunnel. For this reason,
-we need the identity signed in a different format called `file` which exports
-SSH keys too.
-
-```bash
-$ tctl auth sign --auth-server=yourproxy.teleport.sh:443 --format=file --user=access-plugin --out=auth --ttl=8760h
-# ...
-```
-
-
-
-
 ## Generate the certificate
 
 For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -69,7 +69,7 @@ spec:
     rules:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
-version: v4
+version: v5
 ```
 
 ### User

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -43,7 +43,7 @@ For a list of available tags, visit [https://quay.io/](https://quay.io/repositor
 
 ### Building from source
 
-To build the plugin from source you need Go >= 1.16 and `make`.
+To build the plugin from source you need [Go](https://go.dev/) and `make`.
 
 ```bash
 $ git clone https://github.com/gravitational/teleport-plugins.git

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -1,19 +1,163 @@
 # Teleport Slack Plugin
 
-This package implements a simple Slack plugin using the API provided in the
-[`access`](../) package which notifies about Access Requests via Slack
-messages.
+This package implements a simple Slack plugin using the Teleport Access API. A slack channel receives an alert when an access request is created.
 
 ## Setup
 
 [See setup instructions on Teleport's website](https://goteleport.com/teleport/docs/enterprise/workflow/ssh_approval_slack/)
 
-You must have Go version 1.15 or higher to build.
-
-Run `make access-slack` from the repository root to build the slack plugin. Then
-you can find it in `./access/slack/build/teleport-slack`.
-
 Detailed install steps are provided in our [docs](https://goteleport.com/docs/enterprise/workflow/ssh-approval-slack/).
+
+## Install the plugin
+
+There are several methods to installing and using the Teleport Slack Plugin:
+
+1. Use a [precompiled binary](#precompiled-binary)
+
+2. Use a [docker image](#docker-image)
+
+3. Install from [source](#building-from-source)
+
+### Precompiled Binary
+
+Get the plugin distribution.
+
+```bash
+$ curl -L https://get.gravitational.com/teleport-access-slack-v7.0.2-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-slack-v7.0.2-linux-amd64-bin.tar.gz
+$ cd teleport-access-slack
+$ ./install
+```
+
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/access-plugin-slack:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/access-plugin-slack:9.0.2 version
+teleport-slack v9.0.2 git:teleport-slack-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-slack?tab=tags)
+
+### Building from source
+
+To build the plugin from source you need Go >= 1.16 and `make`.
+
+```bash
+$ git clone https://github.com/gravitational/teleport-plugins.git
+$ cd teleport-plugins/access/slack
+$ make
+$ ./build/teleport-slack start
+```
+
+
+
+## Teleport User and Role
+
+Using Web UI or `tctl` CLI utility, create the role `access-slack` and the user `access-slack` belonging to the role `access-slack`. You may use the following YAML declarations.
+
+### Role
+
+```yaml
+kind: role
+metadata:
+  name: access-slack
+spec:
+  allow:
+    rules:
+      - resources: ['access_request']
+        verbs: ['list', 'read', 'update']
+version: v4
+```
+
+### User
+
+```yaml
+kind: user
+metadata:
+  name: access-slack
+spec:
+  roles: ['access-slack']
+version: v2
+```
+
+## Generate the certificate
+
+For the plugin to connect to Auth Server, it needs an identity file containing TLS/SSH certificates. This can be obtained with tctl:
+
+```bash
+$ tctl auth sign --auth-server=AUTH-SERVER:PORT --format=file --user=access-slack --out=/var/lib/teleport/plugins/slack/auth_id --ttl=8760h
+```
+
+Here, `AUTH-SERVER:PORT` could be `localhost:3025`, `your-in-cluster-auth.example.com:3025`, `your-remote-proxy.example.com:3080` or `your-teleport-cloud.teleport.sh:443`. For non-localhost connections, you might want to pass the `--identity=...` option to authenticate yourself to Auth Server.
+
+## Configuring Slack Plugin
+
+Slack Plugin uses a config file in TOML format. Generate a boilerplate config
+by running the following command:
+
+```
+$ teleport-slack configure > /etc/teleport-slack.yml
+```
+
+Then, edit the config as needed.
+
+```TOML
+# Example slack plugin configuration TOML file
+
+[teleport]
+# This section 
+
+# Teleport Auth/Proxy Server address.
+# addr = "example.com:3025"
+#
+# Should be port 3025 for Auth Server and 3080 or 443 for Proxy.
+# For Teleport Cloud, should be in the form "your-account.teleport.sh:443".
+
+# Credentials generated with `tctl auth sign`.
+#
+# When using --format=file:
+# identity = "/var/lib/teleport/plugins/slack/auth_id"    # Identity file
+#
+# When using --format=tls:
+# client_key = "/var/lib/teleport/plugins/slack/auth.key" # Teleport TLS secret key
+# client_crt = "/var/lib/teleport/plugins/slack/auth.crt" # Teleport TLS certificate
+# root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport CA certs
+
+[slack]
+# Slack Bot OAuth token
+token = "xoxb-11xx"
+
+[role_to_recipients]
+# Map roles to recipients.
+#
+# Provide slack user_email/channel recipients for access requests for specific roles. 
+# role.suggested_reviewers will automatically be treated as additional email recipients.
+# "*" must be provided to match non-specified roles.
+#
+# "dev" = "devs-slack-channel"
+# "*" = ["admin@email.com", "admin-slack-channel"]
+
+[log]
+output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/slack.log"
+severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+```
+
+## Running the plugin
+
+With the config above, you should be able to run the bot invoking
+
+```bash
+$ teleport-slack start
+```
+
+or with docker:
+
+```bash
+$ docker run -v <path/to/config>:/etc/teleport-slack.toml quay.io/gravitational/access-plugin-slack:9.0.2 start
+```
 
 ## Usage
 

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -108,8 +108,6 @@ Then, edit the config as needed.
 # Example slack plugin configuration TOML file
 
 [teleport]
-# This section 
-
 # Teleport Auth/Proxy Server address.
 # addr = "example.com:3025"
 #

--- a/access/slack/example_config.toml
+++ b/access/slack/example_config.toml
@@ -1,8 +1,6 @@
 # Example slack plugin configuration TOML file
 
 [teleport]
-# This section 
-
 # Teleport Auth/Proxy Server address.
 # addr = "example.com:3025"
 #

--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -121,7 +121,7 @@ spec:
     rules:
       - resources: ['event','session']
         verbs: ['list','read']
-version: v4
+version: v5
 ```
 
 It defines `teleport-event-handler` role and user which has read-only access to the `event` API.

--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -13,18 +13,47 @@ This guide assumes that you have:
 
 The required Fluentd version for production setup is v1.12.4 or newer. Lower versions do not support TLS.
 
-## Installing the plugin
+## Install the plugin
 
-We recommend installing the Teleport Plugins alongside the Teleport Proxy. This is an ideal location as plugins have a low memory footprint, and will require both public internet access and Teleport Auth access. We currently only provide linux-amd64 binaries, you can also compile these plugins from source.
+There are several methods to installing and using the Teleport Event Handler Plugin:
 
-### Install the plugin from source
+1. Use a [precompiled binary](#precompiled-binary)
+
+2. Use a [docker image](#docker-image)
+
+3. Install from [source](#building-from-source)
+
+### Precompiled Binary
+
+Get the plugin distribution.
+
+```bash
+$ curl -L https://get.gravitational.com/teleport-event-handler-v7.0.2-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-event-handler-v7.0.2-linux-amd64-bin.tar.gz
+$ cd teleport-event-handler
+$ ./install
+```
+
+### Docker Image
+```bash
+$ docker pull quay.io/gravitational/event-handler-plugin:9.0.2
+```
+
+```bash
+$ docker run quay.io/gravitational/event-handler-plugin:9.0.2 version
+Teleport event handler v9.0.2 git:teleport-event-handler-v9.0.2-0-g9e149895 go1.17.8
+```
+
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/event-handler-plugin?tab=tags)
+
+### Building from source
 
 Please ensure that Docker is running!
 
 ```sh
-git clone https://github.com/gravitational/teleport-plugins.git --depth 1
-cd teleport-plugins/event-handler/build.assets
-make install
+$ git clone https://github.com/gravitational/teleport-plugins.git --depth 1
+$ cd teleport-plugins/event-handler/build.assets
+$ make install
 ```
 
 This command will build `build/teleport-event-handler` executable and place it to `/usr/local/bin` folder. The following error means that you do not have write permissions on target folder:
@@ -36,45 +65,43 @@ cp: /usr/local/bin/teleport-event-handler: Operation not permitted
 To fix this, you can either set target folder to something listed in your `$PATH`:
 
 ```sh
-make install BINDIR=/tmp/test-fluentd-setup
+$ make install BINDIR=/tmp/test-fluentd-setup
 ```
 
 or copy binary file manually with `sudo`:
 
 ```sh
-sudo cp build/teleport-event-handler /usr/local/bin
+$ sudo cp build/teleport-event-handler /usr/local/bin
 ```
-
-In sections below we assume that you have `teleport-event-handler` executable available in your `$PATH` or cwd.
 
 ## Generate example configuration
 
 Run:
 
 ```sh
-teleport-event-handler configure .
+$ teleport-event-handler configure .
 ```
 
 You'll see the following output:
 
 ```sh
-Teleport event handler 0.0.1 07617b0ad0829db043fe779faf1669defdc8d84e
+Teleport event handler 9.0.2 teleport-event-handler-v9.0.2-0-g9e149895
 
-[1] mTLS Fluentd certificates generated and saved to ca.crt, ca.key, server.crt, server.key, client.crt, client.key
+[1] Generated mTLS Fluentd certificates ca.crt, ca.key, server.crt, server.key, client.crt, client.key
 [2] Generated sample teleport-event-handler role and user file teleport-event-handler-role.yaml
 [3] Generated sample fluentd configuration file fluent.conf
 [4] Generated plugin configuration file teleport-event-handler.toml
 
 Follow-along with our getting started guide:
 
-https://goteleport.com/setup/guides/fluentd
+https://goteleport.com/docs/setup/guides/fluentd
 ```
 
 Where `ca.crt` and `ca.key` would be Fluentd self-signed CA certificate and private key, `server.crt` and `server.key` would be fluentd server certificate and key, `client.crt` and `client.key` would be Fluentd client certificate and key, all signed by the generated CA.
 
 Check ```teleport-event-handler configure --help``` usage instructions. You may set several configuration options, including key/cert file names, server key encryption password and Teleport auth proxy address.
 
-### Create user and role for access audit log events
+## Create user and role for access audit log events
 
 The generated `teleport-event-handler-role.yaml` would contain the following content:
 
@@ -105,7 +132,7 @@ Log into Teleport Authentication Server, this is where you normally run `tctl`. 
 tctl create -f teleport-event-handler-role.yaml
 ```
 
-### <a name="export"></a>Export teleport-event-handler identity file
+## <a name="export"></a>Export teleport-event-handler identity file
 
 Teleport Plugin use the fluentd role and user to read the events. We export the identity files, using tctl auth sign.
 
@@ -115,7 +142,7 @@ tctl auth sign --out identity --user teleport-event-handler
 
 This will generate `identity` which contains TLS certificates and will be used to connect plugin to your Teleport instance.
 
-### Run fluentd
+## Run fluentd
 
 The plugin will send events to the fluentd instance using keys generated on the previous step. Generated `fluent.conf` file would contain the following content:
 
@@ -161,7 +188,7 @@ Start fluentd instance:
 docker run -p 8888:8888 -v $(pwd):/keys -v $(pwd)/fluent.conf:/fluentd/etc/fluent.conf fluent/fluentd:edge 
 ```
 
-### Configure the plugin
+## Configure the plugin
 
 The generated `teleport-event-handler.toml` would contain the following plugin configuration:
 
@@ -183,10 +210,16 @@ addr = "localhost:3025" # Default local Teleport instance address
 identity = "identity"   # Identity file exported on previous step
 ```
 
-### Start the plugin
+## Start the plugin
 
 ```sh
-teleport-event-handler start --config teleport-event-handler.toml --start-time 2021-01-01T00:00:00Z
+$ teleport-event-handler start --config teleport-event-handler.toml --start-time 2021-01-01T00:00:00Z
+```
+
+or with docker:
+
+```sh
+$ docker run -v </path/to/config>:/etc/teleport-event-handler quay.io/gravitational/event-handler-plugin:9.0.2 start --config /etc/teleport-event-handler/teleport-event-handler.toml --start-time 2021-01-01T00:00:00Z
 ```
 
 Note that here we used start time at the beginning of year 2021. Supposedly you have some events at the Teleport instance you are connecting to. Otherwise, you can omit `--start-time` flag, start the service and generate an events using `tctl create -f teleport-event-handler.yaml` then from the first step. `teleport-event-handler` will wait for that new events to appear and will send them to the fluentd.
@@ -263,13 +296,13 @@ You could use `--dry-run` argument if you want event handler to simulate event e
 ### Login to Teleport cloud:
 
 ```sh
- tsh login --proxy test.teleport.sh:443 --user test@evilmartians.com
- ```
+$ tsh login --proxy test.teleport.sh:443 --user test@evilmartians.com
+```
 
 ### Generate sample configuration using the cloud address:
 
 ```sh
-teleport-event-handler configure . test.teleport.sh:443
+$ teleport-event-handler configure . test.teleport.sh:443
 ```
 
 Then follow the manual starting at ["Export teleport-event-handler identity file"](#export) section.


### PR DESCRIPTION
This PR contains general documentation improvements as well as information on how to find and run teleport plugins docker images. This is a part of https://github.com/gravitational/teleport-plugins/issues/438

There are now three documented methods of installing the teleport-plugins:
1. Install from release
2. Docker images
3. Build from source

All three of these methods are documented in each plugin repository. 

Documentation has been added also on running the plugin both with local binary as well as with the docker images. 

## Testing
I tested that the docker image links provided throughout the documentation worked such that someone could copy and paste the image name from the documentation. 

However, I did not test that the plugin still works. 