### PR TITLE
TF test: session rec must check host

### DIFF
--- a/terraform/test/fixtures/session_recording_config_0_set.tf
+++ b/terraform/test/fixtures/session_recording_config_0_set.tf
@@ -7,6 +7,7 @@ resource "teleport_session_recording_config" "test" {
     }
                     
     spec = {
+        mode = "node"
         proxy_checks_host_keys = true
     }		
 }

--- a/terraform/test/fixtures/session_recording_config_1_update.tf
+++ b/terraform/test/fixtures/session_recording_config_1_update.tf
@@ -7,6 +7,7 @@ resource "teleport_session_recording_config" "test" {
     }
                     
     spec = {
-        proxy_checks_host_keys = false
+        mode = "off"
+        proxy_checks_host_keys = true
     }
 }

--- a/terraform/test/session_recording_config_test.go
+++ b/terraform/test/session_recording_config_test.go
@@ -34,7 +34,7 @@ func (s *TerraformSuite) TestSessionRecordingConfig() {
 				Config: s.getFixture("session_recording_config_0_set.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "kind", "session_recording_config"),
-					resource.TestCheckResourceAttr(name, "spec.proxy_checks_host_keys", "true"),
+					resource.TestCheckResourceAttr(name, "spec.mode", "node"),
 				),
 			},
 			{
@@ -45,7 +45,7 @@ func (s *TerraformSuite) TestSessionRecordingConfig() {
 				Config: s.getFixture("session_recording_config_1_update.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "kind", "session_recording_config"),
-					resource.TestCheckResourceAttr(name, "spec.proxy_checks_host_keys", "false"),
+					resource.TestCheckResourceAttr(name, "spec.mode", "off"),
 				),
 			},
 			{
@@ -64,7 +64,7 @@ func (s *TerraformSuite) TestImportSessionRecordingConfig() {
 	sessionrRecordingConfig := &types.SessionRecordingConfigV2{
 		Metadata: types.Metadata{},
 		Spec: types.SessionRecordingConfigSpecV2{
-			ProxyChecksHostKeys: types.NewBoolOption(true),
+			Mode: "off",
 		},
 	}
 	err := sessionrRecordingConfig.CheckAndSetDefaults()
@@ -83,7 +83,7 @@ func (s *TerraformSuite) TestImportSessionRecordingConfig() {
 				ImportStateId: id,
 				ImportStateCheck: func(state []*terraform.InstanceState) error {
 					require.Equal(s.T(), state[0].Attributes["kind"], "session_recording_config")
-					require.Equal(s.T(), state[0].Attributes["spec.proxy_checks_host_keys"], "true")
+					require.Equal(s.T(), state[0].Attributes["spec.mode"], "off")
 
 					return nil
 				},

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -26,7 +26,6 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
-	_ "github.com/golang/protobuf/ptypes/timestamp"
 	github_com_gravitational_teleport_api_constants "github.com/gravitational/teleport/api/constants"
 	github_com_gravitational_teleport_api_types "github.com/gravitational/teleport/api/types"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
@@ -34,6 +33,7 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1578,7 +1578,7 @@ func GenSchemaRoleV5(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Optional:      true,
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 4)},
+			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 5)},
 		},
 	}}, nil
 }
@@ -1863,7 +1863,7 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:      true,
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
 		},
 	}}, nil
 }


### PR DESCRIPTION
We had a test validating the change of a variable in SessionRecordingConfig
However, this variable must always be true when we are running the
enterprise (or cloud) version

https://github.com/gravitational/teleport/blob/809e60c318cf98207f0db40795faff5020baaa07/lib/modules/modules.go#L132

We ended up changing the test's target to another variable which should
be just as good as the current one: recording mode.

This way we can use either the enterprise or the OSS version and the
test should pass