### PR TITLE
Add role_to_recipients to access email plugin

### DIFF
--- a/access/Dockerfile
+++ b/access/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy the go source
 COPY access/${ACCESS_PLUGIN} access/${ACCESS_PLUGIN}
+COPY access/config access/config
 COPY lib lib
 
 # Build

--- a/access/config/recipients_map.go
+++ b/access/config/recipients_map.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2022 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package config
 

--- a/access/config/recipients_map.go
+++ b/access/config/recipients_map.go
@@ -1,3 +1,18 @@
+/*
+   Copyright 2022 Gravitational, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package config
 
 import "fmt"
@@ -5,6 +20,10 @@ import "fmt"
 // RecipientsMap is a mapping of roles to recipient(s).
 type RecipientsMap map[string][]string
 
+// UnmarshalTOML will convert the input into map[string][]string
+// The input can be one of the following:
+// "key" = "value"
+// "key" = ["multiple", "values"]
 func (r *RecipientsMap) UnmarshalTOML(in interface{}) error {
 	*r = make(RecipientsMap)
 

--- a/access/config/recipients_map.go
+++ b/access/config/recipients_map.go
@@ -1,0 +1,34 @@
+package config
+
+import "fmt"
+
+// RecipientsMap is a mapping of roles to recipient(s).
+type RecipientsMap map[string][]string
+
+func (r *RecipientsMap) UnmarshalTOML(in interface{}) error {
+	*r = make(RecipientsMap)
+
+	recipientsMap, ok := in.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected type for recipients %T", in)
+	}
+
+	for k, v := range recipientsMap {
+		switch val := v.(type) {
+		case string:
+			(*r)[k] = []string{val}
+		case []interface{}:
+			for _, str := range val {
+				str, ok := str.(string)
+				if !ok {
+					return fmt.Errorf("unexpected type for recipients value %T", v)
+				}
+				(*r)[k] = append((*r)[k], str)
+			}
+		default:
+			return fmt.Errorf("unexpected type for recipients value %T", v)
+		}
+	}
+
+	return nil
+}

--- a/access/config/recipients_map.go
+++ b/access/config/recipients_map.go
@@ -15,7 +15,12 @@ limitations under the License.
 */
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport-plugins/lib/stringset"
+	"github.com/gravitational/teleport/api/types"
+)
 
 // RecipientsMap is a mapping of roles to recipient(s).
 type RecipientsMap map[string][]string
@@ -50,4 +55,21 @@ func (r *RecipientsMap) UnmarshalTOML(in interface{}) error {
 	}
 
 	return nil
+}
+
+func (r RecipientsMap) GetRecipientsFor(roles, suggestedReviewers []string) []string {
+	recipients := stringset.New()
+
+	for _, role := range roles {
+		roleRecipients := r[role]
+		if len(roleRecipients) == 0 {
+			roleRecipients = r[types.Wildcard]
+		}
+
+		recipients.Add(roleRecipients...)
+	}
+
+	recipients.Add(suggestedReviewers...)
+
+	return recipients.ToSlice()
 }

--- a/access/config/recipients_map.go
+++ b/access/config/recipients_map.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (
@@ -57,6 +58,11 @@ func (r *RecipientsMap) UnmarshalTOML(in interface{}) error {
 	return nil
 }
 
+// GetRecipientsFor will return the set of recipients given a list of roles and suggested reviewers.
+// We create a unique list based on:
+// - the list of suggestedReviewers
+// - for each role, the list of reviewers
+//   - if the role doesn't exist in the map (or it's empty), we add the list of recipients for the default role ("*") instead
 func (r RecipientsMap) GetRecipientsFor(roles, suggestedReviewers []string) []string {
 	recipients := stringset.New()
 

--- a/access/config/recipients_map_test.go
+++ b/access/config/recipients_map_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/access/config/recipients_map_test.go
+++ b/access/config/recipients_map_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2022 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package config
 

--- a/access/config/recipients_map_test.go
+++ b/access/config/recipients_map_test.go
@@ -1,3 +1,18 @@
+/*
+   Copyright 2022 Gravitational, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package config
 
 import (

--- a/access/config/recipients_map_test.go
+++ b/access/config/recipients_map_test.go
@@ -98,3 +98,50 @@ func TestRecipientsMap(t *testing.T) {
 		})
 	}
 }
+
+func TestRecipientsMapGetRecipients(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		m                  RecipientsMap
+		roles              []string
+		suggestedReviewers []string
+		output             []string
+	}{
+		{
+			desc: "test match exact role",
+			m: RecipientsMap{
+				"dev": []string{"chanDev"},
+				"*":   []string{"chanA", "chanB"},
+			},
+			roles:              []string{"dev"},
+			suggestedReviewers: []string{},
+			output:             []string{"chanDev"},
+		},
+		{
+			desc: "test only default recipient",
+			m: RecipientsMap{
+				"*": []string{"chanA", "chanB"},
+			},
+			roles:              []string{"dev"},
+			suggestedReviewers: []string{},
+			output:             []string{"chanA", "chanB"},
+		},
+		{
+			desc: "test deduplicate recipients",
+			m: RecipientsMap{
+				"dev": []string{"chanA", "chanB"},
+				"*":   []string{"chanC"},
+			},
+			roles:              []string{"dev"},
+			suggestedReviewers: []string{"chanA", "chanB"},
+			output:             []string{"chanA", "chanB"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			recipients := tc.m.GetRecipientsFor(tc.roles, tc.suggestedReviewers)
+			require.ElementsMatch(t, recipients, tc.output)
+		})
+	}
+}

--- a/access/config/recipients_map_test.go
+++ b/access/config/recipients_map_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/require"
+)
+
+type wrapRecipientsMap struct {
+	RecipientsMap RecipientsMap `toml:"role_to_recipients"`
+}
+
+func TestRecipientsMap(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		in               string
+		expectRecipients RecipientsMap
+	}{
+		{
+			desc: "test role_to_recipients multiple format",
+			in: `
+            [role_to_recipients]
+            "dev" = ["dev-channel", "admin-channel"]
+            "*" = "admin-channel"
+            `,
+			expectRecipients: RecipientsMap{
+				"dev":          []string{"dev-channel", "admin-channel"},
+				types.Wildcard: []string{"admin-channel"},
+			},
+		},
+		{
+			desc: "test role_to_recipients role to list of recipients",
+			in: `
+            [role_to_recipients]
+            "dev" = ["dev-channel", "admin-channel"]
+            "prod" = ["sre-channel", "oncall-channel"]
+            `,
+			expectRecipients: RecipientsMap{
+				"dev":  []string{"dev-channel", "admin-channel"},
+				"prod": []string{"sre-channel", "oncall-channel"},
+			},
+		},
+		{
+			desc: "test role_to_recipients role to string recipient",
+			in: `
+            [role_to_recipients]
+            "single" = "admin-channel"
+            `,
+			expectRecipients: RecipientsMap{
+				"single": []string{"admin-channel"},
+			},
+		},
+		{
+			desc: "test role_to_recipients multiple format",
+			in: `
+            [role_to_recipients]
+            "dev" = ["dev-channel", "admin-channel"]
+            "*" = "admin-channel"
+            `,
+			expectRecipients: RecipientsMap{
+				"dev":          []string{"dev-channel", "admin-channel"},
+				types.Wildcard: []string{"admin-channel"},
+			},
+		},
+		{
+			desc: "test role_to_recipients no mapping",
+			in: `
+            [role_to_recipients]
+            `,
+			expectRecipients: RecipientsMap{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := wrapRecipientsMap{}
+			err := toml.Unmarshal([]byte(tc.in), &w)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectRecipients, w.RecipientsMap)
+		})
+	}
+}

--- a/access/email/app.go
+++ b/access/email/app.go
@@ -292,7 +292,7 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 }
 
 // getEmailRecipients converts suggested reviewers to email recipients
-func (a *App) getEmailRecipients(ctx context.Context, roles []string, suggestedReviewers []string) []string {
+func (a *App) getEmailRecipients(ctx context.Context, roles, suggestedReviewers []string) []string {
 	log := logger.Get(ctx)
 	validEmailRecipients := []string{}
 

--- a/access/email/app.go
+++ b/access/email/app.go
@@ -295,9 +295,7 @@ func (a *App) onDeletedRequest(ctx context.Context, reqID string) error {
 // getEmailRecipients converts suggested reviewers to email recipients
 func (a *App) getEmailRecipients(ctx context.Context, roles []string, suggestedReviewers []string) []string {
 	log := logger.Get(ctx)
-	recipients := stringset.NewWithCap(len(suggestedReviewers) + len(a.conf.Delivery.Recipients))
-
-	recipients.Add(a.conf.Delivery.Recipients...)
+	recipients := stringset.New()
 
 	for _, role := range roles {
 		roleRecipients := a.conf.RoleToRecipients[role]

--- a/access/email/config.go
+++ b/access/email/config.go
@@ -121,7 +121,7 @@ func (c *MailgunConfig) CheckAndSetDefaults() error {
 
 	if c.PrivateKey == "" {
 		if c.PrivateKeyFile == "" {
-			return trace.BadParameter("Please, specify mailgun.private_key or mailgun.private_key_file!")
+			return trace.BadParameter("specify mailgun.private_key or mailgun.private_key_file")
 		}
 
 		c.PrivateKey, err = lib.ReadPassword(c.PrivateKeyFile)
@@ -130,14 +130,14 @@ func (c *MailgunConfig) CheckAndSetDefaults() error {
 		}
 
 		if c.PrivateKey == "" {
-			return trace.BadParameter("Please, provide mailgun.private_key or mailgun.private_key_file to use Mailgun!"+
-				"Ensure that password file %v is not empty!", c.PrivateKeyFile)
+			return trace.BadParameter("provide mailgun.private_key or mailgun.private_key_file to use Mailgun"+
+				" and ensure that password file %v is not empty", c.PrivateKeyFile)
 		}
 
 	}
 
 	if c.Domain == "" {
-		return trace.BadParameter("Please, provide mailgun.domain to use Mailgun")
+		return trace.BadParameter("provide mailgun.domain to use Mailgun")
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (c *SMTPConfig) CheckAndSetDefaults() error {
 	var err error
 
 	if c.Host == "" {
-		return trace.BadParameter("Please, provide smtp.host to use SMTP")
+		return trace.BadParameter("provide smtp.host to use SMTP")
 	}
 
 	if c.Port == 0 {
@@ -156,12 +156,12 @@ func (c *SMTPConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.Username == "" {
-		return trace.BadParameter("Please, provide smtp.username to use SMTP")
+		return trace.BadParameter("provide smtp.username to use SMTP")
 	}
 
 	if c.Password == "" {
 		if c.PasswordFile == "" {
-			return trace.BadParameter("Please, specify smtp.password or smtp.password_file!")
+			return trace.BadParameter("specify smtp.password or smtp.password_file")
 		}
 
 		c.Password, err = lib.ReadPassword(c.PasswordFile)
@@ -170,8 +170,8 @@ func (c *SMTPConfig) CheckAndSetDefaults() error {
 		}
 
 		if c.Password == "" {
-			return trace.BadParameter("Please, provide smtp.password or smtp.password_file!"+
-				"Ensure that password file %v is not empty!", c.PasswordFile)
+			return trace.BadParameter("provide smtp.password or smtp.password_file"+
+				" and ensure that password file %v is not empty", c.PasswordFile)
 		}
 	}
 
@@ -191,7 +191,7 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if len(c.Delivery.Recipients) > 0 {
 		if len(c.RoleToRecipients) > 0 {
-			return trace.BadParameter("provide either delivery.recipients or role_to_recipients, not both.")
+			return trace.BadParameter("provide either delivery.recipients or role_to_recipients, not both")
 		}
 
 		c.RoleToRecipients = config.RecipientsMap{
@@ -201,23 +201,23 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if len(c.RoleToRecipients) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients.")
+		return trace.BadParameter("missing required value role_to_recipients")
 	}
 	if len(c.RoleToRecipients[types.Wildcard]) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients[%v].", types.Wildcard)
+		return trace.BadParameter("missing required value role_to_recipients[%v]", types.Wildcard)
 	}
 
 	for role, recipientsList := range c.RoleToRecipients {
 		for _, recipient := range recipientsList {
 			if !lib.IsEmail(recipient) {
-				return trace.BadParameter("Invalid email address %v in role_to_recipients.%s", recipient, role)
+				return trace.BadParameter("invalid email address %v in role_to_recipients.%s", recipient, role)
 			}
 		}
 	}
 
 	// Validate mailer settings
 	if c.SMTP == nil && c.Mailgun == nil {
-		return trace.BadParameter("Provide either [mailgun] or [smtp] sections to work with plugin")
+		return trace.BadParameter("provide either [mailgun] or [smtp] sections to work with plugin")
 	}
 
 	// Validate Mailgun settings

--- a/access/email/config.go
+++ b/access/email/config.go
@@ -19,8 +19,10 @@ package main
 import (
 	_ "embed"
 
+	"github.com/gravitational/teleport-plugins/access/config"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
 )
@@ -50,11 +52,12 @@ type SMTPConfig struct {
 
 // Config stores the full configuration for the teleport-email plugin to run.
 type Config struct {
-	Teleport lib.TeleportConfig `toml:"teleport"`
-	Mailgun  *MailgunConfig     `toml:"mailgun"`
-	SMTP     *SMTPConfig        `toml:"smtp"`
-	Delivery DeliveryConfig     `toml:"delivery"`
-	Log      logger.Config      `toml:"log"`
+	Teleport         lib.TeleportConfig   `toml:"teleport"`
+	Mailgun          *MailgunConfig       `toml:"mailgun"`
+	SMTP             *SMTPConfig          `toml:"smtp"`
+	Delivery         DeliveryConfig       `toml:"delivery"`
+	RoleToRecipients config.RecipientsMap `toml:"role_to_recipients"`
+	Log              logger.Config        `toml:"log"`
 }
 
 // TODO: Replace auth_server with addr once it is merged
@@ -84,8 +87,11 @@ password = ""
 # password_file = "/var/lib/teleport/plugins/email/smtp_password"
 
 [delivery]
-sender = "noreply@example.com"    # From: email address
-recipients = ["person@gmail.com"] # These recipients will receive all review requests
+sender = "noreply@example.com" # From: email address
+
+[role_to_recipients]
+"dev" = "dev-manager@example.com" # All requests to 'dev' role will be sent to this address
+"*" = ["root@example.com", "admin@example.com"] # These recipients will receive review requests not handled by the roles above
 
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/email.log"
@@ -183,11 +189,36 @@ func (c *Config) CheckAndSetDefaults() error {
 		c.Log.Severity = "info"
 	}
 
+	if len(c.Delivery.Recipients) > 0 {
+		if len(c.RoleToRecipients) > 0 {
+			return trace.BadParameter("provide either delivery.recipients or role_to_recipients, not both.")
+		}
+
+		c.RoleToRecipients = config.RecipientsMap{
+			types.Wildcard: c.Delivery.Recipients,
+		}
+		c.Delivery.Recipients = nil
+	}
+
 	// Validate emails in user aliases
 	for _, e := range c.Delivery.Recipients {
 		if !lib.IsEmail(e) {
-			return trace.BadParameter("Invalid email address %v in users.recipients", e)
+			return trace.BadParameter("Invalid email address %v in delivery.recipients", e)
 		}
+	}
+
+	for role, recipientsList := range c.RoleToRecipients {
+		for _, recipient := range recipientsList {
+			if !lib.IsEmail(recipient) {
+				return trace.BadParameter("Invalid email address %v in role_to_recipients.%s", recipient, role)
+			}
+		}
+	}
+
+	if len(c.RoleToRecipients) == 0 {
+		return trace.BadParameter("missing required value role_to_recipients.")
+	} else if len(c.RoleToRecipients[types.Wildcard]) == 0 {
+		return trace.BadParameter("missing required value role_to_recipients[%v].", types.Wildcard)
 	}
 
 	// Validate mailer settings

--- a/access/email/config.go
+++ b/access/email/config.go
@@ -200,11 +200,11 @@ func (c *Config) CheckAndSetDefaults() error {
 		c.Delivery.Recipients = nil
 	}
 
-	// Validate emails in user aliases
-	for _, e := range c.Delivery.Recipients {
-		if !lib.IsEmail(e) {
-			return trace.BadParameter("Invalid email address %v in delivery.recipients", e)
-		}
+	if len(c.RoleToRecipients) == 0 {
+		return trace.BadParameter("missing required value role_to_recipients.")
+	}
+	if len(c.RoleToRecipients[types.Wildcard]) == 0 {
+		return trace.BadParameter("missing required value role_to_recipients[%v].", types.Wildcard)
 	}
 
 	for role, recipientsList := range c.RoleToRecipients {
@@ -213,12 +213,6 @@ func (c *Config) CheckAndSetDefaults() error {
 				return trace.BadParameter("Invalid email address %v in role_to_recipients.%s", recipient, role)
 			}
 		}
-	}
-
-	if len(c.RoleToRecipients) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients.")
-	} else if len(c.RoleToRecipients[types.Wildcard]) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients[%v].", types.Wildcard)
 	}
 
 	// Validate mailer settings

--- a/access/email/config_test.go
+++ b/access/email/config_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/teleport-plugins/access/config"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecipients(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		in               string
+		expectErr        require.ErrorAssertionFunc
+		expectRecipients config.RecipientsMap
+	}{
+		{
+			desc: "test delivery recipients",
+			in: `
+            [mailgun]
+            domain = "x"
+            private_key = "y"
+            [delivery]
+            sender = "email@example.org"
+			recipients = ["email1@example.org","email2@example.org"]
+			`,
+			expectRecipients: config.RecipientsMap{
+				types.Wildcard: []string{"email1@example.org", "email2@example.org"},
+			},
+		},
+		{
+			desc: "test role_to_recipients",
+			in: `
+            [mailgun]
+            domain = "x"
+            private_key = "y"
+            [delivery]
+            sender = "email@example.org"
+
+			[role_to_recipients]
+			"dev" = ["dev@example.org","sre@example.org"]
+			"*" = "admin@example.org"
+			`,
+			expectRecipients: config.RecipientsMap{
+				"dev":          []string{"dev@example.org", "sre@example.org"},
+				types.Wildcard: []string{"admin@example.org"},
+			},
+		},
+		{
+			desc: "test role_to_recipients but no wildcard",
+			in: `
+            [mailgun]
+            domain = "x"
+            private_key = "y"
+            [delivery]
+            sender = "email@example.org"
+
+			[role_to_recipients]
+			"dev" = ["dev@example.org","sre@example.org"]
+			`,
+			expectErr: func(tt require.TestingT, e error, i ...interface{}) {
+				require.Error(t, e)
+				require.True(t, trace.IsBadParameter(e))
+			},
+		},
+		{
+			desc: "test role_to_recipients with wildcard but empty list of recipients",
+			in: `
+            [mailgun]
+            domain = "x"
+            private_key = "y"
+            [delivery]
+            sender = "email@example.org"
+
+			[role_to_recipients]
+            "dev" = "email@example.org"
+			"*" = []
+			`,
+			expectErr: func(tt require.TestingT, e error, i ...interface{}) {
+				require.Error(t, e)
+				require.True(t, trace.IsBadParameter(e))
+			},
+		},
+		{
+			desc: "test no recipients or role_to_recipients",
+			in: `
+            [mailgun]
+            domain = "x"
+            private_key = "y"
+            [delivery]
+            sender = "email@example.org"
+			`,
+			expectErr: func(tt require.TestingT, e error, i ...interface{}) {
+				require.Error(t, e)
+				require.True(t, trace.IsBadParameter(e))
+			},
+		},
+		{
+			desc: "test recipients and role_to_recipients",
+			in: `
+			[slack]
+			token = "token"
+			recipients = ["dev@example.org","admin@example.org"]
+
+			[role_to_recipients]
+			"dev" = ["dev@example.org","admin@example.org"]
+			"*" = "admin@example.org"
+			`,
+			expectErr: func(tt require.TestingT, e error, i ...interface{}) {
+				require.Error(t, e)
+				require.True(t, trace.IsBadParameter(e))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "config_test.toml")
+			err := os.WriteFile(filePath, []byte(tc.in), 0777)
+			require.NoError(t, err)
+
+			c, err := LoadConfig(filePath)
+			if tc.expectErr != nil {
+				tc.expectErr(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectRecipients, c.RoleToRecipients)
+		})
+	}
+}

--- a/access/email/config_test.go
+++ b/access/email/config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/access/email/email_test.go
+++ b/access/email/email_test.go
@@ -200,7 +200,7 @@ func (s *EmailSuite) SetupTest() {
 	}
 	conf.Delivery.Sender = sender
 	conf.RoleToRecipients = map[string][]string{
-		types.Wildcard: []string{allRecipient},
+		types.Wildcard: {allRecipient},
 	}
 
 	s.appConfig = conf

--- a/access/email/email_test.go
+++ b/access/email/email_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/access/email/email_test.go
+++ b/access/email/email_test.go
@@ -199,7 +199,9 @@ func (s *EmailSuite) SetupTest() {
 		APIBase:    s.mockMailgun.GetURL(),
 	}
 	conf.Delivery.Sender = sender
-	conf.Delivery.Recipients = []string{allRecipient}
+	conf.RoleToRecipients = map[string][]string{
+		types.Wildcard: []string{allRecipient},
+	}
 
 	s.appConfig = conf
 	s.SetContextTimeout(5 * time.Minute)

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -365,8 +365,8 @@ func (a *App) tryLookupDirectChannelByEmail(ctx context.Context, userEmail strin
 func (a *App) getMessageRecipients(ctx context.Context, req types.AccessRequest) []string {
 	log := logger.Get(ctx)
 
-	// We receive a set from the method above but we still might end up with duplicate channel names
-	// This can happen if this set contains the channel `C` and the email for channel `C`
+	// We receive a set from GetRecipientsFor but we still might end up with duplicate channel names.
+	// This can happen if this set contains the channel `C` and the email for channel `C`.
 	channelSet := stringset.New()
 
 	validEmaislSuggReviewers := []string{}

--- a/access/slack/config_test.go
+++ b/access/slack/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gravitational/teleport-plugins/access/config"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ func TestRecipients(t *testing.T) {
 		desc             string
 		in               string
 		expectErr        require.ErrorAssertionFunc
-		expectRecipients RecipientsMap
+		expectRecipients config.RecipientsMap
 	}{
 		{
 			desc: "test recipients",
@@ -24,7 +25,7 @@ func TestRecipients(t *testing.T) {
 			token = "token"
 			recipients = ["dev-channel","admin-channel"]
 			`,
-			expectRecipients: RecipientsMap{
+			expectRecipients: config.RecipientsMap{
 				types.Wildcard: []string{"dev-channel", "admin-channel"},
 			},
 		},
@@ -38,7 +39,7 @@ func TestRecipients(t *testing.T) {
 			"dev" = ["dev-channel","admin-channel"]
 			"*" = "admin-channel"
 			`,
-			expectRecipients: RecipientsMap{
+			expectRecipients: config.RecipientsMap{
 				"dev":          []string{"dev-channel", "admin-channel"},
 				types.Wildcard: []string{"admin-channel"},
 			},

--- a/access/slack/slack_test.go
+++ b/access/slack/slack_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/gravitational/teleport-plugins/access/config"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	. "github.com/gravitational/teleport-plugins/lib/testing"
@@ -302,7 +303,7 @@ func (s *SlackSuite) TestRecipientsConfig() {
 
 	reviewer1 := s.fakeSlack.StoreUser(User{Profile: UserProfile{Email: s.userNames.reviewer1}})
 	reviewer2 := s.fakeSlack.StoreUser(User{Profile: UserProfile{Email: s.userNames.reviewer2}})
-	s.appConfig.Recipients = RecipientsMap{
+	s.appConfig.Recipients = config.RecipientsMap{
 		types.Wildcard: []string{reviewer2.Profile.Email, reviewer1.ID},
 	}
 


### PR DESCRIPTION
This PR adds the role_to_recipients capability to the access email plugin.

This feature allows the plugin to send emails to different recipients based on
the specific roles.

You can now use the following configuration

**Usage**
```toml
 # other settings
[delivery]
sender = "noreply@example.com"
 # recipients is deprecated
 # cannot be used at the same time as `role_to_recipients`

[role_to_recipients]
"dev" = "devs@example.org" # either an email or list of emails
"*" = ["admin@email.com"] # default list of recipients if not matched above
```

Relevant PR with the same functionality but for the slack plugin
https://github.com/gravitational/teleport-plugins/pull/433

Fixes https://github.com/gravitational/teleport-plugins/issues/465