### PR TITLE
Update OCI image names 

### DIFF
--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -16,8 +16,8 @@ RELEASE=$(RELEASE_NAME)-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
-DOCKER_NAME = access-plugin-email
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME = teleport-plugin-email
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=email --build-arg GITREF=$(GITREF)
 

--- a/access/email/README.md
+++ b/access/email/README.md
@@ -23,15 +23,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/access-plugin-email:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-email:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/access-plugin-email:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-email:9.0.2 version
 teleport-email v9.0.2 git:teleport-email-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-email?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-email?tab=tags)
 
 ### Building from source
 
@@ -126,7 +126,7 @@ $ teleport-email start
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:/etc/teleport-email.toml quay.io/gravitational/access-plugin-email:9.0.2 start
+$ docker run -v <path/to/config>:/etc/teleport-email.toml quay.io/gravitational/teleport-plugin-email:9.0.2 start
 ```
 
 If something bad happens, try to run it with `-d` option i.e. `teleport-email start -d` and attach the stdout output to the issue you are going to create.

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -16,8 +16,8 @@ RELEASE=$(RELEASE_NAME)-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
-DOCKER_NAME = access-plugin-jira
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME = teleport-plugin-jira
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=jira --build-arg GITREF=$(GITREF)
 

--- a/access/jira/README.md
+++ b/access/jira/README.md
@@ -27,15 +27,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/access-plugin-jira:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-jira:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/access-plugin-jira:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-jira:9.0.2 version
 teleport-jira v9.0.2 git:teleport-jira-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-jira?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-jira?tab=tags)
 
 ### Building from source
 
@@ -153,7 +153,7 @@ $ teleport-jira start
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:/etc/teleport-jira.toml quay.io/gravitational/access-plugin-jira:9.0.2 start
+$ docker run -v <path/to/config>:/etc/teleport-jira.toml quay.io/gravitational/teleport-plugin-jira:9.0.2 start
 ```
 
 If something bad happens, try to run it with `-d` option i.e. `teleport-jira start -d` and attach the stdout output to the issue you are going to create.

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -16,8 +16,8 @@ RELEASE=$(RELEASE_NAME)-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
-DOCKER_NAME=access-plugin-mattermost
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME = teleport-plugin-mattermost
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=mattermost --build-arg GITREF=$(GITREF)
 

--- a/access/mattermost/README.md
+++ b/access/mattermost/README.md
@@ -36,15 +36,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/access-plugin-mattermost:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-mattermost:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/access-plugin-mattermost:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-mattermost:9.0.2 version
 teleport-mattermost v9.0.2 git:teleport-mattermost-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-mattermost?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-mattermost?tab=tags)
 
 ### Building from source
 
@@ -171,7 +171,7 @@ $ teleport-mattermost start
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:/etc/teleport-mattermost.toml quay.io/gravitational/access-plugin-mattermost:9.0.2 start
+$ docker run -v <path/to/config>:/etc/teleport-mattermost.toml quay.io/gravitational/teleport-plugin-mattermost:9.0.2 start
 ```
 
 ## The Workflow

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -16,8 +16,8 @@ RELEASE=$(RELEASE_NAME)-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
-DOCKER_NAME=access-plugin-pagerduty
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME = teleport-plugin-pagerduty
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=pagerduty --build-arg GITREF=$(GITREF)
 

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -37,15 +37,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/access-plugin-pagerduty:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-pagerduty:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/access-plugin-pagerduty:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-pagerduty:9.0.2 version
 teleport-pagerduty v9.0.2 git:teleport-pagerduty-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-pagerduty?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-pagerduty?tab=tags)
 
 ### Building from source
 
@@ -198,5 +198,5 @@ $ teleport-pagerduty start
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:/etc/teleport-pagerduty.toml quay.io/gravitational/access-plugin-pagerduty:9.0.2 start
+$ docker run -v <path/to/config>:/etc/teleport-pagerduty.toml quay.io/gravitational/teleport-plugin-pagerduty:9.0.2 start
 ```

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -16,8 +16,8 @@ RELEASE=$(RELEASE_NAME)-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
-DOCKER_NAME=access-plugin-slack
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME = teleport-plugin-slack
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=slack --build-arg GITREF=$(GITREF)
 

--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -31,15 +31,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/access-plugin-slack:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-slack:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/access-plugin-slack:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-slack:9.0.2 version
 teleport-slack v9.0.2 git:teleport-slack-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/access-plugin-slack?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-slack?tab=tags)
 
 ### Building from source
 
@@ -154,7 +154,7 @@ $ teleport-slack start
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:/etc/teleport-slack.toml quay.io/gravitational/access-plugin-slack:9.0.2 start
+$ docker run -v <path/to/config>:/etc/teleport-slack.toml quay.io/gravitational/teleport-plugin-slack:9.0.2 start
 ```
 
 ## Usage

--- a/charts/access/email/Chart.yaml
+++ b/charts/access/email/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: access-plugin-email
+name: teleport-plugin-email
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -23,10 +23,10 @@ should match the snapshot (mailgun on):
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: access-plugin-email
+        app.kubernetes.io/name: teleport-plugin-email
         app.kubernetes.io/version: 9.0.0
-        helm.sh/chart: access-plugin-email-1.0.0
-      name: RELEASE-NAME-access-plugin-email
+        helm.sh/chart: teleport-plugin-email-1.0.0
+      name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
     apiVersion: v1
@@ -55,10 +55,10 @@ should match the snapshot (smtp on):
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: access-plugin-email
+        app.kubernetes.io/name: teleport-plugin-email
         app.kubernetes.io/version: 9.0.0
-        helm.sh/chart: access-plugin-email-1.0.0
-      name: RELEASE-NAME-access-plugin-email
+        helm.sh/chart: teleport-plugin-email-1.0.0
+      name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
     apiVersion: v1
@@ -87,7 +87,7 @@ should match the snapshot (smtp on, password file):
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: access-plugin-email
+        app.kubernetes.io/name: teleport-plugin-email
         app.kubernetes.io/version: 9.0.0
-        helm.sh/chart: access-plugin-email-1.0.0
-      name: RELEASE-NAME-access-plugin-email
+        helm.sh/chart: teleport-plugin-email-1.0.0
+      name: RELEASE-NAME-teleport-plugin-email

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -6,21 +6,21 @@ should match the snapshot:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: access-plugin-email
+        app.kubernetes.io/name: teleport-plugin-email
         app.kubernetes.io/version: 9.0.0
-        helm.sh/chart: access-plugin-email-1.0.0
-      name: RELEASE-NAME-access-plugin-email
+        helm.sh/chart: teleport-plugin-email-1.0.0
+      name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: access-plugin-email
+          app.kubernetes.io/name: teleport-plugin-email
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: access-plugin-email
+            app.kubernetes.io/name: teleport-plugin-email
         spec:
           containers:
           - command:
@@ -30,7 +30,7 @@ should match the snapshot:
             - /etc/teleport-email.toml
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
-            name: access-plugin-email
+            name: teleport-plugin-email
             ports:
             - containerPort: 80
               name: http
@@ -48,7 +48,7 @@ should match the snapshot:
           volumes:
           - configMap:
               defaultMode: 384
-              name: RELEASE-NAME-access-plugin-email
+              name: RELEASE-NAME-teleport-plugin-email
             name: config
           - name: auth-id
             secret:

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -26,7 +26,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/access-plugin-email",
+                    "repository": "146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-plugin-email",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -40,9 +40,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/access-plugin-email",
+                    "default": "146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-plugin-email",
                     "examples": [
-                        "146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/access-plugin-email"
+                        "146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-plugin-email"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -5,7 +5,7 @@
 # replicaCount: 1
 
 image:
-  repository: 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/access-plugin-email
+  repository: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-plugin-email
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -22,8 +22,8 @@ KEYLEN = 1024
 CLOUD_ADDR=evilmartians.teleport.sh:443
 IDENTITY_FILE=example/keys/identity
 
-DOCKER_NAME=event-handler-plugin
-DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/teleport/$(DOCKER_NAME):$(VERSION)
+DOCKER_NAME=teleport-plugin-event-handler
+DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg GITREF=$(GITREF)
 

--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -36,15 +36,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/event-handler-plugin:9.0.2
+$ docker pull quay.io/gravitational/teleport-plugin-event-handler:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/event-handler-plugin:9.0.2 version
+$ docker run quay.io/gravitational/teleport-plugin-event-handler:9.0.2 version
 Teleport event handler v9.0.2 git:teleport-event-handler-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/event-handler-plugin?tab=tags)
+For a list of available tags, visit [https://quay.io/](https://quay.io/gravitational/teleport-plugin-event-handler?tab=tags)
 
 ### Building from source
 
@@ -219,7 +219,7 @@ $ teleport-event-handler start --config teleport-event-handler.toml --start-time
 or with docker:
 
 ```sh
-$ docker run -v </path/to/config>:/etc/teleport-event-handler quay.io/gravitational/event-handler-plugin:9.0.2 start --config /etc/teleport-event-handler/teleport-event-handler.toml --start-time 2021-01-01T00:00:00Z
+$ docker run -v </path/to/config>:/etc/teleport-event-handler quay.io/gravitational/teleport-plugin-event-handler:9.0.2 start --config /etc/teleport-event-handler/teleport-event-handler.toml --start-time 2021-01-01T00:00:00Z
 ```
 
 Note that here we used start time at the beginning of year 2021. Supposedly you have some events at the Teleport instance you are connecting to. Otherwise, you can omit `--start-time` flag, start the service and generate an events using `tctl create -f teleport-event-handler.yaml` then from the first step. `teleport-event-handler` will wait for that new events to appear and will send them to the fluentd.


### PR DESCRIPTION
This PR is a part of https://github.com/gravitational/cloud-terraform/issues/513 which recommends updating OCI Images and helm charts to a different naming convention. 

This PR updates the naming in three separate areas:
* Makefile variables https://github.com/gravitational/teleport-plugins/pull/489/commits/5332edb755dfff8ce3fec6f441afb163aed60c22
* README documentation https://github.com/gravitational/teleport-plugins/pull/489/commits/43a5683a3aaad319f8710ca382fef667afd468e8
* Helm chart tests and chart information. https://github.com/gravitational/teleport-plugins/pull/489/commits/5ab2cb0d8cd9c55b37fe9a10251377efed4b1485

The quay.io repositories have already been created. This PR will redirect the promotion steps to these new repositories and the tagged images to new internal staging repositories. 

This PR should not be merged until https://github.com/gravitational/cloud-terraform/pull/515 is merged. 

## Testing
Links were tested to ensure they work. When https://github.com/gravitational/cloud-terraform/pull/515 is merged I will test that the new pipeline steps will work as intended. 