### PR TITLE
Disable CGO for terraform plugin

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -8,7 +8,7 @@ TFDIR ?= example
 
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 RELEASE = terraform-provider-teleport-v$(VERSION)-$(OS)-$(ARCH)-bin
 


### PR DESCRIPTION
We don't have a hard requirement to have CGO enabled for the terraform
plugin

Disabling it will generate a static binary, wich doesn't need glibc.

This will the usage of the plugin without depending on glibc
As an example: alpine and nixos distros

Fixes #447