### PR TITLE
Fix darwin build when building darwin artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,6 +65,7 @@ steps:
       # This will remove subdirectories under pkg/mod which 0400 permissions.
       # See for more details: https://github.com/golang/go/issues/27455
       - go clean -modcache
+      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
       - rm -rf /tmp/teleport-plugins/test-darwin/go
       - mkdir -p /tmp/teleport-plugins/test-darwin/go
 
@@ -142,6 +143,7 @@ steps:
       # This will remove subdirectories under pkg/mod which 0400 permissions.
       # See for more details: https://github.com/golang/go/issues/27455
       - go clean -modcache
+      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
       - rm -rf /tmp/teleport-plugins/build-darwin/go
       - mkdir -p /tmp/teleport-plugins/build-darwin/go/cache
 
@@ -626,6 +628,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 4393ffb49dba5c0789d1f925c4e78f89d10e235dc86d476cb760afd524ec18ea
+hmac: 47fcd1903112ba7c637bcf5e33d91e956d0c09da75b40698f6e0891b2ef165c4
 
 ...


### PR DESCRIPTION
We have multiple errors for the `test-darwin` step on our CI
It happens because we can't remove the files inside our temp directory
This directory, which contains the go packages, is created and
everything inside of it is readonly (this is by design)

The command `go clean -modcache` was suppose to remove the entire cache,
but looks like it's not working (or something else is up, not sure)

This commit adds an extra step: change the every folder/file to be RW on
this temporary directory
This should allow us to, latter on, remove the entire directory