### PR TITLE
Bumped version to latest

### DIFF
--- a/charts/access/email/Chart.yaml
+++ b/charts/access/email/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "9.0.0"
+appVersion: "9.0.4"

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,7 +24,7 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.0.0
+        app.kubernetes.io/version: 9.0.4
         helm.sh/chart: teleport-plugin-email-1.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
@@ -56,7 +56,7 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.0.0
+        app.kubernetes.io/version: 9.0.4
         helm.sh/chart: teleport-plugin-email-1.0.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
@@ -88,6 +88,6 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.0.0
+        app.kubernetes.io/version: 9.0.4
         helm.sh/chart: teleport-plugin-email-1.0.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.0.0
+        app.kubernetes.io/version: 9.0.4
         helm.sh/chart: teleport-plugin-email-1.0.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:


### PR DESCRIPTION
The chart's `appVersion` was still set to 9.0.0 and it broke the build.