### PR TITLE
Resign .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -628,6 +628,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d5a5c8557a0903baf070be22b6fb54bf1e830ba388a32cb8d46cc519015b0585
+hmac: 5cfe82e8c35ed3e6fbfbada4e08648e4ca3ea2af9e950ab0d2f98c6a30f00414
 
 ...


### PR DESCRIPTION
https://github.com/gravitational/teleport-plugins/pull/504 had an incorrect signature, and is causing post-merge builds to hang as seen at:

https://drone.platform.teleport.sh/gravitational/teleport-plugins/1057