### PR TITLE
Update the drone user for ecr and helm charts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -782,6 +782,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY 
 ---
 kind: signature
-hmac: ca2146a3d75fd1978286d3c2ee088338134a96a0a0455a818a193d31c999ebce
+hmac: f43aec74e773c04c7b0977191176be5bed538fb6218d68bd65bf66170e7580bd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -233,9 +233,9 @@ steps:
     image: docker:git
     environment:
       AWS_ACCESS_KEY_ID:
-        from_secret: PLUGIN_DRONE_ECR_KEY
+        from_secret: PLUGIN_BUILD_USER_STAGING_KEY
       AWS_SECRET_ACCESS_KEY:
-        from_secret: PLUGIN_DRONE_ECR_SECRET
+        from_secret: PLUGIN_BUILD_USER_STAGING_SECRET
       AWS_DEFAULT_REGION: us-west-2
       DOCKER_BUILDKIT: 1
     volumes:
@@ -406,9 +406,9 @@ steps:
     image: docker:git
     environment:
       AWS_ACCESS_KEY_ID:
-        from_secret: PLUGIN_DRONE_ECR_KEY
+        from_secret: PLUGIN_BUILD_USER_STAGING_KEY
       AWS_SECRET_ACCESS_KEY:
-        from_secret: PLUGIN_DRONE_ECR_SECRET
+        from_secret: PLUGIN_BUILD_USER_STAGING_SECRET
       AWS_DEFAULT_REGION: us-west-2
       DOCKER_BUILDKIT: 1
     volumes:
@@ -548,9 +548,9 @@ steps:
       QUAYIO_DOCKER_PASSWORD:
         from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
       AWS_ACCESS_KEY_ID:
-        from_secret: PLUGIN_DRONE_ECR_KEY
+        from_secret: PLUGIN_BUILD_USER_STAGING_KEY
       AWS_SECRET_ACCESS_KEY:
-        from_secret: PLUGIN_DRONE_ECR_SECRET
+        from_secret: PLUGIN_BUILD_USER_STAGING_SECRET
       AWS_DEFAULT_REGION: us-west-2
       DOCKER_BUILDKIT: 1
     volumes:
@@ -600,9 +600,9 @@ steps:
       QUAYIO_DOCKER_PASSWORD:
         from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
       AWS_ACCESS_KEY_ID:
-        from_secret: PLUGIN_DRONE_ECR_KEY
+        from_secret: PLUGIN_BUILD_USER_STAGING_KEY
       AWS_SECRET_ACCESS_KEY:
-        from_secret: PLUGIN_DRONE_ECR_SECRET
+        from_secret: PLUGIN_BUILD_USER_STAGING_SECRET
       AWS_DEFAULT_REGION: us-west-2
       DOCKER_BUILDKIT: 1
     volumes:


### PR DESCRIPTION
This PR updates the drone user used.

Links:
* https://github.com/gravitational/ops/pull/356
* https://github.com/gravitational/cloud-terraform/pull/506
* https://github.com/gravitational/cloud-terraform/pull/505

## Testing Done
Confirmed manually that the policy attached to the referenced user matches 1:1 with the existing user. Tested the policy by pulling `teleport-plugin` images.