### PR TITLE
Terraform: TrustedCluster Token must not be logged

### DIFF
--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -272,6 +272,7 @@ sensitive_fields:
     - "GithubConnectorV3.Spec.ClientSecret"
     - "OIDCConnectorV3.Spec.ClientSecret"
     - "OIDCConnectorV3.Spec.GoogleServiceAccount"
+    - "TrustedClusterV2.Spec.Token"
 
 # These suffixes for custom methods called when field has custom_type flag. By default they might be weird.
 suffixes:

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -2277,6 +2277,7 @@ func GenSchemaTrustedClusterV2(ctx context.Context) (github_com_hashicorp_terraf
 				"token": {
 					Description: "Token is the authorization token provided by another cluster needed by this cluster to join.",
 					Optional:    true,
+					Sensitive:   true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"tunnel_addr": {


### PR DESCRIPTION
The TrustedCluster.Spec.Token was being leaked in the logs
This PR changes the field's Sensitive property to true, preventing it from being
used in log messages.

Technical info:
- change the `terraform/protoc-gen-terraform-teleport.yaml` `sensitive_fields`
section
- run `cd terraform; make gen-tfschema`

Fixes #515