### PR TITLE
Makes Darwin builder use the release-appropriate go version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,26 +59,41 @@ trigger:
 workspace:
   path: /tmp/teleport-plugins/test-darwin
 
+environment:
+  GOLANG_VERSION: go1.17.9
+  GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go
+  GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go/cache
+  TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
+
 steps:
-  - name: Clean up exec runner storage
+  - name: Install Go Toolchain
     commands:
-      # This will remove subdirectories under pkg/mod which 0400 permissions.
-      # See for more details: https://github.com/golang/go/issues/27455
-      - go clean -modcache
-      - chmod -R u+rw /tmp/teleport-plugins/test-darwin/go
-      - rm -rf /tmp/teleport-plugins/test-darwin/go
-      - mkdir -p /tmp/teleport-plugins/test-darwin/go
+      - set -u
+      - mkdir -p $TOOLCHAIN_DIR
+      - curl --silent -O https://dl.google.com/go/$GOLANG_VERSION.darwin-amd64.tar.gz
+      - tar -C  $TOOLCHAIN_DIR -xzf $GOLANG_VERSION.darwin-amd64.tar.gz
+      - rm -rf $GOLANG_VERSION.darwin-amd64.tar.gz
 
   - name: Run tests
     environment:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
       TELEPORT_GET_VERSION: v9.0.4
-      GOPATH: /tmp/teleport-plugins/test-darwin/go
-      GOCACHE: /tmp/teleport-plugins/test-darwin/go/cache
     commands:
+      - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
       - go version
+      - make clean
       - make test
+
+  - name: Clean up toolchains (post)
+    when:
+      status:
+      - success
+      - failure
+    commands:
+      - set -u
+      - rm -rf $TOOLCHAIN_DIR
+      - rm -rf $GOPATH
 
 ---
 kind: pipeline
@@ -137,22 +152,36 @@ depends_on:
 workspace:
   path: /tmp/teleport-plugins/build-darwin
 
+environment:
+  GOLANG_VERSION: go1.17.9
+  GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go
+  GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go/cache
+  TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
+
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Install Go Toolchain
     commands:
-      # This will remove subdirectories under pkg/mod which 0400 permissions.
-      # See for more details: https://github.com/golang/go/issues/27455
-      - go clean -modcache
-      - chmod -R u+rw /tmp/teleport-plugins/build-darwin/go
-      - rm -rf /tmp/teleport-plugins/build-darwin/go
-      - mkdir -p /tmp/teleport-plugins/build-darwin/go/cache
+      - set -u
+      - mkdir -p $TOOLCHAIN_DIR
+      - curl --silent -O https://dl.google.com/go/$GOLANG_VERSION.darwin-amd64.tar.gz
+      - tar -C  $TOOLCHAIN_DIR -xzf $GOLANG_VERSION.darwin-amd64.tar.gz
+      - rm -rf $GOLANG_VERSION.darwin-amd64.tar.gz
 
   - name: Build artifacts (darwin)
-    environment:
-      GOPATH: /tmp/teleport-plugins/build-darwin/go
-      GOCACHE: /tmp/teleport-plugins/build-darwin/go/cache
     commands:
+      - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
+      - go version
+      - go clean
       - make build-all
+
+  - name: Clean up toolchains (post)
+    when:
+      status:
+      - success
+      - failure
+    commands:
+      - set -u
+      - rm -rf /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}
 
 ---
 kind: pipeline
@@ -788,6 +817,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY 
 ---
 kind: signature
-hmac: 36eb337a8b7f47150cfbbbc0ca5ca6b6f6510fdc755536de6e28fe3e6f5f4c57
+hmac: cc769493c8154bff0faf7b6d1b5120d011e1102ff25d406e9e040e39bf5b17b6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -60,7 +60,7 @@ workspace:
   path: /tmp/teleport-plugins/test-darwin
 
 environment:
-  GOLANG_VERSION: go1.17.9
+  GO_VERSION: go1.17.9
   GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go
   GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go/cache
   TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
@@ -70,9 +70,9 @@ steps:
     commands:
       - set -u
       - mkdir -p $TOOLCHAIN_DIR
-      - curl --silent -O https://dl.google.com/go/$GOLANG_VERSION.darwin-amd64.tar.gz
-      - tar -C  $TOOLCHAIN_DIR -xzf $GOLANG_VERSION.darwin-amd64.tar.gz
-      - rm -rf $GOLANG_VERSION.darwin-amd64.tar.gz
+      - curl --silent -O https://dl.google.com/go/$GO_VERSION.darwin-amd64.tar.gz
+      - tar -C  $TOOLCHAIN_DIR -xzf $GO_VERSION.darwin-amd64.tar.gz
+      - rm -rf $GO_VERSION.darwin-amd64.tar.gz
 
   - name: Run tests
     environment:
@@ -153,7 +153,7 @@ workspace:
   path: /tmp/teleport-plugins/build-darwin
 
 environment:
-  GOLANG_VERSION: go1.17.9
+  GO_VERSION: go1.17.9
   GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go
   GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/go/cache
   TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
@@ -163,9 +163,9 @@ steps:
     commands:
       - set -u
       - mkdir -p $TOOLCHAIN_DIR
-      - curl --silent -O https://dl.google.com/go/$GOLANG_VERSION.darwin-amd64.tar.gz
-      - tar -C  $TOOLCHAIN_DIR -xzf $GOLANG_VERSION.darwin-amd64.tar.gz
-      - rm -rf $GOLANG_VERSION.darwin-amd64.tar.gz
+      - curl --silent -O https://dl.google.com/go/$GO_VERSION.darwin-amd64.tar.gz
+      - tar -C  $TOOLCHAIN_DIR -xzf $GO_VERSION.darwin-amd64.tar.gz
+      - rm -rf $GO_VERSION.darwin-amd64.tar.gz
 
   - name: Build artifacts (darwin)
     commands:
@@ -817,6 +817,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY 
 ---
 kind: signature
-hmac: cc769493c8154bff0faf7b6d1b5120d011e1102ff25d406e9e040e39bf5b17b6
+hmac: efc14a6c143161ae7402910942d4828174a267c835aa49cda72266350e4150b7
 
 ...

--- a/tooling/cmd/promote-terraform/main.go
+++ b/tooling/cmd/promote-terraform/main.go
@@ -31,7 +31,13 @@ import (
 const (
 	objectStoreKeyPrefix = "store"
 	registryKeyPrefix    = "registry"
+	jsonContentType      = "application/json"
 )
+
+type fileInfo struct {
+	name        string
+	contentType string
+}
 
 func main() {
 	args := parseCommandLine()
@@ -87,7 +93,7 @@ func logLevel(args *args) log.Level {
 // We could layer a locking mechanism on top of another AWS service, but for
 // now we are relying on drone to honour its concurrency limits (i.e. 1) to
 // serialise access to the live `versions` file.
-func updateRegistry(ctx context.Context, prodBucket *bucketConfig, workspace *workspacePaths, namespace, provider string, newVersion registry.Version, files []string) error {
+func updateRegistry(ctx context.Context, prodBucket *bucketConfig, workspace *workspacePaths, namespace, provider string, newVersion registry.Version, files []fileInfo) error {
 	s3client, err := newS3ClientFromBucketConfig(ctx, prodBucket)
 	if err != nil {
 		return trace.Wrap(err)
@@ -129,7 +135,7 @@ func updateRegistry(ctx context.Context, prodBucket *bucketConfig, workspace *wo
 	if err = versions.Save(versionsFilePath); err != nil {
 		return trace.Wrap(err, "failed saving index file")
 	}
-	files = append(files, versionsFilePath)
+	files = append(files, fileInfo{name: versionsFilePath, contentType: jsonContentType})
 
 	// Finally, push the new index files to the production bucket
 	err = uploadRegistry(ctx, s3client, prodBucket.bucketName, workspace.productionDir, files)
@@ -140,40 +146,47 @@ func updateRegistry(ctx context.Context, prodBucket *bucketConfig, workspace *wo
 	return nil
 }
 
-func uploadRegistry(ctx context.Context, s3Client *s3.Client, bucketName string, productionDir string, files []string) error {
+func uploadRegistry(ctx context.Context, s3Client *s3.Client, bucketName string, productionDir string, files []fileInfo) error {
 	uploader := manager.NewUploader(s3Client)
 	log.Infof("Production dir: %s", productionDir)
+
+	doUpload := func(key string, f fileInfo) error {
+		src, err := os.Open(f.name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer src.Close()
+
+		input := s3.PutObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(key),
+			Body:   src,
+		}
+
+		if f.contentType != "" {
+			input.ContentType = aws.String(f.contentType)
+		}
+
+		_, err = uploader.Upload(ctx, &input)
+
+		return trace.Wrap(err)
+	}
+
 	for _, f := range files {
 		log.Infof("Uploading %s", f)
 
-		if !strings.HasPrefix(f, productionDir) {
+		if !strings.HasPrefix(f.name, productionDir) {
 			return trace.Errorf("file outside of registry dir")
 		}
 
-		key, err := filepath.Rel(productionDir, f)
+		key, err := filepath.Rel(productionDir, f.name)
 		if err != nil {
 			return trace.Wrap(err, "failed to extract key")
 		}
 
 		log.Tracef("... to %s", key)
 
-		doUpload := func() error {
-			f, err := os.Open(f)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			defer f.Close()
-
-			_, err = uploader.Upload(ctx, &s3.PutObjectInput{
-				Bucket: aws.String(bucketName),
-				Key:    aws.String(key),
-				Body:   f,
-			})
-
-			return trace.Wrap(err)
-		}
-
-		if err = doUpload(); err != nil {
+		if err = doUpload(key, f); err != nil {
 			return trace.Wrap(err, "failed uploading registry file")
 		}
 	}
@@ -201,13 +214,13 @@ func flattenVersionIndex(versionIndex map[semver.Version]registry.Version) []reg
 	return result
 }
 
-func repackProviders(candidateFilenames []string, workspace *workspacePaths, objectStoreUrl string, signingEntity *openpgp.Entity, protocolVersions []string, providerNamespace, providerName string) (registry.Version, []string, error) {
+func repackProviders(candidateFilenames []string, workspace *workspacePaths, objectStoreUrl string, signingEntity *openpgp.Entity, protocolVersions []string, providerNamespace, providerName string) (registry.Version, []fileInfo, error) {
 
 	versionRecord := registry.Version{
 		Protocols: protocolVersions,
 	}
 
-	newFiles := []string{}
+	newFiles := []fileInfo{}
 
 	unsetVersion := semver.Version{}
 
@@ -224,7 +237,10 @@ func repackProviders(candidateFilenames []string, workspace *workspacePaths, obj
 		}
 
 		log.Infof("Provider repacked to %s/%s", workspace.objectStoreDir, registryInfo.Zip)
-		newFiles = append(newFiles, registryInfo.Zip, registryInfo.Sum, registryInfo.Sig)
+		newFiles = append(newFiles,
+			fileInfo{name: registryInfo.Zip},
+			fileInfo{name: registryInfo.Sum},
+			fileInfo{name: registryInfo.Sig})
 
 		if versionRecord.Version == unsetVersion {
 			versionRecord.Version = registryInfo.Version
@@ -241,7 +257,7 @@ func repackProviders(candidateFilenames []string, workspace *workspacePaths, obj
 		if err != nil {
 			return registry.Version{}, nil, trace.Wrap(err, "Failed saving download info record")
 		}
-		newFiles = append(newFiles, filename)
+		newFiles = append(newFiles, fileInfo{name: filename, contentType: jsonContentType})
 
 		versionRecord.Platforms = append(versionRecord.Platforms, registry.Platform{
 			OS:   registryInfo.OS,


### PR DESCRIPTION
The Darwin build and test scripts now download and install a release-appropriate version of Go before building and testing the code.

See-Also: #524