### PR TITLE
Make the TF promotion script use the exact tag

### DIFF
--- a/tooling/internal/staging/staging.go
+++ b/tooling/internal/staging/staging.go
@@ -4,9 +4,9 @@ package staging
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +54,7 @@ type downloader interface {
 }
 
 func tagPrefix(tag string) string {
-	return path.Join(keyPrefix, tag)
+	return fmt.Sprintf("%s%s/", keyPrefix, tag)
 }
 
 func fetchObject(ctx context.Context, client downloader, dstDirRoot string, bucket, key string, keyPrefix string) (string, error) {


### PR DESCRIPTION
When downloading artifacts to promote the script was using the build tag
without an explicit path separator, meaning that the downloader would
match `terraform-provider-teleport-v9.1.2` would match both
`terraform-provider-teleport-v9.1.2` _and_ something like
`terraform-provider-teleport-v9.1.2-dev.1`.

The script would then process _both_ matches for promotion, which could
result in an unintended overwrite of a provider.

This patch explicitly terminates the S2 key prefix generated from the
tag with a path separator, so only _exact_ matches will be found.