### PR TITLE
Adds disaster recovery tooling for the terraform promotion script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -746,6 +746,8 @@ steps:
       strip_prefix: packages
     
 ---
+# NOTE: Any changes here need to be reflected in the emergency deployment 
+#       scripts in tooling/bin
 kind: pipeline
 type: kubernetes
 name: tag-stage-terraform-provider
@@ -800,6 +802,8 @@ steps:
       SIGNING_KEY:
         from_secret: STAGING_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
+# NOTE: Any changes here need to be reflected in the emergency deployment 
+#       scripts in tooling/bin
 kind: pipeline
 type: kubernetes
 name: promote-staging-terraform-provider
@@ -853,6 +857,8 @@ steps:
       SIGNING_KEY:
         from_secret: STAGING_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
+# NOTE: Any changes here need to be reflected in the emergency deployment 
+#       scripts in tooling/bin
 kind: pipeline
 type: kubernetes
 name: promote-terraform-provider
@@ -907,6 +913,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY 
 ---
 kind: signature
-hmac: aadba22a5eb8175d4b08404bea82b7d7a1643a789f233b0d8c24cd1fbe682479
+hmac: 00f6ab1621124f81ccb6d4b60f2697851b2a7c11e7c2d5cadca9c234ff4da49c
 
 ...

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,35 @@
+# Teleport Plugins Release Process
+
+The Teleport plugins release process is controlled by Drone, and is described in detail by [RFD003](./rfd0003-teleport-plugins-versioning.md).
+
+## Recovery & Troubleshooting
+
+### Terraform Registry
+
+You can manually invoke the terraform registry promotion to fix a failed
+provider release. In order to do this you will need:
+
+* this repository
+* access to the `sops`-encrypted Drone secrets file for the teleport-plugins
+  build
+* access to the key to decrypt the secrets file
+* the git tag of the provider to publish (e.g. `terraform-provider-teleport-v9.1.3`)
+  
+#### Step 1: Build the secret injection shim
+
+See `tooling/with-secrets/main.go` for details about why this shim is necessary.
+
+```sh
+$ (cd tooling; go build -o .. ./cmd/with-secrets)
+```
+
+#### Step 2: Publish the provider
+
+There are scripts to download, repackage and push the provider archive to the
+staging and production terraform registries under `./tooling/bin`. They take all
+the same actions as the drone promotion pipeline, but are much easier to
+troubleshoot. They can be run like so:
+
+```sh
+$ sops -d $plugins_secrets | ./with-secrets ./tooling/bin/release $terraform_provider_version
+```

--- a/tooling/bin/tf-release
+++ b/tooling/bin/tf-release
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# NOTE: The variable mappings here need to match those in the
+#       promote-terraform-provider Drone pipeline. Any change here should
+#       be reflected there, and vice versa.
+
 export STAGING_REGION=us-west-2
 export STAGING_BUCKET=$AWS_S3_BUCKET
 export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID

--- a/tooling/bin/tf-release
+++ b/tooling/bin/tf-release
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+export STAGING_REGION=us-west-2
+export STAGING_BUCKET=$AWS_S3_BUCKET
+export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+export STAGING_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+    
+export PROD_REGION=$PRODUCTION_TERRAFORM_AWS_REGION
+export PROD_BUCKET=$PRODUCTION_TERRAFORM_AWS_BUCKET
+export PROD_ACCESS_KEY_ID=$PRODUCTION_TERRAFORM_AWS_ACCESS_KEY_ID_nope
+export PROD_SECRET_ACCESS_KEY=$PRODUCTION_TERRAFORM_AWS_SECRET_ACCESS_KEY
+export DEPLOYMENT_ROLE=$PRODUCTION_TERRAFORM_AWS_DEPLOYMENT_ROLE
+export SIGNING_KEY=$PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
+
+export DRONE_TAG=$1
+
+cd tooling
+go run ./cmd/promote-terraform                                 \
+  -d workspace-prod                                            \
+  --tag $DRONE_TAG                                             \
+  -p 6                                                         \
+  --registry-url https://terraform.releases.teleport.dev/      \
+  --namespace gravitational                                    \
+  --name teleport                                              \
+  --deployment-role $DEPLOYMENT_ROLE
+

--- a/tooling/bin/tf-stage
+++ b/tooling/bin/tf-stage
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# NOTE: The variable mappings here need to match those in the
+#       tag-stage-terraform-provider and promote-staging-terraform-provider
+#       Drone pipelines. Any change here should be reflected there, and vice 
+#       versa.
+
+
 export STAGING_REGION=us-west-2
 export STAGING_BUCKET=$AWS_S3_BUCKET
 export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID

--- a/tooling/bin/tf-stage
+++ b/tooling/bin/tf-stage
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+export STAGING_REGION=us-west-2
+export STAGING_BUCKET=$AWS_S3_BUCKET
+export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+export STAGING_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+    
+export PROD_REGION=$STAGING_TERRAFORM_AWS_REGION
+export PROD_BUCKET=$STAGING_TERRAFORM_AWS_BUCKET
+export PROD_ACCESS_KEY_ID=$STAGING_TERRAFORM_AWS_ACCESS_KEY_ID
+export PROD_SECRET_ACCESS_KEY=$STAGING_TERRAFORM_AWS_SECRET_ACCESS_KEY
+export DEPLOYMENT_ROLE=$STAGING_TERRAFORM_AWS_DEPLOYMENT_ROLE
+export SIGNING_KEY=$STAGING_TERRAFORM_REGISTRY_SIGNING_KEY
+
+export DRONE_TAG=$1
+
+cd tooling
+go run ./cmd/promote-terraform                                         \
+  -d workspace-staging                                                 \
+  --tag $DRONE_TAG                                                     \
+  -p 6                                                                 \
+  --registry-url https://terraform-staging.releases.teleport.dev/      \
+  --namespace gravitational                                            \
+  --name teleport                                                      \
+  --deployment-role $DEPLOYMENT_ROLE

--- a/tooling/cmd/with-secrets/main.go
+++ b/tooling/cmd/with-secrets/main.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Emulates the behaviour of sops --exec-env, in that it takes the decrypted
+// yaml output from `sops -d $drone-secrets-file` and runs the supplied program
+// with the secrets injected its environment.
+//
+// For some reason (either the way we've structured the yaml in the drone
+// secrets files, the use use of multi-line secrets, or both), `sops --exec-env`
+// doesn't work with our Drone secrets files, so this shim exists to emulate that
+// behaviour
+//
+// For example:
+//  $ sops -d encrypted-secrets.yaml | with-secrets ./do-the-thing arg1 arg2
+// ... so that the decrypted secrets are never written to disk.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+
+	"gopkg.in/yaml.v2"
+)
+
+type secret struct {
+	Value string `yaml:"value"`
+}
+
+type Secrets struct {
+	Secrets map[string]secret `yaml:"secrets"`
+}
+
+func main() {
+	text, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	secrets := Secrets{}
+	err = yaml.Unmarshal(text, &secrets)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	cmd := exec.Command(os.Args[1], os.Args[2:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	for key, value := range secrets.Secrets {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value.Value))
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatalf("Run failed: %s", err)
+	}
+}

--- a/tooling/go.mod
+++ b/tooling/go.mod
@@ -10,11 +10,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.10.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.0
 	github.com/coreos/go-semver v0.3.0
 	github.com/gravitational/kingpin v2.1.10+incompatible
 	github.com/gravitational/trace v1.1.18
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -31,7 +33,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.16.0 // indirect
 	github.com/aws/smithy-go v1.11.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/tooling/go.sum
+++ b/tooling/go.sum
@@ -197,8 +197,9 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Adds tooling to locally run promotions to the terraform registry in the event of errors in the Drone process.

Expected process looks something like:

```
 $ (cd tooling; go build -o .. ./cmd/with-secrets)
 $ sops -d $plugins_secrets | ./with-secrets ./tooling/bin/release $terraform_provider_version
```

...substituting the appropriate `$plugins_secrets` Drone secrets file and `$terrafom_provider_version` tag (e.g. `terraform-provider-teleport-v9.1.3`)

See `tooling/cmd/with-secrets/main.go` for more info on why `with-secrets` is required.