### PR TITLE
Add installation instructions to the chart's README

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -116,6 +116,7 @@ helm install teleport-plugin-email teleport/teleport-plugin-email \
 ```
 
 See [Settings](#settings) for more details.
+
 ## Settings
 
 The following values can be set for the Helm chart:

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -11,7 +11,7 @@ First, you'll need to create a Teleport user and role for the plugin. The follow
 ```yaml
 ---
 kind: role
-version: v4
+version: v5
 metadata:
   name: teleport-plugin-email
 spec:
@@ -39,7 +39,7 @@ spec:
     - teleport-plugin-email
 ```
 
-You can either create the user and the roles by putting the YAML above to a file and issuing the following command  (you must be logged in with `tsh`):
+You can either create the user and the roles by putting the YAML above into a file and issuing the following command  (you must be logged in with `tsh`):
 
 ```
 tctl create user.yaml

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -27,7 +27,7 @@ spec:
       - update
   options:
     forward_agent: false
-    max_session_ttl: 8h0m0s
+    max_session_ttl: 8760h0m0s
     port_forwarding: false
 ---
 kind: user
@@ -45,33 +45,21 @@ You can either create the user and the roles by putting the YAML above into a fi
 tctl create user.yaml
 ```
 
-or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` and `https://<yourserver>/web/roles` respectively.
+or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` and `https://<yourserver>/web/roles` respectively. You'll also need to create a password for the user by either clicking `Options/Reset password...` under `https://<yourserver>/web/users` on the UI or issuing `tctl users reset teleport-plugin-jiraport` in the command line.
 
-The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, use the following command:
+The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
+
+```
+tsh login --proxy=access-dev.teleportinfra.dev --auth local --user teleport-plugin-email --ttl 525600
+```
 
 ```
 tctl auth sign --user teleport-plugin-email --ttl 8760h --out teleport-plugin-email-identity
 ```
 
-You'll need to be logged in and have the privileges to impersonate that user. You can add the required permissions to your user by assigning the following role or similar:
-
-```yaml
-kind: role
-version: v5
-metadata:
-  name: teleport-plugin-email-impersonator
-spec:
-  allow:
-    impersonate:
-      roles:
-      - teleport-plugin-email
-      users:
-      - teleport-plugin-email
-```
-
 Alternatively, you can execute the command above on one of the `auth` instances/pods.
 
-The last step is to create the secret. The following command will create a secret with the name `teleport-plugin-email-identity` with the key `auth_id` in it holding the contents of the file `teleport-plugin-email-identity`:
+The last step is to create the secret. The following command will create a Kubernetes secret with the name `teleport-plugin-email-identity` with the key `auth_id` in it holding the contents of the file `teleport-plugin-email-identity`:
 
 ```
 kubectl create secret generic teleport-plugin-email-identity --from-file=auth_id=teleport-plugin-email-identity

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -125,12 +125,14 @@ The following values can be set for the Helm chart:
     <td>Name of the Kubernetes secret that contains the credentials for the connection</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>yes</td>
   </tr>
   <tr>
     <td><code>teleport.identitySecretPath</code></td>
     <td>Key of the field in the secret specified by <code>teleport.identitySecretName</code></td>
     <td>string</td>
     <td><code>"auth_id"</code></td>
+    <td>no</td>
   </tr>
 
   <tr>
@@ -141,18 +143,21 @@ The following values can be set for the Helm chart:
     </td>
     <td>boolean</td>
     <td><code>false</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>mailgun.domain</code></td>
     <td>Domain name of the Mailgun instance</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>mailgun.privateKey</code></td>
     <td>Private key for accessing the Mailgun instance</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
 
   <tr>
@@ -163,30 +168,35 @@ The following values can be set for the Helm chart:
     </td>
     <td>boolean</td>
     <td><code>false</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.host</code></td>
     <td>SMTP host.</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.port</code></td>
     <td>Port of the SMTP server.</td>
     <td>integer</td>
     <td><code>587</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.username</code></td>
     <td>Username to be used with the SMTP server.</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.password</code></td>
     <td>Password to be used with the SMTP server. Mutually exclusive with <code>smtp.passwordFile</code>.</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.passwordFile</code></td>
@@ -195,12 +205,14 @@ The following values can be set for the Helm chart:
     </td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>smtp.starttlsPolicy</code></td>
     <td>Which policy to use for secure communications: mandatory, opportunistic or disabled.</td>
     <td>string</td>
     <td><code>"mandatory"</code></td>
+    <td>no</td>
   </tr>
 
   <tr>
@@ -208,12 +220,14 @@ The following values can be set for the Helm chart:
     <td>Email address to be used in the <code>From</code> field of the emails.</td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>yes</td>
   </tr>
   <tr>
     <td><code>delivery.recipients</code></td>
     <td>Array of the recipients the plugin should send emails.</td>
     <td>array</td>
     <td><code>[]</code></td>
+    <td>no</td>
   </tr>
 
   <tr>
@@ -238,6 +252,7 @@ The following values can be set for the Helm chart:
     </td>
     <td>string</td>
     <td><code>"stdout"</code></td>
+    <td>no</td>
   </tr>
   <tr>
     <td><code>log.severity</code></td>
@@ -247,5 +262,6 @@ The following values can be set for the Helm chart:
     </td>
     <td>string</td>
     <td><code>"INFO"</code></td>
+    <td>no</td>
   </tr>
 </table>

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -45,7 +45,7 @@ You can either create the user and the roles by putting the YAML above into a fi
 tctl create user.yaml
 ```
 
-or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` and `https://<yourserver>/web/roles` respectively. You'll also need to create a password for the user by either clicking `Options/Reset password...` under `https://<yourserver>/web/users` on the UI or issuing `tctl users reset teleport-plugin-jiraport` in the command line.
+or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` and `https://<yourserver>/web/roles` respectively. You'll also need to create a password for the user by either clicking `Options/Reset password...` under `https://<yourserver>/web/users` on the UI or issuing `tctl users reset teleport-plugin-email` in the command line.
 
 The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
 

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -53,7 +53,23 @@ The next step is to create an identity file, which contains a private/public key
 tctl auth sign --user teleport-plugin-email --ttl 8760h --out teleport-plugin-email-identity
 ```
 
-You'll need to be logged in and have the privileges to impersonate that user. Alternatively, you can execute the command above on one of the `auth` instances/pods (if you have access to them).
+You'll need to be logged in and have the privileges to impersonate that user. You can add the required permissions to your user by assigning the following role or similar:
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: teleport-plugin-email-impersonator
+spec:
+  allow:
+    impersonate:
+      roles:
+      - teleport-plugin-email
+      users:
+      - teleport-plugin-email
+```
+
+Alternatively, you can execute the command above on one of the `auth` instances/pods.
 
 The last step is to create the secret. The following command will create a secret with the name `teleport-plugin-email-identity` with the key `auth_id` in it holding the contents of the file `teleport-plugin-email-identity`:
 


### PR DESCRIPTION
This change adds installation instructions for the Helm chart of `teleport-plugin-email`.

Tasks:
- [x] Include instructions to create identity file using impersonation
- [x] ~~Extend documentation with `roleToRecipients` (not implemented yet)~~ - will be fixed by #547

Note: this should be merged only after everything else is in place (eg. Helm charts are uploaded)!

Related to #439