### PR TITLE
Add rolemap support to teleport-plugin-email chart

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -119,6 +119,20 @@ The following values can be set for the Helm chart:
   </tr>
 
   <tr>
+    <td><code>roleToRecipients</code></td>
+    <td>
+      Mapping of roles to a list of channels and Slack emails. <br />
+      Example:
+      <pre>
+"dev" = ["dev-access-requests", "user@example.com"]
+"*" = ["access-requests"]</pre>
+    </td>
+    <td>map</td>
+    <td><code>{}</code></td>
+    <td>yes</td>
+  </tr>
+
+  <tr>
     <td><code>log.output</code></td>
     <td>
       Logger output. Could be <code>"stdout"</code>, <code>"stderr"</code> or a file name,

--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -121,10 +121,10 @@ The following values can be set for the Helm chart:
   <tr>
     <td><code>roleToRecipients</code></td>
     <td>
-      Mapping of roles to a list of channels and Slack emails. <br />
+      Mapping of roles to a list of emails. <br />
       Example:
       <pre>
-"dev" = ["dev-access-requests", "user@example.com"]
+"dev" = ["developers@example.com", "user@example.com"]
 "*" = ["access-requests"]</pre>
     </td>
     <td>map</td>

--- a/charts/access/email/templates/configmap.yaml
+++ b/charts/access/email/templates/configmap.yaml
@@ -10,11 +10,11 @@ data:
     addr = "{{ .Values.teleport.address }}"
     identity = "/var/lib/teleport/plugins/email/auth_id"
 
-    {{ if .Values.mailgun.enabled }}
+    {{ if .Values.mailgun.enabled -}}
     [mailgun]
     domain      = "{{ .Values.mailgun.domain }}"
     private_key = "{{ .Values.mailgun.privateKey }}"
-    {{ else if .Values.smtp.enabled }}
+    {{ else if .Values.smtp.enabled -}}
     [smtp]
     host          = "{{ .Values.smtp.host }}"
     port          = {{ .Values.smtp.port }}
@@ -25,11 +25,19 @@ data:
     password_file = "{{ .Values.smtp.passwordFile }}"
     {{ end }}
     starttls_policy = "{{ .Values.smtp.starttlsPolicy }}"
-    {{ end -}}
+    {{- end }}
 
     [delivery]
     sender = "{{ .Values.delivery.sender }}"
+    {{- if (not .Values.roleToRecipients) }}
     recipients = {{ .Values.delivery.recipients | toJson }}
+    {{- else }}
+
+    [role_to_recipients]
+    {{- range $role, $recipients := .Values.roleToRecipients }}
+    {{ $role | toJson }} = {{ $recipients | toJson }}
+    {{- end }}
+    {{- end }}
 
     [log]
     output = "{{ .Values.log.output }}"

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -7,10 +7,11 @@ should match the snapshot (mailgun on):
         addr = "teleport.example.com:1234"
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
-
         [mailgun]
         domain      = "mymailgunsubdomain.mailgun.org"
         private_key = "xoxb-71d75f662b0eac53565a38c8cc0316f6"
+
+
         [delivery]
         sender = ""
         recipients = []
@@ -36,7 +37,6 @@ should match the snapshot (smtp on):
         addr = "teleport.example.com:1234"
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
-
         [smtp]
         host          = "smtp.someservice.com"
         port          = 1234
@@ -44,6 +44,7 @@ should match the snapshot (smtp on):
         password      = "mysmtppasswd"
 
         starttls_policy = "mandatory"
+
         [delivery]
         sender = "teleport@example.com"
         recipients = ["security@mycompany.com"]
@@ -69,7 +70,6 @@ should match the snapshot (smtp on, no starttls):
         addr = "teleport.example.com:1234"
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
-
         [smtp]
         host          = "smtp.someservice.com"
         port          = 1234
@@ -77,6 +77,7 @@ should match the snapshot (smtp on, no starttls):
         password_file = "/etc/teleport/supersecretemailpw"
 
         starttls_policy = "mandatory"
+
         [delivery]
         sender = ""
         recipients = []
@@ -102,7 +103,6 @@ should match the snapshot (smtp on, password file):
         addr = "teleport.example.com:1234"
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
-
         [smtp]
         host          = "smtp.someservice.com"
         port          = 1234
@@ -110,6 +110,7 @@ should match the snapshot (smtp on, password file):
         password_file = "/etc/teleport/supersecretemailpw"
 
         starttls_policy = "mandatory"
+
         [delivery]
         sender = ""
         recipients = []
@@ -126,6 +127,42 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/version: 9.2.3
         helm.sh/chart: teleport-plugin-email-9.2.3
       name: RELEASE-NAME-teleport-plugin-email
+should match the snapshot (smtp on, roleToRecipients set):
+  1: |
+    apiVersion: v1
+    data:
+      teleport-email.toml: |
+        [teleport]
+        addr = "teleport.example.com:1234"
+        identity = "/var/lib/teleport/plugins/email/auth_id"
+
+        [smtp]
+        host          = "smtp.someservice.com"
+        port          = 1234
+        username      = "mysmtpuser"
+        password      = "mysmtppasswd"
+
+        starttls_policy = "mandatory"
+
+        [delivery]
+        sender = "teleport@example.com"
+
+        [role_to_recipients]
+        "*" = ["security@mycompany.com"]
+        "dev" = ["developers@mycompany.com"]
+
+        [log]
+        output = "/var/log/teleport-email.log"
+        severity = "DEBUG"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.1.3
+        helm.sh/chart: teleport-plugin-email-9.1.3
+      name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
     apiVersion: v1
@@ -135,7 +172,6 @@ should match the snapshot (smtp on, starttls disabled):
         addr = "teleport.example.com:1234"
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
-
         [smtp]
         host          = "smtp.someservice.com"
         port          = 1234
@@ -143,6 +179,7 @@ should match the snapshot (smtp on, starttls disabled):
         password_file = "/etc/teleport/supersecretemailpw"
 
         starttls_policy = "disabled"
+
         [delivery]
         sender = ""
         recipients = []

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -38,7 +38,7 @@ should match the snapshot (smtp on):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.someservice.com"
+        host          = "smtp.example.com"
         port          = 1234
         username      = "mysmtpuser"
         password      = "mysmtppasswd"
@@ -71,7 +71,7 @@ should match the snapshot (smtp on, no starttls):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.someservice.com"
+        host          = "smtp.example.com"
         port          = 1234
         username      = "mysmtpuser"
         password_file = "/etc/teleport/supersecretemailpw"
@@ -104,7 +104,7 @@ should match the snapshot (smtp on, password file):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.someservice.com"
+        host          = "smtp.example.com"
         port          = 1234
         username      = "mysmtpuser"
         password_file = "/etc/teleport/supersecretemailpw"
@@ -137,7 +137,7 @@ should match the snapshot (smtp on, roleToRecipients set):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.someservice.com"
+        host          = "smtp.example.com"
         port          = 1234
         username      = "mysmtpuser"
         password      = "mysmtppasswd"
@@ -160,8 +160,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.1.3
-        helm.sh/chart: teleport-plugin-email-9.1.3
+        app.kubernetes.io/version: 9.2.1
+        helm.sh/chart: teleport-plugin-email-9.2.1
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -173,7 +173,7 @@ should match the snapshot (smtp on, starttls disabled):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.someservice.com"
+        host          = "smtp.example.com"
         port          = 1234
         username      = "mysmtpuser"
         password_file = "/etc/teleport/supersecretemailpw"

--- a/charts/access/email/tests/configmap_test.yaml
+++ b/charts/access/email/tests/configmap_test.yaml
@@ -9,7 +9,7 @@ tests:
       maingun.enabled: false
       smtp:
         enabled: true
-        host: smtp.someservice.com
+        host: smtp.example.com
         port: 1234
         username: mysmtpuser
         password: mysmtppasswd
@@ -31,7 +31,7 @@ tests:
       maingun.enabled: false
       smtp:
         enabled: true
-        host: smtp.someservice.com
+        host: smtp.example.com
         port: 1234
         username: mysmtpuser
         password: mysmtppasswd
@@ -56,7 +56,7 @@ tests:
       maingun.enabled: false
       smtp:
         enabled: true
-        host: smtp.someservice.com
+        host: smtp.example.com
         port: 1234
         username: mysmtpuser
         passwordFile: /etc/teleport/supersecretemailpw
@@ -71,7 +71,7 @@ tests:
       maingun.enabled: false
       smtp:
         enabled: true
-        host: smtp.someservice.com
+        host: smtp.example.com
         port: 1234
         username: mysmtpuser
         passwordFile: /etc/teleport/supersecretemailpw
@@ -86,7 +86,7 @@ tests:
       maingun.enabled: false
       smtp:
         enabled: true
-        host: smtp.someservice.com
+        host: smtp.example.com
         port: 1234
         username: mysmtpuser
         passwordFile: /etc/teleport/supersecretemailpw

--- a/charts/access/email/tests/configmap_test.yaml
+++ b/charts/access/email/tests/configmap_test.yaml
@@ -24,6 +24,31 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: should match the snapshot (smtp on, roleToRecipients set)
+    set:
+      teleport:
+        address: teleport.example.com:1234
+      maingun.enabled: false
+      smtp:
+        enabled: true
+        host: smtp.someservice.com
+        port: 1234
+        username: mysmtpuser
+        password: mysmtppasswd
+        starttlsPolicy: mandatory
+      delivery:
+        sender: teleport@example.com
+      roleToRecipients:
+        '*':
+          - security@mycompany.com
+        'dev':
+          - 'developers@mycompany.com'
+      log:
+        output: /var/log/teleport-email.log
+        severity: DEBUG
+    asserts:
+      - matchSnapshot: {}
+
   - it: should match the snapshot (smtp on, password file)
     set:
       teleport:

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -472,6 +472,33 @@
             },
             "additionalProperties": true
         },
+        "roleToRecipients": {
+            "$id": "#/properties/roleToRecipients",
+            "type": "object",
+            "default": {},
+            "examples": [
+                {
+                    "dev": [
+                        "devs-slack-channel"
+                    ],
+                    "*": [
+                        "admin@email.com",
+                        "admin-slack-channel"
+                    ]
+                }
+            ],
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "examples": [
+                        "example-slack-channel",
+                        "user@example.com"
+                    ]
+                },
+                "minItems": 1
+            }
+        },
         "log": {
             "$id": "#/properties/log",
             "type": "object",

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -77,6 +77,8 @@ delivery:
   sender: ""
   recipients: []
 
+roleToRecipients: {}
+
 log:
   output: stdout
   severity: INFO


### PR DESCRIPTION
Extends #459 with the new configuration value added in #488

## Testing

Tested with a MailGun sandbox instance using both the legacy (`delivery.recipients`) and the new setting, works as expected.

Related to #439