### PR TITLE
Update chart's snapshot (missing from 9.2.3 upgrade)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ update-helm-version:
 	$(SED) 's/appVersion: .*/appVersion: "$(VERSION)"/' charts/access/email/Chart.yaml
 	$(SED) 's/version: .*/version: "$(VERSION)"/' charts/access/email/Chart.yaml
 	# Update snapshots
-	@helm unittest -u charts/access/email || { echo "Please install unittest as described in .cloudbuild/helm-unittest.yaml" ; exit 1; }
+	@helm unittest -u charts/access/email || { echo "Please install unittest as described in .cloudbuild/ci/helm-unittest.yaml" ; exit 1; }
 
 .PHONY: update-tag
 update-tag:

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -160,8 +160,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.2.1
-        helm.sh/chart: teleport-plugin-email-9.2.1
+        app.kubernetes.io/version: 9.2.3
+        helm.sh/chart: teleport-plugin-email-9.2.3
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |


### PR DESCRIPTION
This is the output of
`make update-version VERSION=9.2.3`

There was a missing snapshot version update
There was a PR, based on 9.2.1 which added a new snapshot
This PR was rebased from master whose version was already 9.2.3 but we didn't upgrade the snapshot
This PR re-runs the `update-version` command

My only question is how did this PR got merged even though it had a failing step
https://github.com/gravitational/teleport-plugins/pull/547
EDIT it was not marked as required