### PR TITLE
Add installation instructions for the PagerDuty Helm chart

### DIFF
--- a/charts/access/pagerduty/README.md
+++ b/charts/access/pagerduty/README.md
@@ -2,6 +2,101 @@
 
 This chart sets up and configures a Deployment for the Access Request PagerDuty plugin.
 
+## Installation
+
+### Prerequisites
+
+First, you'll need to create a Teleport user and role for the plugin. The following file contains a minimal user that's needed for the plugin to work:
+
+```yaml
+---
+kind: role
+version: v5
+metadata:
+  name: teleport-plugin-pagerduty
+spec:
+  allow:
+    logins:
+    - teleport-plugin-pagerduty
+    rules:
+    - resources:
+      - access_request
+      verbs:
+      - list
+      - read
+      - update
+  options:
+    forward_agent: false
+    max_session_ttl: 8760h0m0s
+    port_forwarding: false
+---
+kind: user
+version: v2
+metadata:
+  name: teleport-plugin-pagerduty
+spec:
+  roles:
+    - teleport-plugin-pagerduty
+```
+
+You can either create the user and the roles by putting the YAML above into a file and issuing the following command  (you must be logged in with `tsh`):
+
+```
+tctl create user.yaml
+```
+
+or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` and `https://<yourserver>/web/roles` respectively. You'll also need to create a password for the user by either clicking `Options/Reset password...` under `https://<yourserver>/web/users` on the UI or issuing `tctl users reset teleport-plugin-pagerduty` in the command line.
+
+The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
+
+```
+tsh login --proxy=access-dev.teleportinfra.dev --auth local --user teleport-plugin-pagerduty --ttl 525600
+```
+
+```
+tctl auth sign --user teleport-plugin-pagerduty --ttl 8760h --out teleport-plugin-pagerduty-identity
+```
+
+Alternatively, you can execute the command above on one of the `auth` instances/pods.
+
+The last step is to create the secret. The following command will create a Kubernetes secret with the name `teleport-plugin-pagerduty-identity` with the key `auth_id` in it holding the contents of the file `teleport-plugin-pagerduty-identity`:
+
+```
+kubectl create secret generic teleport-plugin-pagerduty-identity --from-file=auth_id=teleport-plugin-pagerduty-identity
+```
+
+### Installing the plugin
+
+```
+helm repo add teleport https://charts.releases.teleport.dev/
+```
+
+```shell
+helm install teleport-plugin-pagerduty teleport/teleport-plugin-pagerduty --values teleport-plugin-pagerduty-values.yaml
+```
+
+Example `teleport-plugin-pagerduty-values.yaml`:
+
+```yaml
+teleport:
+  address: teleport.example.com:443
+  identitySecretName: teleport-plugin-pagerduty-identity
+
+pagerduty:
+  apiKey: pagerdutyapikey
+  userEmail: pagerduty-bot-user@example.com
+  notifyService: "request approvals"
+  servies:
+    - on-call
+    - support
+```
+
+See [Settings](#settings) for more details.
+
+### Setting up roles
+
+After the PagerDuty plugin has been set up correctly, you'll need to adjust the roles you'd like to set up with it by adding the proper annotations based on your use case. For more information, visit [Setting up Pagerduty notification alerts](../../../access/pagerduty/README.md#setting-up-pagerduty-notification-alerts) in the plugin's documentation.
+
 ## Settings
 
 The following values can be set for the Helm chart:

--- a/charts/access/pagerduty/README.md
+++ b/charts/access/pagerduty/README.md
@@ -50,7 +50,7 @@ or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` a
 The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
 
 ```
-tsh login --proxy=access-dev.teleportinfra.dev --auth local --user teleport-plugin-pagerduty --ttl 525600
+tsh login --proxy proxy.example.com --auth local --user teleport-plugin-pagerduty --ttl 525600
 ```
 
 ```

--- a/charts/access/pagerduty/README.md
+++ b/charts/access/pagerduty/README.md
@@ -41,7 +41,7 @@ spec:
 
 You can either create the user and the roles by putting the YAML above into a file and issuing the following command  (you must be logged in with `tsh`):
 
-```
+```console
 tctl create user.yaml
 ```
 
@@ -49,11 +49,11 @@ or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` a
 
 The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
 
-```
+```console
 tsh login --proxy proxy.example.com --auth local --user teleport-plugin-pagerduty --ttl 525600
 ```
 
-```
+```console
 tctl auth sign --user teleport-plugin-pagerduty --ttl 8760h --out teleport-plugin-pagerduty-identity
 ```
 
@@ -61,17 +61,17 @@ Alternatively, you can execute the command above on one of the `auth` instances/
 
 The last step is to create the secret. The following command will create a Kubernetes secret with the name `teleport-plugin-pagerduty-identity` with the key `auth_id` in it holding the contents of the file `teleport-plugin-pagerduty-identity`:
 
-```
+```console
 kubectl create secret generic teleport-plugin-pagerduty-identity --from-file=auth_id=teleport-plugin-pagerduty-identity
 ```
 
 ### Installing the plugin
 
-```
+```console
 helm repo add teleport https://charts.releases.teleport.dev/
 ```
 
-```shell
+```console
 helm install teleport-plugin-pagerduty teleport/teleport-plugin-pagerduty --values teleport-plugin-pagerduty-values.yaml
 ```
 

--- a/charts/access/pagerduty/values.yaml
+++ b/charts/access/pagerduty/values.yaml
@@ -2,8 +2,25 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# replicaCount: 1
+#
+# Plugin specific options
+#
+teleport:
+  address: ""
+  identitySecretName: ""
+  identitySecretPath: "auth_id"
 
+pagerduty:
+  apiKey: ""
+  userEmail: ""
+
+log:
+  output: stdout
+  severity: INFO
+
+#
+# Deployment
+#
 image:
   repository: quay.io/gravitational/teleport-plugin-pagerduty
   pullPolicy: IfNotPresent
@@ -40,19 +57,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-#
-# Plugin specific options
-#
-teleport:
-  address: ""
-  identitySecretName: ""
-  identitySecretPath: "auth_id"
-
-pagerduty:
-  apiKey: ""
-  userEmail: ""
-
-log:
-  output: stdout
-  severity: INFO


### PR DESCRIPTION
This change adds installation instructions to the documentation of the PagerDuty Helm chart.

Testing was done using an open source Teleport instance.

Part of #439 
Closes #499 