### PR TITLE
Add missing plugins to helm unittests

### DIFF
--- a/.cloudbuild/ci/helm-unittest.yaml
+++ b/.cloudbuild/ci/helm-unittest.yaml
@@ -6,4 +6,7 @@ steps:
       - |
         apk add openssl curl bash git &&
         helm plugin install --version=v1.0.16 https://github.com/vbehar/helm3-unittest &&
-        helm unittest ./charts/access/email
+        helm unittest ./charts/access/email &&
+        helm unittest ./charts/access/slack &&
+        helm unittest ./charts/access/pagerduty &&
+        helm unittest ./charts/access/mattermost


### PR DESCRIPTION
These Helm chart tests were missing from the PR builds