### PR TITLE
Change domain names in some example commands

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -50,7 +50,7 @@ or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` a
 The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
 
 ```
-tsh login --proxy=access-dev.teleportinfra.dev --auth local --user teleport-plugin-email --ttl 525600
+tsh login --proxy=proxy.example.com --auth local --user teleport-plugin-email --ttl 525600
 ```
 
 ```

--- a/charts/access/slack/README.md
+++ b/charts/access/slack/README.md
@@ -50,7 +50,7 @@ or by navigating to the Teleport Web UI under `https://<yourserver>/web/users` a
 The next step is to create an identity file, which contains a private/public key pair and a certificate that'll identify us as the user above. To do this, log in with the newly created credentials and issue a new certificate (525600 and 8760 are both roughly a year in minutes and hours respectively):
 
 ```
-tsh login --proxy=access-dev.teleportinfra.dev --auth local --user teleport-plugin-slack --ttl 525600
+tsh login --proxy=proxy.example.com --auth local --user teleport-plugin-slack --ttl 525600
 ```
 
 ```


### PR DESCRIPTION
These examples have accidentally spilled into the installation instructions. Removing them now.