### PR TITLE
Add Make Target: update go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,23 @@ update-tag:
 	git push origin terraform-provider-teleport-v$(VERSION)
 	git push origin v$(VERSION)
 
+
+.PHONY: update-goversion
+update-goversion:
+	# Make sure GOVERSION is set on the command line "make update-goversion GOVERSION=x.y.z".
+	@test $(GOVERSION)
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/jira/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/mattermost/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/slack/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/pagerduty/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/email/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' event-handler/Makefile
+	$(SED) 's/^RUNTIME ?= go.*/RUNTIME ?= go$(GOVERSION)/' docker/Makefile
+	$(SED) 's/- name: golang:.*/- name: golang:$(GOVERSION)/' .cloudbuild/ci/unit-tests-linux.yaml
+	$(SED) 's/image: golang:.*/image: golang:$(GOVERSION)/g' .drone.yml
+	$(SED) 's/GO_VERSION: go.*/GO_VERSION: go$(GOVERSION)/g' .drone.yml
+	@echo Please sign .drone.yml before staging and committing the changes
+
 #
 # Lint the Go code.
 # By default lint scans the entire repo. Pass GO_LINT_FLAGS='--new' to only scan local


### PR DESCRIPTION
This PR adds a new make target that updates the go version
Usage:
```shell
$ make update-goversion GOVERSION=1.17.11
```

<details>
<summary>Demo</summary>

`make update-goversion GOVERSION=1.17.12`
```shell
# Make sure GOVERSION is set on the command line "make update-goversion GOVERSION=x.y.z".
sed -i '2s/.*/GO_VERSION=1.17.12/' access/jira/Makefile
sed -i '2s/.*/GO_VERSION=1.17.12/' access/mattermost/Makefile
sed -i '2s/.*/GO_VERSION=1.17.12/' access/slack/Makefile
sed -i '2s/.*/GO_VERSION=1.17.12/' access/pagerduty/Makefile
sed -i '2s/.*/GO_VERSION=1.17.12/' access/email/Makefile
sed -i '2s/.*/GO_VERSION=1.17.12/' event-handler/Makefile
sed -i 's/^RUNTIME ?= go.*/RUNTIME ?= go1.17.12/' docker/Makefile
sed -i 's/- name: golang:.*/- name: golang:1.17.12/' .cloudbuild/ci/unit-tests-linux.yaml
sed -i 's/image: golang:.*/image: golang:1.17.12/g' .drone.yml
sed -i 's/GO_VERSION: go.*/GO_VERSION: go1.17.12/g' .drone.yml
Please sign .drone.yml before staging and committing the changes
```

`git diff`

```diff
diff --git a/.cloudbuild/ci/unit-tests-linux.yaml b/.cloudbuild/ci/unit-tests-linux.yaml
index 3b6ef5dc..d4dc9fe5 100644
--- a/.cloudbuild/ci/unit-tests-linux.yaml
+++ b/.cloudbuild/ci/unit-tests-linux.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: golang:1.17.11
+  - name: golang:1.17.12
     env:
       - TELEPORT_GET_VERSION=v9.0.4
     secretEnv:
diff --git a/.drone.yml b/.drone.yml
index 76f144cd..133a8dae 100644
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       - make lint
 
   - name: Run tests
-    image: golang:1.17.11
+    image: golang:1.17.12
     environment:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
@@ -62,7 +62,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.17.11
+      GO_VERSION: go1.17.12
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -119,7 +119,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.17.11
+    image: golang:1.17.12
marco@lenix ~/t/teleport-plugins (marco/make_target_bump_go)> git diff | echo

marco@lenix ~/t/teleport-plugins (marco/make_target_bump_go)> git diff | cat
diff --git a/.cloudbuild/ci/unit-tests-linux.yaml b/.cloudbuild/ci/unit-tests-linux.yaml
index 3b6ef5dc..d4dc9fe5 100644
--- a/.cloudbuild/ci/unit-tests-linux.yaml
+++ b/.cloudbuild/ci/unit-tests-linux.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: golang:1.17.11
+  - name: golang:1.17.12
     env:
       - TELEPORT_GET_VERSION=v9.0.4
     secretEnv:
diff --git a/.drone.yml b/.drone.yml
index 76f144cd..133a8dae 100644
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       - make lint
 
   - name: Run tests
-    image: golang:1.17.11
+    image: golang:1.17.12
     environment:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
@@ -62,7 +62,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.17.11
+      GO_VERSION: go1.17.12
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -119,7 +119,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - make build-all
 
@@ -155,7 +155,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.17.11
+      GO_VERSION: go1.17.12
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -209,7 +209,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - mkdir -p build/
       - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
@@ -339,7 +339,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - mkdir -p build/
       - make release/terraform
@@ -421,7 +421,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - mkdir -p build/
       - make release/event-handler
@@ -768,7 +768,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - cd tooling
       - |
@@ -823,7 +823,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - cd tooling
       - |
@@ -878,7 +878,7 @@ concurrency:
 
 steps:
   - name: Promote terraform provider to public registry
-    image: golang:1.17.11
+    image: golang:1.17.12
     commands:
       - cd tooling
       - |
diff --git a/access/email/Makefile b/access/email/Makefile
index 0672b8e9..faf23854 100644
--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-email
diff --git a/access/jira/Makefile b/access/jira/Makefile
index 948ca835..be506117 100644
--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-jira
diff --git a/access/mattermost/Makefile b/access/mattermost/Makefile
index e8c2e9ea..7d448b8c 100644
--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-mattermost
diff --git a/access/pagerduty/Makefile b/access/pagerduty/Makefile
index a0ae1413..5af3beb7 100644
--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-pagerduty
diff --git a/access/slack/Makefile b/access/slack/Makefile
index 9e1289bd..7c86fc70 100644
--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-slack
diff --git a/docker/Makefile b/docker/Makefile
index 7558060f..eea4691f 100644
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 # enterprise version, but has to be available on get.gravitational.com
 RELEASE ?= teleport-ent-v6.0.2-linux-amd64-bin
 
-RUNTIME ?= go1.17.11
+RUNTIME ?= go1.17.12
 BBOX ?= quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 
 # Teleport CLI and plugins CLI flags to pass to them on start
diff --git a/event-handler/Makefile b/event-handler/Makefile
index 02f029b9..356242b7 100644
--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -1,5 +1,5 @@
 VERSION=9.3.2
-GO_VERSION=1.17.11
+GO_VERSION=1.17.12
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
```

</details>
