### PR TITLE
Make test data more obviously fake

### DIFF
--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -9,7 +9,7 @@ should match the snapshot (mailgun on):
 
         [mailgun]
         domain      = "mymailgunsubdomain.mailgun.org"
-        private_key = "xoxb-71d75f662b0eac53565a38c8cc0316f6"
+        private_key = "xoxb-fakekey62b0eac53565a38c8cc0316f6"
 
 
         [delivery]

--- a/charts/access/email/tests/configmap_test.yaml
+++ b/charts/access/email/tests/configmap_test.yaml
@@ -101,6 +101,6 @@ tests:
       mailgun:
         enabled: true
         domain: mymailgunsubdomain.mailgun.org
-        privateKey: xoxb-71d75f662b0eac53565a38c8cc0316f6
+        privateKey: xoxb-fakekey62b0eac53565a38c8cc0316f6
     asserts:
       - matchSnapshot: {}

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -311,8 +311,8 @@
             "examples": [
                 {
                     "enabled": false,
-                    "domain": "sandboxbd81caddef744a69be0e5b544ab0c3bd.mailgun.org",
-                    "privateKey": "xoxb-11xx"
+                    "domain": "yourdomain.mailgun.org",
+                    "privateKey": "xoxb-fakekey62b0eac53565a38c8cc0316f6"
                 }
             ],
             "required": [
@@ -334,7 +334,7 @@
                     "type": "string",
                     "default": "",
                     "examples": [
-                        "sandboxbd81caddef744a69be0e5b544ab0c3bd.mailgun.org"
+                        "yourdomain.mailgun.org"
                     ]
                 },
                 "privateKey": {


### PR DESCRIPTION
We had a report that this looked like were were leaking internal data.
After testing the credential, it isn't valid: 

```
walt@work:~$ curl -s --user 'api:xoxb-71d75f662b0eac53565a38c8cc0316f6' https://api.mailgun.net/v3/domains
{"message":"Invalid private key"}
```

However we don't want any future researchers to make the same mistaken assumption.