### PR TITLE
Improve secret management in Helm charts

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -164,6 +164,20 @@ The following values can be set for the Helm chart:
     <td><code>""</code></td>
     <td>no</td>
   </tr>
+  <tr>
+    <td><code>mailgun.privateKeyFromSecret</code></td>
+    <td>Kubernetes secret to read the private key from instead of using <code>mailgun.privateKey</code></td>
+    <td>string</td>
+    <td><code>""</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>mailgun.privateKeySecretPath</code></td>
+    <td>The path of the private key in the secret described by <code>mailgun.privateKeyFromSecret</code></td>
+    <td>string</td>
+    <td><code>"mailgunPrivateKey"</code></td>
+    <td>no</td>
+  </tr>
 
   <tr>
     <td><code>smtp.enabled</code></td>
@@ -204,12 +218,17 @@ The following values can be set for the Helm chart:
     <td>no</td>
   </tr>
   <tr>
-    <td><code>smtp.passwordFile</code></td>
-    <td>
-      Path of the file that contains the password to be used with the SMTP server. Can be mounted via <code>volumes</code> and <code>volumeMounts</code>. Mutually exclusive with <code>smtp.password</code>.
-    </td>
+    <td><code>smtp.passwordFromSecret</code></td>
+    <td>Kubernetes secret to read the SMTP password from instead of using <code>smtp.password</code></td>
     <td>string</td>
     <td><code>""</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>smtp.passwordSecretPath</code></td>
+    <td>The path of the SMTP password in the secret described by <code>smtp.passwordFromSecret</code></td>
+    <td>string</td>
+    <td><code>"smtpPassword"</code></td>
     <td>no</td>
   </tr>
   <tr>

--- a/charts/access/email/templates/configmap.yaml
+++ b/charts/access/email/templates/configmap.yaml
@@ -12,18 +12,14 @@ data:
 
     {{ if .Values.mailgun.enabled -}}
     [mailgun]
-    domain      = "{{ .Values.mailgun.domain }}"
-    private_key = "{{ .Values.mailgun.privateKey }}"
+    domain           = "{{ .Values.mailgun.domain }}"
+    private_key_file = "/var/lib/teleport/plugins/email/mailgun_private_key"
     {{ else if .Values.smtp.enabled -}}
     [smtp]
-    host          = "{{ .Values.smtp.host }}"
-    port          = {{ .Values.smtp.port }}
-    username      = "{{ .Values.smtp.username }}"
-    {{ if eq .Values.smtp.passwordFile "" -}}
-    password      = "{{ .Values.smtp.password }}"
-    {{ else -}}
-    password_file = "{{ .Values.smtp.passwordFile }}"
-    {{ end }}
+    host            = "{{ .Values.smtp.host }}"
+    port            = {{ .Values.smtp.port }}
+    username        = "{{ .Values.smtp.username }}"
+    password_file   = "/var/lib/teleport/plugins/email/smtp_password"
     starttls_policy = "{{ .Values.smtp.starttlsPolicy }}"
     {{- end }}
 

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -53,7 +53,8 @@ spec:
               {{- if .Values.mailgun.enabled }}
               mountPath: "/var/lib/teleport/plugins/email/mailgun_private_key"
               subPath: "{{ .Values.mailgun.privateKeySecretPath }}"
-              {{- else }}
+              {{- end }}
+              {{- if .Values.smtp.enabled }}
               mountPath: "/var/lib/teleport/plugins/email/smtp_password"
               subPath: "{{ .Values.smtp.passwordSecretPath }}"
               {{- end }}
@@ -82,6 +83,7 @@ spec:
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
             defaultMode: 0600
+        {{- if or .Values.smtp.enabled .Values.mailgun.enabled }}
         {{- if .Values.smtp.enabled }}
         - name: {{ .Values.secretVolumeName }}
           secret:
@@ -93,6 +95,7 @@ spec:
           secret:
             secretName: "{{ coalesce .Values.mailgun.privateKeyFromSecret (printf "%s-secret" (include "email.fullname" .)) }}"
             defaultMode: 0600
+        {{- end }}
         {{- end }}
         {{- with .Values.volumes -}}
           {{- toYaml . | nindent 8 }}

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               mountPath: /var/lib/teleport/plugins/email/auth_id
               subPath: {{ .Values.teleport.identitySecretPath }}
             {{- if or .Values.mailgun.enabled .Values.smtp.enabled }}
-            - name: password-file
+            - name: {{ .Values.secretVolumeName }}
               {{- if .Values.mailgun.enabled }}
               mountPath: "/var/lib/teleport/plugins/email/mailgun_private_key"
               subPath: mailgunPrivateKey
@@ -83,7 +83,7 @@ spec:
             secretName: "{{ .Values.teleport.identitySecretName }}"
             defaultMode: 0600
         {{- if or .Values.mailgun.enabled .Values.smtp.enabled }}
-        - name: password-file
+        - name: {{ .Values.secretVolumeName }}
           secret:
             secretName: "{{ include "email.fullname" . }}-password"
             defaultMode: 0600

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -48,6 +48,16 @@ spec:
             - name: auth-id
               mountPath: /var/lib/teleport/plugins/email/auth_id
               subPath: {{ .Values.teleport.identitySecretPath }}
+            {{- if or .Values.mailgun.enabled .Values.smtp.enabled }}
+            - name: password-file
+              {{- if .Values.mailgun.enabled }}
+              mountPath: "/var/lib/teleport/plugins/email/mailgun_private_key"
+              subPath: mailgunPrivateKey
+              {{- else }}
+              mountPath: "/var/lib/teleport/plugins/email/smtp_password"
+              subPath: smtpPassword
+              {{- end }}
+            {{- end }}
             {{- with .Values.volumeMounts -}}
               {{- toYaml . | nindent 12 }}
             {{- end}}
@@ -72,6 +82,12 @@ spec:
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
             defaultMode: 0600
+        {{- if or .Values.mailgun.enabled .Values.smtp.enabled }}
+        - name: password-file
+          secret:
+            secretName: "{{ include "email.fullname" . }}-password"
+            defaultMode: 0600
+        {{- end }}
         {{- with .Values.volumes -}}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -85,13 +85,13 @@ spec:
         {{- if .Values.smtp.enabled }}
         - name: {{ .Values.secretVolumeName }}
           secret:
-            secretName: "{{ coalesce .Values.smtp.passwordFromSecret (printf "%s-password" (include "email.fullname" .)) }}"
+            secretName: "{{ coalesce .Values.smtp.passwordFromSecret (printf "%s-secret" (include "email.fullname" .)) }}"
             defaultMode: 0600
         {{- end }}
         {{- if .Values.mailgun.enabled }}
         - name: {{ .Values.secretVolumeName }}
           secret:
-            secretName: "{{ coalesce .Values.mailgun.privateKeyFromSecret (printf "%s-password" (include "email.fullname" .)) }}"
+            secretName: "{{ coalesce .Values.mailgun.privateKeyFromSecret (printf "%s-secret" (include "email.fullname" .)) }}"
             defaultMode: 0600
         {{- end }}
         {{- with .Values.volumes -}}

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -52,10 +52,10 @@ spec:
             - name: {{ .Values.secretVolumeName }}
               {{- if .Values.mailgun.enabled }}
               mountPath: "/var/lib/teleport/plugins/email/mailgun_private_key"
-              subPath: mailgunPrivateKey
+              subPath: "{{ .Values.mailgun.privateKeySecretPath }}"
               {{- else }}
               mountPath: "/var/lib/teleport/plugins/email/smtp_password"
-              subPath: smtpPassword
+              subPath: "{{ .Values.smtp.passwordSecretPath }}"
               {{- end }}
             {{- end }}
             {{- with .Values.volumeMounts -}}
@@ -82,10 +82,16 @@ spec:
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
             defaultMode: 0600
-        {{- if or .Values.mailgun.enabled .Values.smtp.enabled }}
+        {{- if .Values.smtp.enabled }}
         - name: {{ .Values.secretVolumeName }}
           secret:
-            secretName: "{{ include "email.fullname" . }}-password"
+            secretName: "{{ coalesce .Values.smtp.passwordFromSecret (printf "%s-password" (include "email.fullname" .)) }}"
+            defaultMode: 0600
+        {{- end }}
+        {{- if .Values.mailgun.enabled }}
+        - name: {{ .Values.secretVolumeName }}
+          secret:
+            secretName: "{{ coalesce .Values.mailgun.privateKeyFromSecret (printf "%s-password" (include "email.fullname" .)) }}"
             defaultMode: 0600
         {{- end }}
         {{- with .Values.volumes -}}

--- a/charts/access/email/templates/secret.yaml
+++ b/charts/access/email/templates/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "email.fullname" . }}-password
+  name: {{ include "email.fullname" . }}-secret
 data:
   {{- if .Values.mailgun.enabled }}
   mailgunPrivateKey: {{ .Values.mailgun.privateKey | b64enc }}

--- a/charts/access/email/templates/secret.yaml
+++ b/charts/access/email/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{ if or .Values.mailgun.enabled .Values.smtp.enabled }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "email.fullname" . }}-password
+data:
+  {{- if .Values.mailgun.enabled }}
+  mailgunPrivateKey: {{ .Values.mailgun.privateKey | b64enc }}
+  {{- end }}
+  {{- if .Values.smtp.enabled }}
+  smtpPassword: {{ b64enc .Values.smtp.password }}
+  {{- end }}
+{{- end }}

--- a/charts/access/email/templates/secret.yaml
+++ b/charts/access/email/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{ if or .Values.mailgun.enabled .Values.smtp.enabled }}
+{{- if or (and .Values.mailgun.enabled (not .Values.mailgun.privateKeyFromSecret))
+         (and .Values.smtp.enabled (not .Values.smtp.passwordFromSecret)) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,8 +8,8 @@ should match the snapshot (mailgun on):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [mailgun]
-        domain      = "mymailgunsubdomain.mailgun.org"
-        private_key = "xoxb-fakekey62b0eac53565a38c8cc0316f6"
+        domain           = "mymailgunsubdomain.mailgun.org"
+        private_key_file = "/var/lib/teleport/plugins/email/mailgun_private_key"
 
 
         [delivery]
@@ -38,11 +38,10 @@ should match the snapshot (smtp on):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.example.com"
-        port          = 1234
-        username      = "mysmtpuser"
-        password      = "mysmtppasswd"
-
+        host            = "smtp.example.com"
+        port            = 1234
+        username        = "mysmtpuser"
+        password_file   = "/var/lib/teleport/plugins/email/smtp_password"
         starttls_policy = "mandatory"
 
         [delivery]
@@ -71,11 +70,10 @@ should match the snapshot (smtp on, no starttls):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.example.com"
-        port          = 1234
-        username      = "mysmtpuser"
-        password_file = "/etc/teleport/supersecretemailpw"
-
+        host            = "smtp.example.com"
+        port            = 1234
+        username        = "mysmtpuser"
+        password_file   = "/var/lib/teleport/plugins/email/smtp_password"
         starttls_policy = "mandatory"
 
         [delivery]
@@ -104,11 +102,10 @@ should match the snapshot (smtp on, password file):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.example.com"
-        port          = 1234
-        username      = "mysmtpuser"
-        password_file = "/etc/teleport/supersecretemailpw"
-
+        host            = "smtp.example.com"
+        port            = 1234
+        username        = "mysmtpuser"
+        password_file   = "/var/lib/teleport/plugins/email/smtp_password"
         starttls_policy = "mandatory"
 
         [delivery]
@@ -137,11 +134,10 @@ should match the snapshot (smtp on, roleToRecipients set):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.example.com"
-        port          = 1234
-        username      = "mysmtpuser"
-        password      = "mysmtppasswd"
-
+        host            = "smtp.example.com"
+        port            = 1234
+        username        = "mysmtpuser"
+        password_file   = "/var/lib/teleport/plugins/email/smtp_password"
         starttls_policy = "mandatory"
 
         [delivery]
@@ -173,11 +169,10 @@ should match the snapshot (smtp on, starttls disabled):
         identity = "/var/lib/teleport/plugins/email/auth_id"
 
         [smtp]
-        host          = "smtp.example.com"
-        port          = 1234
-        username      = "mysmtpuser"
-        password_file = "/etc/teleport/supersecretemailpw"
-
+        host            = "smtp.example.com"
+        port            = 1234
+        username        = "mysmtpuser"
+        password_file   = "/var/lib/teleport/plugins/email/smtp_password"
         starttls_policy = "disabled"
 
         [delivery]

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -54,3 +54,129 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
+should match the snapshot (mailgun on):
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-email-9.3.4
+      name: RELEASE-NAME-teleport-plugin-email
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-email
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-email
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-email.toml
+            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-email
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-email.toml
+              name: config
+              subPath: teleport-email.toml
+            - mountPath: /var/lib/teleport/plugins/email/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/email/mailgun_private_key
+              name: password-file
+              subPath: mailgunPrivateKey
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-email
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-email-password
+should match the snapshot (smtp on):
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-email-9.3.4
+      name: RELEASE-NAME-teleport-plugin-email
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-email
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-email
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-email.toml
+            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-email
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-email.toml
+              name: config
+              subPath: teleport-email.toml
+            - mountPath: /var/lib/teleport/plugins/email/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/email/smtp_password
+              name: password-file
+              subPath: smtpPassword
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-email
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-email-password

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -1,4 +1,4 @@
-should be possible to change volume name (smtp on):
+should be possible to override volume name (smtp on):
   1: |
     apiVersion: apps/v1
     kind: Deployment
@@ -243,3 +243,129 @@ should match the snapshot (smtp on):
             secret:
               defaultMode: 384
               secretName: RELEASE-NAME-teleport-plugin-email-password
+should mount external secret (mailgun on):
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-email-9.3.4
+      name: RELEASE-NAME-teleport-plugin-email
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-email
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-email
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-email.toml
+            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-email
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-email.toml
+              name: config
+              subPath: teleport-email.toml
+            - mountPath: /var/lib/teleport/plugins/email/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/email/mailgun_private_key
+              name: password-file
+              subPath: my-path-in-secret
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-email
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: my-secret-name
+should mount external secret (smtp on):
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-email-9.3.4
+      name: RELEASE-NAME-teleport-plugin-email
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-email
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-email
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-email.toml
+            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-email
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-email.toml
+              name: config
+              subPath: teleport-email.toml
+            - mountPath: /var/lib/teleport/plugins/email/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/email/smtp_password
+              name: password-file
+              subPath: my-path-in-secret
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-email
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: my-secret-name

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-email-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-email-9.3.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -28,7 +28,7 @@ should be possible to override volume name (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.6
+            image: quay.io/gravitational/teleport-plugin-email:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -126,8 +126,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-email-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-email-9.3.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -147,7 +147,7 @@ should match the snapshot (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.6
+            image: quay.io/gravitational/teleport-plugin-email:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -189,8 +189,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-email-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-email-9.3.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -210,7 +210,7 @@ should match the snapshot (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.6
+            image: quay.io/gravitational/teleport-plugin-email:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -252,8 +252,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-email-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-email-9.3.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -273,7 +273,7 @@ should mount external secret (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.6
+            image: quay.io/gravitational/teleport-plugin-email:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -315,8 +315,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-email-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-email-9.3.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -336,7 +336,7 @@ should mount external secret (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.6
+            image: quay.io/gravitational/teleport-plugin-email:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-email-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-email-9.3.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -28,7 +28,7 @@ should be possible to override volume name (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.5
+            image: quay.io/gravitational/teleport-plugin-email:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -126,8 +126,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-email-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-email-9.3.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -147,7 +147,7 @@ should match the snapshot (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.5
+            image: quay.io/gravitational/teleport-plugin-email:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -189,8 +189,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-email-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-email-9.3.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -210,7 +210,7 @@ should match the snapshot (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.5
+            image: quay.io/gravitational/teleport-plugin-email:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -252,8 +252,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-email-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-email-9.3.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -273,7 +273,7 @@ should mount external secret (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.5
+            image: quay.io/gravitational/teleport-plugin-email:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -315,8 +315,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-email-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-email-9.3.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -336,7 +336,7 @@ should mount external secret (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.5
+            image: quay.io/gravitational/teleport-plugin-email:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -1,3 +1,66 @@
+should be possible to change volume name (smtp on):
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-email
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-email-9.3.4
+      name: RELEASE-NAME-teleport-plugin-email
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-email
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-email
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-email.toml
+            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-email
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-email.toml
+              name: config
+              subPath: teleport-email.toml
+            - mountPath: /var/lib/teleport/plugins/email/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/email/smtp_password
+              name: secret-volume
+              subPath: smtpPassword
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-email
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: secret-volume
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-email-password
 should match the snapshot:
   1: |
     apiVersion: apps/v1

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-email-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-email-9.3.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -28,7 +28,7 @@ should be possible to override volume name (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            image: quay.io/gravitational/teleport-plugin-email:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -126,8 +126,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-email-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-email-9.3.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -147,7 +147,7 @@ should match the snapshot (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            image: quay.io/gravitational/teleport-plugin-email:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -189,8 +189,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-email-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-email-9.3.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -210,7 +210,7 @@ should match the snapshot (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            image: quay.io/gravitational/teleport-plugin-email:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -252,8 +252,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-email-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-email-9.3.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -273,7 +273,7 @@ should mount external secret (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            image: quay.io/gravitational/teleport-plugin-email:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -315,8 +315,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-email-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-email-9.3.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -336,7 +336,7 @@ should mount external secret (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:9.3.4
+            image: quay.io/gravitational/teleport-plugin-email:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -60,7 +60,7 @@ should be possible to override volume name (smtp on):
           - name: secret-volume
             secret:
               defaultMode: 384
-              secretName: RELEASE-NAME-teleport-plugin-email-password
+              secretName: RELEASE-NAME-teleport-plugin-email-secret
 should match the snapshot:
   1: |
     apiVersion: apps/v1
@@ -179,7 +179,7 @@ should match the snapshot (mailgun on):
           - name: password-file
             secret:
               defaultMode: 384
-              secretName: RELEASE-NAME-teleport-plugin-email-password
+              secretName: RELEASE-NAME-teleport-plugin-email-secret
 should match the snapshot (smtp on):
   1: |
     apiVersion: apps/v1
@@ -242,7 +242,7 @@ should match the snapshot (smtp on):
           - name: password-file
             secret:
               defaultMode: 384
-              secretName: RELEASE-NAME-teleport-plugin-email-password
+              secretName: RELEASE-NAME-teleport-plugin-email-secret
 should mount external secret (mailgun on):
   1: |
     apiVersion: apps/v1

--- a/charts/access/email/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/secret_test.yaml.snap
@@ -5,7 +5,7 @@ should match the snapshot (mailgun on):
       mailgunPrivateKey: LS0tIFRFU1QgUFJJVkFURSBLRVkgLS0t
     kind: Secret
     metadata:
-      name: RELEASE-NAME-teleport-plugin-email-password
+      name: RELEASE-NAME-teleport-plugin-email-secret
     type: Opaque
 should match the snapshot (smtp on):
   1: |
@@ -14,5 +14,5 @@ should match the snapshot (smtp on):
       smtpPassword: bXlzbXRwcGFzc3dk
     kind: Secret
     metadata:
-      name: RELEASE-NAME-teleport-plugin-email-password
+      name: RELEASE-NAME-teleport-plugin-email-secret
     type: Opaque

--- a/charts/access/email/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,18 @@
+should match the snapshot (mailgun on):
+  1: |
+    apiVersion: v1
+    data:
+      mailgunPrivateKey: LS0tIFRFU1QgUFJJVkFURSBLRVkgLS0t
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-email-password
+    type: Opaque
+should match the snapshot (smtp on):
+  1: |
+    apiVersion: v1
+    data:
+      smtpPassword: bXlzbXRwcGFzc3dk
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-email-password
+    type: Opaque

--- a/charts/access/email/tests/configmap_test.yaml
+++ b/charts/access/email/tests/configmap_test.yaml
@@ -1,4 +1,4 @@
-suite: Test deployment
+suite: Test configmap
 templates:
   - configmap.yaml
 tests:
@@ -6,7 +6,7 @@ tests:
     set:
       teleport:
         address: teleport.example.com:1234
-      maingun.enabled: false
+      mailgun.enabled: false
       smtp:
         enabled: true
         host: smtp.example.com
@@ -28,7 +28,7 @@ tests:
     set:
       teleport:
         address: teleport.example.com:1234
-      maingun.enabled: false
+      mailgun.enabled: false
       smtp:
         enabled: true
         host: smtp.example.com
@@ -53,7 +53,7 @@ tests:
     set:
       teleport:
         address: teleport.example.com:1234
-      maingun.enabled: false
+      mailgun.enabled: false
       smtp:
         enabled: true
         host: smtp.example.com
@@ -68,7 +68,7 @@ tests:
     set:
       teleport:
         address: teleport.example.com:1234
-      maingun.enabled: false
+      mailgun.enabled: false
       smtp:
         enabled: true
         host: smtp.example.com
@@ -83,7 +83,7 @@ tests:
     set:
       teleport:
         address: teleport.example.com:1234
-      maingun.enabled: false
+      mailgun.enabled: false
       smtp:
         enabled: true
         host: smtp.example.com

--- a/charts/access/email/tests/deployment_test.yaml
+++ b/charts/access/email/tests/deployment_test.yaml
@@ -23,3 +23,11 @@ tests:
         enabled: true
     asserts:
       - matchSnapshot: {}
+
+  - it: should be possible to override volume name (smtp on)
+    set:
+      smtp:
+        enabled: true
+      secretVolumeName: "secret-volume"
+    asserts:
+      - matchSnapshot: {}

--- a/charts/access/email/tests/deployment_test.yaml
+++ b/charts/access/email/tests/deployment_test.yaml
@@ -9,3 +9,17 @@ tests:
         tag: v98.76.54
     asserts:
       - matchSnapshot: {}
+
+  - it: should match the snapshot (mailgun on)
+    set:
+      mailgun:
+        enabled: true
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should match the snapshot (smtp on)
+    set:
+      smtp:
+        enabled: true
+    asserts:
+      - matchSnapshot: {}

--- a/charts/access/email/tests/deployment_test.yaml
+++ b/charts/access/email/tests/deployment_test.yaml
@@ -31,3 +31,21 @@ tests:
       secretVolumeName: "secret-volume"
     asserts:
       - matchSnapshot: {}
+
+  - it: should mount external secret (mailgun on)
+    set:
+      mailgun:
+        enabled: true
+        privateKeyFromSecret: my-secret-name
+        privateKeySecretPath: my-path-in-secret
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should mount external secret (smtp on)
+    set:
+      smtp:
+        enabled: true
+        passwordFromSecret: my-secret-name
+        passwordSecretPath: my-path-in-secret
+    asserts:
+      - matchSnapshot: {}

--- a/charts/access/email/tests/secret_test.yaml
+++ b/charts/access/email/tests/secret_test.yaml
@@ -23,3 +23,21 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not exist (smtp.passwordFromSecret used)
+    set:
+      smtp:
+        enabled: true
+        passwordFromSecret: teleport-email-plugin-smtp
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not exist (mailgun.privateKeyFromSecret used)
+    set:
+      mailgun:
+        enabled: true
+        privateKeyFromSecret: teleport-email-plugin-mailgun
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/access/email/tests/secret_test.yaml
+++ b/charts/access/email/tests/secret_test.yaml
@@ -1,0 +1,25 @@
+suite: Test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should match the snapshot (smtp on)
+    set:
+      mailgun.enabled: false
+      smtp:
+        enabled: true
+        password: mysmtppasswd
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should match the snapshot (mailgun on)
+    set:
+      mailgun:
+        enabled: true
+        privateKey: "--- TEST PRIVATE KEY ---"
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should not exist (both off)
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -344,6 +344,22 @@
                     "examples": [
                         "xoxb-11xx"
                     ]
+                },
+                "privateKeyFromSecret": {
+                    "$id": "#/properties/mailgun/properties/privateKeyFromSecret",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "my-secret-name"
+                    ]
+                },
+                "privateKeySecretPath": {
+                    "$id": "#/properties/mailgun/properties/privateKeySecretPath",
+                    "type": "string",
+                    "default": "mailgunPrivateKey",
+                    "examples": [
+                        "my-path-in-secret"
+                    ]
                 }
             },
             "additionalProperties": true
@@ -405,6 +421,16 @@
                     "$id": "#/properties/smtp/properties/password",
                     "type": "string",
                     "default": ""
+                },
+                "passwordFromSecret": {
+                    "$id": "#/properties/smtp/properties/passwordFromSecret",
+                    "type": "string",
+                    "default": ""
+                },
+                "passwordSecretPath": {
+                    "$id": "#/properties/smtp/properties/passwordSecretPath",
+                    "type": "string",
+                    "default": "smtpPassword"
                 },
                 "starttlsPolicy": {
                     "$id": "#/properties/smtp/properties/starttlsPolicy",
@@ -492,6 +518,14 @@
                 },
                 "minItems": 1
             }
+        },
+        "secretVolumeName": {
+            "$id": "#/properties/secretVolumeName",
+            "type": "string",
+            "default": "password-file",
+            "examples": [
+                "my-secret-volume"
+            ]
         },
         "log": {
             "$id": "#/properties/log",

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -359,7 +359,6 @@
                     "port": 587,
                     "username": "username@example.com",
                     "password": "",
-                    "passwordFile": "",
                     "starttlsPolicy": "mandatory"
                 }
             ],
@@ -404,11 +403,6 @@
                 },
                 "password": {
                     "$id": "#/properties/smtp/properties/password",
-                    "type": "string",
-                    "default": ""
-                },
-                "passwordFile": {
-                    "$id": "#/properties/smtp/properties/passwordFile",
                     "type": "string",
                     "default": ""
                 },

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -21,7 +21,6 @@ smtp:
   port: 587
   username: ""
   password: ""
-  passwordFile: ""
   starttlsPolicy: "mandatory"
 
 delivery:

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -14,6 +14,8 @@ mailgun:
   enabled: false
   domain: ""
   privateKey: ""
+  privateKeyFromSecret: ""
+  privateKeySecretPath: "mailgunPrivateKey"
 
 smtp:
   enabled: false
@@ -21,6 +23,8 @@ smtp:
   port: 587
   username: ""
   password: ""
+  passwordFromSecret: ""
+  passwordSecretPath: "smtpPassword"
   starttlsPolicy: "mandatory"
 
 delivery:

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -55,23 +55,10 @@ fullnameOverride: ""
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 nodeSelector: {}
 
@@ -80,11 +67,5 @@ tolerations: []
 affinity: {}
 
 volumes: []
-  # - name: password-file
-  #   secret:
-  #     secretName: teleport-email-plugin-password-file
-  #     defaultMode: 0600
 
 volumeMounts: []
-  # - name: password-file
-  #   mountPath: /var/lib/teleport/plugins/email/smtp_password

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -29,6 +29,8 @@ delivery:
 
 roleToRecipients: {}
 
+secretVolumeName: "password-file"
+
 log:
   output: stdout
   severity: INFO

--- a/charts/access/jira/Chart.yaml
+++ b/charts/access/jira/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "9.3.4"
+version: "9.3.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "9.3.4"
+appVersion: "9.3.7"

--- a/charts/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -31,6 +31,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-jira-9.3.4
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-jira-9.3.7
       name: RELEASE-NAME-teleport-plugin-jira

--- a/charts/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-jira-9.3.4
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-jira-9.3.7
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1

--- a/charts/access/mattermost/README.md
+++ b/charts/access/mattermost/README.md
@@ -140,6 +140,20 @@ The following values can be set for the Helm chart:
     <td>yes</td>
   </tr>
   <tr>
+    <td><code>mattermost.tokenFromSecret</code></td>
+    <td>Kubernetes secret to read the token from instead of <code>mattermost.token</code></td>
+    <td>string</td>
+    <td><code>""</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>mattermost.tokenSecretPath</code></td>
+    <td>The path of the token in the secret described by <code>mattermost.tokenFromSecret</code></td>
+    <td>string</td>
+    <td><code>"mattermostToken"</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
     <td><code>mattermost.recipients</code></td>
     <td>Array of the recipients the plugin should send access requests to.</td>
     <td>array</td>

--- a/charts/access/mattermost/templates/configmap.yaml
+++ b/charts/access/mattermost/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
 
     [mattermost]
     url        = "{{ .Values.mattermost.url }}"
-    token      = "{{ .Values.mattermost.token }}"
+    token      = "/var/lib/teleport/plugins/mattermost/mattermost_token"
     recipients = {{ .Values.mattermost.recipients | toJson }}
 
     [log]

--- a/charts/access/mattermost/templates/deployment.yaml
+++ b/charts/access/mattermost/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: auth-id
               mountPath: /var/lib/teleport/plugins/mattermost/auth_id
               subPath: {{ .Values.teleport.identitySecretPath }}
+            - name: {{ .Values.secretVolumeName }}
+              mountPath: /var/lib/teleport/plugins/mattermost/mattermost_token
+              subPath: {{ .Values.mattermost.tokenSecretPath }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -68,4 +71,8 @@ spec:
         - name: auth-id
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
+            defaultMode: 0600
+        - name: {{ .Values.secretVolumeName }}
+          secret:
+            secretName: "{{ coalesce .Values.mattermost.tokenFromSecret (printf "%s-secret" (include "mattermost.fullname" .)) }}"
             defaultMode: 0600

--- a/charts/access/mattermost/templates/secret.yaml
+++ b/charts/access/mattermost/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if not .Values.mattermost.tokenFromSecret -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "mattermost.fullname" . }}-secret
+data:
+  mattermostToken: {{ .Values.mattermost.token | b64enc }}
+{{- end }}

--- a/charts/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -9,7 +9,7 @@ should match the snapshot:
 
         [mattermost]
         url        = "https://my.mattermost.com"
-        token      = "test-mattermost-token"
+        token      = "/var/lib/teleport/plugins/mattermost/mattermost_token"
         recipients = ["security@example.com"]
 
         [log]

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -70,8 +70,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-mattermost-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-mattermost-9.3.7
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -91,7 +91,7 @@ should mount external secret:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.6
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -133,8 +133,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.6
-        helm.sh/chart: teleport-plugin-mattermost-9.3.6
+        app.kubernetes.io/version: 9.3.7
+        helm.sh/chart: teleport-plugin-mattermost-9.3.7
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -154,7 +154,7 @@ should override volume name:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.6
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -70,8 +70,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-mattermost-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-mattermost-9.3.6
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -91,7 +91,7 @@ should mount external secret:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.5
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -133,8 +133,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.5
-        helm.sh/chart: teleport-plugin-mattermost-9.3.5
+        app.kubernetes.io/version: 9.3.6
+        helm.sh/chart: teleport-plugin-mattermost-9.3.6
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -154,7 +154,7 @@ should override volume name:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.5
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -70,8 +70,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-mattermost-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-mattermost-9.3.5
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -91,7 +91,7 @@ should mount external secret:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.4
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -133,8 +133,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 9.3.4
-        helm.sh/chart: teleport-plugin-mattermost-9.3.4
+        app.kubernetes.io/version: 9.3.5
+        helm.sh/chart: teleport-plugin-mattermost-9.3.5
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -154,7 +154,7 @@ should override volume name:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.4
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -44,6 +44,9 @@ should match the snapshot:
             - mountPath: /var/lib/teleport/plugins/mattermost/auth_id
               name: auth-id
               subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/mattermost/mattermost_token
+              name: password-file
+              subPath: mattermostToken
           securityContext: {}
           volumes:
           - configMap:
@@ -54,3 +57,133 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-mattermost-secret
+should mount external secret:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-mattermost
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-mattermost-9.3.4
+      name: RELEASE-NAME-teleport-plugin-mattermost
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-mattermost
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-mattermost
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-mattermost.toml
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-mattermost
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-mattermost.toml
+              name: config
+              subPath: teleport-mattermost.toml
+            - mountPath: /var/lib/teleport/plugins/mattermost/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/mattermost/mattermost_token
+              name: password-file
+              subPath: my-token-in-secret
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-mattermost
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: my-mattermost-secret
+should override volume name:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-mattermost
+        app.kubernetes.io/version: 9.3.4
+        helm.sh/chart: teleport-plugin-mattermost-9.3.4
+      name: RELEASE-NAME-teleport-plugin-mattermost
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-mattermost
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: teleport-plugin-mattermost
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-mattermost.toml
+            image: quay.io/gravitational/teleport-plugin-mattermost:9.3.4
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-mattermost
+            ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-mattermost.toml
+              name: config
+              subPath: teleport-mattermost.toml
+            - mountPath: /var/lib/teleport/plugins/mattermost/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/mattermost/mattermost_token
+              name: my-secret-volume
+              subPath: mattermostToken
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-mattermost
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: my-secret-volume
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-mattermost-secret

--- a/charts/access/mattermost/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,9 @@
+should contain the token:
+  1: |
+    apiVersion: v1
+    data:
+      mattermostToken: bXltYXR0ZXJtb3N0dG9rZW4=
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-mattermost-secret
+    type: Opaque

--- a/charts/access/mattermost/tests/deployment_test.yaml
+++ b/charts/access/mattermost/tests/deployment_test.yaml
@@ -9,3 +9,17 @@ tests:
         tag: v98.76.54
     asserts:
       - matchSnapshot: {}
+
+  - it: should mount external secret
+    set:
+      mattermost:
+        tokenFromSecret: my-mattermost-secret
+        tokenSecretPath: my-token-in-secret
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should override volume name
+    set:
+      secretVolumeName: my-secret-volume
+    asserts:
+      - matchSnapshot: {}

--- a/charts/access/mattermost/tests/secret_test.yaml
+++ b/charts/access/mattermost/tests/secret_test.yaml
@@ -1,0 +1,18 @@
+suite: Test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should contain the token
+    set:
+      mattermost:
+        token: mymattermosttoken
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should not exist when using external secret
+    set:
+      mattermost:
+        tokenFromSecret: my-mattermost-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/access/mattermost/values.schema.json
+++ b/charts/access/mattermost/values.schema.json
@@ -317,6 +317,22 @@
                         "example-token"
                     ]
                 },
+                "tokenFromSecret": {
+                    "$id": "#/properties/mattermost/properties/tokenFromSecret",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "my-mattermost-secret"
+                    ]
+                },
+                "tokenSecretPath": {
+                    "$id": "#/properties/mattermost/properties/tokenSecretPath",
+                    "type": "string",
+                    "default": "pagerdutyApiKey",
+                    "examples": [
+                        "pagerdutyApiKey"
+                    ]
+                },
                 "recipients": {
                     "$id": "#/properties/mattermost/properties/recipients",
                     "type": "array",
@@ -343,6 +359,14 @@
                 }
             },
             "additionalProperties": true
+        },
+        "secretVolumeName": {
+            "$id": "#/properties/secretVolumeName",
+            "type": "string",
+            "default": "password-file",
+            "examples": [
+                "my-secret-volume"
+            ]
         },
         "log": {
             "$id": "#/properties/log",

--- a/charts/access/mattermost/values.yaml
+++ b/charts/access/mattermost/values.yaml
@@ -13,11 +13,15 @@ teleport:
 mattermost:
   url: ""
   token: ""
+  tokenFromSecret: ""
+  tokenSecretPath: "mattermostToken"
   recipients: []
 
 log:
   output: stdout
   severity: INFO
+
+secretVolumeName: "password-file"
 
 image:
   repository: quay.io/gravitational/teleport-plugin-mattermost

--- a/charts/access/mattermost/values.yaml
+++ b/charts/access/mattermost/values.yaml
@@ -2,7 +2,22 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# replicaCount: 1
+#
+# Plugin specific options
+#
+teleport:
+  address: ""
+  identitySecretName: ""
+  identitySecretPath: "auth_id"
+
+mattermost:
+  url: ""
+  token: ""
+  recipients: []
+
+log:
+  output: stdout
+  severity: INFO
 
 image:
   repository: quay.io/gravitational/teleport-plugin-mattermost
@@ -40,20 +55,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-#
-# Plugin specific options
-#
-teleport:
-  address: ""
-  identitySecretName: ""
-  identitySecretPath: "auth_id"
-
-mattermost:
-  url: ""
-  token: ""
-  recipients: []
-
-log:
-  output: stdout
-  severity: INFO

--- a/charts/access/pagerduty/README.md
+++ b/charts/access/pagerduty/README.md
@@ -140,6 +140,20 @@ The following values can be set for the Helm chart:
     <td>yes</td>
   </tr>
   <tr>
+    <td><code>pagerduty.apiKeyFromSecret</code></td>
+    <td>Kubernetes secret to read the api key from instead of <code>pagerduty.apiKey</code></td>
+    <td>string</td>
+    <td><code>""</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>pagerduty.apiKeySecretPath</code></td>
+    <td>The path of the api key in the secret described by <code>pagerduty.apiKeyFromSecret</code></td>
+    <td>string</td>
+    <td><code>"pagerdutyApiKey"</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
     <td><code>pagerduty.userEmail</code></td>
     <td>PagerDuty bot user email</td>
     <td>string</td>

--- a/charts/access/pagerduty/templates/configmap.yaml
+++ b/charts/access/pagerduty/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     identity = "/var/lib/teleport/plugins/pagerduty/auth_id"
 
     [pagerduty]
-    api_key = "{{ .Values.pagerduty.apiKey }}"
+    api_key    = "/var/lib/teleport/plugins/pagerduty/pagerduty_api_key"
     user_email = "{{ .Values.pagerduty.userEmail }}"
 
     [log]

--- a/charts/access/pagerduty/templates/deployment.yaml
+++ b/charts/access/pagerduty/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: auth-id
               mountPath: /var/lib/teleport/plugins/pagerduty/auth_id
               subPath: {{ .Values.teleport.identitySecretPath }}
+            - name: {{ .Values.secretVolumeName }}
+              mountPath: /var/lib/teleport/plugins/pagerduty/pagerduty_api_key
+              subPath: {{ .Values.pagerduty.apiKeySecretPath }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -68,4 +71,8 @@ spec:
         - name: auth-id
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
+            defaultMode: 0600
+        - name: {{ .Values.secretVolumeName }}
+          secret:
+            secretName: "{{ coalesce .Values.pagerduty.apiKeyFromSecret (printf "%s-secret" (include "pagerduty.fullname" .)) }}"
             defaultMode: 0600

--- a/charts/access/pagerduty/templates/secret.yaml
+++ b/charts/access/pagerduty/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if not .Values.pagerduty.apiKeyFromSecret -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "pagerduty.fullname" . }}-secret
+data:
+  pagerdutyApiKey: {{ .Values.pagerduty.apiKey | b64enc }}
+{{- end }}

--- a/charts/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,7 +8,7 @@ should match the snapshot (smtp on):
         identity = "/var/lib/teleport/plugins/pagerduty/auth_id"
 
         [pagerduty]
-        api_key = "test-api-key"
+        api_key    = "/var/lib/teleport/plugins/pagerduty/pagerduty_api_key"
         user_email = "example-user@example.com"
 
         [log]

--- a/charts/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -44,6 +44,9 @@ should match the snapshot:
             - mountPath: /var/lib/teleport/plugins/pagerduty/auth_id
               name: auth-id
               subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/pagerduty/pagerduty_api_key
+              name: password-file
+              subPath: pagerdutyApiKey
           securityContext: {}
           volumes:
           - configMap:
@@ -54,3 +57,7 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-pagerduty-secret

--- a/charts/access/pagerduty/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/pagerduty/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,9 @@
+should contain the api key:
+  1: |
+    apiVersion: v1
+    data:
+      pagerdutyApiKey: bXltYXR0ZXJtb3N0YXBpa2V5
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-pagerduty-secret
+    type: Opaque

--- a/charts/access/pagerduty/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/pagerduty/tests/__snapshot__/secret_test.yaml.snap
@@ -2,7 +2,7 @@ should contain the api key:
   1: |
     apiVersion: v1
     data:
-      pagerdutyApiKey: bXltYXR0ZXJtb3N0YXBpa2V5
+      pagerdutyApiKey: bXlwYWdlcmR1dHlhcGlrZXk=
     kind: Secret
     metadata:
       name: RELEASE-NAME-teleport-plugin-pagerduty-secret

--- a/charts/access/pagerduty/tests/secret_test.yaml
+++ b/charts/access/pagerduty/tests/secret_test.yaml
@@ -1,0 +1,18 @@
+suite: Test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should contain the api key
+    set:
+      pagerduty:
+        apiKey: mymattermostapikey
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should not exist when using external secret
+    set:
+      pagerduty:
+        apiKeyFromSecret: my-pagerduty-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/access/pagerduty/tests/secret_test.yaml
+++ b/charts/access/pagerduty/tests/secret_test.yaml
@@ -5,7 +5,7 @@ tests:
   - it: should contain the api key
     set:
       pagerduty:
-        apiKey: mymattermostapikey
+        apiKey: mypagerdutyapikey
     asserts:
       - matchSnapshot: {}
 

--- a/charts/access/pagerduty/values.schema.json
+++ b/charts/access/pagerduty/values.schema.json
@@ -305,6 +305,22 @@
                         "example-api-key"
                     ]
                 },
+                "apiKeyFromSecret": {
+                    "$id": "#/properties/pagerduty/properties/apiKeyFromSecret",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "my-pagerduty-secret"
+                    ]
+                },
+                "apiKeySecretPath": {
+                    "$id": "#/properties/pagerduty/properties/apiKeySecretPath",
+                    "type": "string",
+                    "default": "pagerdutyApiKey",
+                    "examples": [
+                        "apikey"
+                    ]
+                },
                 "userEmail": {
                     "$id": "#/properties/pagerduty/properties/userEmail",
                     "type": "string",
@@ -349,6 +365,14 @@
                 }
             },
             "additionalProperties": true
+        },
+        "secretVolumeName": {
+            "$id": "#/properties/secretVolumeName",
+            "type": "string",
+            "default": "password-file",
+            "examples": [
+                "my-secret-volume"
+            ]
         }
     },
     "additionalProperties": true

--- a/charts/access/pagerduty/values.yaml
+++ b/charts/access/pagerduty/values.yaml
@@ -12,11 +12,15 @@ teleport:
 
 pagerduty:
   apiKey: ""
+  apiKeyFromSecret: ""
+  apiKeySecretPath: "pagerdutyApiKey"
   userEmail: ""
 
 log:
   output: stdout
   severity: INFO
+
+secretVolumeName: "password-file"
 
 #
 # Deployment

--- a/charts/access/slack/README.md
+++ b/charts/access/slack/README.md
@@ -144,6 +144,20 @@ The following values can be set for the Helm chart:
     <td><code>""</code></td>
     <td>yes</td>
   </tr>
+  <tr>
+    <td><code>slack.tokenFromSecret</code></td>
+    <td>Kubernetes secret to read the token from instead of <code>slack.token</code></td>
+    <td>string</td>
+    <td><code>""</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>slack.tokenSecretPath</code></td>
+    <td>The path of the token in the secret described by <code>slack.tokenFromSecret</code></td>
+    <td>string</td>
+    <td><code>"slackToken"</code></td>
+    <td>no</td>
+  </tr>
 
   <tr>
     <td><code>roleToRecipients</code></td>

--- a/charts/access/slack/templates/configmap.yaml
+++ b/charts/access/slack/templates/configmap.yaml
@@ -11,11 +11,7 @@ data:
     identity = "/var/lib/teleport/plugins/slack/auth_id"
 
     [slack]
-    {{- if .Values.slack.tokenSecretName }}
     token = "/var/lib/teleport/plugins/slack/slack-token"
-    {{- else }}
-    token = "{{ .Values.slack.token }}"
-    {{- end }}
 
     [role_to_recipients]
     {{- range $role, $recipients := .Values.roleToRecipients }}

--- a/charts/access/slack/templates/deployment.yaml
+++ b/charts/access/slack/templates/deployment.yaml
@@ -44,11 +44,9 @@ spec:
             - name: auth-id
               mountPath: /var/lib/teleport/plugins/slack/auth_id
               subPath: {{ .Values.teleport.identitySecretPath }}
-            {{- if .Values.slack.tokenSecretName }}
-            - name: slack-token
+            - name: {{ .Values.secretVolumeName }}
               mountPath: /var/lib/teleport/plugins/slack/slack-token
               subPath: {{ .Values.slack.tokenSecretPath }}
-            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -70,9 +68,7 @@ spec:
           secret:
             secretName: "{{ .Values.teleport.identitySecretName }}"
             defaultMode: 0600
-        {{- if .Values.slack.tokenSecretName }}
-        - name: slack-token
+        - name: {{ .Values.secretVolumeName }}
           secret:
-            secretName: "{{ .Values.slack.tokenSecretName }}"
+            secretName: "{{ coalesce .Values.slack.tokenFromSecret (printf "%s-secret" (include "slack.fullname" .)) }}"
             defaultMode: 0600
-        {{- end }}

--- a/charts/access/slack/templates/secret.yaml
+++ b/charts/access/slack/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if not .Values.slack.tokenFromSecret -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "slack.fullname" . }}-secret
+data:
+   slackToken: {{ .Values.slack.token | b64enc }}
+{{- end }}

--- a/charts/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,7 +8,7 @@ should match the snapshot:
         identity = "/var/lib/teleport/plugins/slack/auth_id"
 
         [slack]
-        token = "test-api-key"
+        token = "/var/lib/teleport/plugins/slack/slack-token"
 
         [role_to_recipients]
         "*" = ["dev-access-requests"]

--- a/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -40,6 +40,9 @@ should match the snapshot:
             - mountPath: /var/lib/teleport/plugins/slack/auth_id
               name: auth-id
               subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/slack/slack-token
+              name: password-file
+              subPath: slackToken
           securityContext: {}
           volumes:
           - configMap:
@@ -50,3 +53,7 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-slack-secret

--- a/charts/access/slack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,9 @@
+should contain the api key:
+  1: |
+    apiVersion: v1
+    data:
+      slackToken: bXlzbGFja3Rva2Vu
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-slack-secret
+    type: Opaque

--- a/charts/access/slack/tests/secret_test.yaml
+++ b/charts/access/slack/tests/secret_test.yaml
@@ -1,0 +1,18 @@
+suite: Test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should contain the api key
+    set:
+      slack:
+        token: myslacktoken
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should not exist when using external secret
+    set:
+      slack:
+        tokenFromSecret: my-slack-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/access/slack/values.schema.json
+++ b/charts/access/slack/values.schema.json
@@ -294,7 +294,7 @@
             ],
             "required": [
                 "token",
-                "tokenSecretName",
+                "tokenFromSecret",
                 "tokenSecretPath"
             ],
             "properties": {
@@ -306,8 +306,8 @@
                         "example-api-token"
                     ]
                 },
-                "tokenSecretName": {
-                    "$id": "#/properties/slack/properties/tokenSecretName",
+                "tokenFromSecret": {
+                    "$id": "#/properties/slack/properties/tokenFromSecret",
                     "type": "string",
                     "default": "",
                     "examples": [
@@ -317,7 +317,7 @@
                 "tokenSecretPath": {
                     "$id": "#/properties/slack/properties/tokenSecretPath",
                     "type": "string",
-                    "default": "",
+                    "default": "slackToken",
                     "examples": [
                         "token"
                     ]
@@ -385,6 +385,14 @@
                 }
             },
             "additionalProperties": true
+        },
+        "secretVolumeName": {
+            "$id": "#/properties/secretVolumeName",
+            "type": "string",
+            "default": "password-file",
+            "examples": [
+                "my-secret-volume"
+            ]
         }
     },
     "additionalProperties": true

--- a/charts/access/slack/values.yaml
+++ b/charts/access/slack/values.yaml
@@ -12,14 +12,16 @@ teleport:
 
 slack:
   token: ""
-  tokenSecretName: ""
-  tokenSecretPath: ""
+  tokenFromSecret: ""
+  tokenSecretPath: "slackToken"
 
 roleToRecipients: {}
 
 log:
   output: stdout
   severity: INFO
+
+secretVolumeName: "password-file"
 
 #
 # Deployment


### PR DESCRIPTION
The following changes were made in the charts:
- Now the Helm charts store all secrets in Kubernetes Secret in a compatible manner
- Added `*FromSecret` and `*SecretPath` variables to support reading passwords and tokens from Secrets created outside of the Helm charts
- Updated/fixed `values.schema.json` files to reflect these changes
- Added documentation for the above changes

Closes #573 