### PR TITLE
Updated default alias to custom one

### DIFF
--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -18,7 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = teleport-plugin-email
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=email --build-arg GITREF=$(GITREF)
 

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -18,7 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = teleport-plugin-jira
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=jira --build-arg GITREF=$(GITREF)
 

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -18,7 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = teleport-plugin-mattermost
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=mattermost --build-arg GITREF=$(GITREF)
 

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -18,7 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = teleport-plugin-pagerduty
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=pagerduty --build-arg GITREF=$(GITREF)
 

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -18,7 +18,7 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 
 DOCKER_NAME = teleport-plugin-slack
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=slack --build-arg GITREF=$(GITREF)
 

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -24,7 +24,7 @@ IDENTITY_FILE=example/keys/identity
 
 DOCKER_NAME=teleport-plugin-event-handler
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/d7a2c0j1/$(DOCKER_NAME):$(VERSION)
+DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg GITREF=$(GITREF)
 


### PR DESCRIPTION
This PR closes #592. AWS has approved the `gravitational` custom alias. This PR updates the `default` generated one to use the custom one. 

## Testing
Confirmed that the original images were accessible under the new alias.