### PR TITLE
PagerDuty: Add config for specifying which roles should trigger incidents

### DIFF
--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -185,7 +185,7 @@ user_email = "me@example.com" # PagerDuty bot user email (Could be admin email)
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
-# Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
+# Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
 [roles_to_process]
 roles = [
   "role1", 

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -184,6 +184,12 @@ user_email = "me@example.com" # PagerDuty bot user email (Could be admin email)
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+
+# Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
+roles_to_process = [
+  "role1", 
+  "role2"
+]
 ```
 
 ## Running the plugin

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -186,8 +186,8 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
 # Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
-[roles_to_process]
-roles = [
+[roles]
+approve = [
   "role1", 
   "role2"
 ]

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -187,7 +187,7 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 
 # Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
 [roles]
-approve = [
+allowlist = [
   "role1", 
   "role2"
 ]

--- a/access/pagerduty/README.md
+++ b/access/pagerduty/README.md
@@ -186,7 +186,8 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
 # Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
-roles_to_process = [
+[roles_to_process]
+roles = [
   "role1", 
   "role2"
 ]

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -240,12 +240,12 @@ func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 }
 
 // maybeProcessRequest checks request against the configured filter and decides if request should be processed.
-// When RolesToProcess field is empty (default) all requests will be processed.
+// When RolesToProcess field is unset or contains "*", all requests will be processed.
 // When RolesToProcess field is configured, requests with roles specified in config will be processed.
 func (a *App) maybeProcessRequest(ctx context.Context, req types.AccessRequest) bool {
 	rolesToProcess := stringset.New(a.conf.RolesToProcess.Roles...)
-	if len(rolesToProcess) == 0 {
-		logger.Get(ctx).Debug("RolesToProcess not specified, processing all requests.")
+	if rolesToProcess.Contains("*") {
+		logger.Get(ctx).Debug("All roles accepted, processing all requests.")
 		return true
 	}
 	for _, r := range req.GetRoles() {

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -243,7 +243,7 @@ func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 // When RolesToProcess field is empty (default) all requests will be processed.
 // When RolesToProcess field is configured, requests with roles specified in config will be processed.
 func (a *App) maybeProcessRequest(ctx context.Context, req types.AccessRequest) bool {
-	rolesToProcess := stringset.New(a.conf.RolesToProcess...)
+	rolesToProcess := stringset.New(a.conf.RolesToProcess.Roles...)
 	if len(rolesToProcess) == 0 {
 		logger.Get(ctx).Debug("RolesToProcess not specified, processing all requests.")
 		return true

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -240,10 +240,10 @@ func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 }
 
 // maybeProcessRequest checks request against the configured filter and decides if request should be processed.
-// When RolesToProcess field is unset or contains "*", all requests will be processed.
-// When RolesToProcess field is configured, requests with roles specified in config will be processed.
+// When Approve field is unset or contains "*", all requests will be processed.
+// When Approve field is configured, requests with roles specified in config will be processed.
 func (a *App) maybeProcessRequest(ctx context.Context, req types.AccessRequest) bool {
-	rolesToProcess := stringset.New(a.conf.RolesToProcess.Roles...)
+	rolesToProcess := stringset.New(a.conf.Roles.Approve...)
 	if rolesToProcess.Contains("*") {
 		logger.Get(ctx).Debug("All roles accepted, processing all requests.")
 		return true

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -243,7 +243,7 @@ func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 // When Approve field is unset or contains "*", all requests will be processed.
 // When Approve field is configured, requests with roles specified in config will be processed.
 func (a *App) maybeProcessRequest(ctx context.Context, req types.AccessRequest) bool {
-	rolesToProcess := stringset.New(a.conf.Roles.Approve...)
+	rolesToProcess := stringset.New(a.conf.Roles.Allowlist...)
 	if rolesToProcess.Contains("*") {
 		logger.Get(ctx).Debug("All roles accepted, processing all requests.")
 		return true

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -43,7 +43,7 @@ type PagerdutyConfig struct {
 }
 
 type Roles struct {
-	Approve []string `toml:"approve"`
+	Allowlist []string `toml:"allowlist"`
 }
 
 const NotifyServiceDefaultAnnotation = "pagerduty_notify_service"
@@ -77,7 +77,7 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 
 # Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
 [roles]
-approve = [
+allowlist = [
   "role1", 
   "role2"
 ]
@@ -126,8 +126,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Log.Severity == "" {
 		c.Log.Severity = "info"
 	}
-	if len(c.Roles.Approve) == 0 {
-		c.Roles.Approve = append(c.Roles.Approve, "*")
+	if len(c.Roles.Allowlist) == 0 {
+		c.Roles.Allowlist = append(c.Roles.Allowlist, "*")
 	}
 	return nil
 }

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	Teleport       lib.TeleportConfig `toml:"teleport"`
 	Pagerduty      PagerdutyConfig    `toml:"pagerduty"`
 	Log            logger.Config      `toml:"log"`
-	RolesToProcess []string           `toml:"roles_to_process"`
+	RolesToProcess RolesToProcess     `toml:"roles_to_process"`
 }
 
 type PagerdutyConfig struct {
@@ -40,6 +40,10 @@ type PagerdutyConfig struct {
 		NotifyService string `toml:"notify_service"`
 		Services      string `toml:"services"`
 	}
+}
+
+type RolesToProcess struct {
+	Roles []string `toml:"roles"`
 }
 
 const NotifyServiceDefaultAnnotation = "pagerduty_notify_service"
@@ -72,7 +76,8 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
 # Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
-roles_to_process = [
+[roles_to_process]
+roles = [
   "role1", 
   "role2"
 ]

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -26,9 +26,10 @@ import (
 )
 
 type Config struct {
-	Teleport  lib.TeleportConfig `toml:"teleport"`
-	Pagerduty PagerdutyConfig    `toml:"pagerduty"`
-	Log       logger.Config      `toml:"log"`
+	Teleport       lib.TeleportConfig `toml:"teleport"`
+	Pagerduty      PagerdutyConfig    `toml:"pagerduty"`
+	Log            logger.Config      `toml:"log"`
+	RolesToProcess []string           `toml:"roles_to_process"`
 }
 
 type PagerdutyConfig struct {
@@ -69,6 +70,12 @@ user_email = "me@example.com" # PagerDuty bot user email (Could be admin email)
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+
+# Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
+roles_to_process = [
+  "role1", 
+  "role2"
+]
 `
 
 func LoadConfig(filepath string) (*Config, error) {

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -75,7 +75,7 @@ user_email = "me@example.com" # PagerDuty bot user email (Could be admin email)
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/pagerduty.log"
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
-# Plugin will only process requests containing specified roles. If unset or empty all requests will be processed.
+# Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
 [roles_to_process]
 roles = [
   "role1", 
@@ -125,6 +125,9 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	if c.Log.Severity == "" {
 		c.Log.Severity = "info"
+	}
+	if len(c.RolesToProcess.Roles) == 0 {
+		c.RolesToProcess.Roles = append(c.RolesToProcess.Roles, "*")
 	}
 	return nil
 }

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -26,10 +26,10 @@ import (
 )
 
 type Config struct {
-	Teleport       lib.TeleportConfig `toml:"teleport"`
-	Pagerduty      PagerdutyConfig    `toml:"pagerduty"`
-	Log            logger.Config      `toml:"log"`
-	RolesToProcess RolesToProcess     `toml:"roles_to_process"`
+	Teleport  lib.TeleportConfig `toml:"teleport"`
+	Pagerduty PagerdutyConfig    `toml:"pagerduty"`
+	Log       logger.Config      `toml:"log"`
+	Roles     Roles              `toml:"roles"`
 }
 
 type PagerdutyConfig struct {
@@ -42,8 +42,8 @@ type PagerdutyConfig struct {
 	}
 }
 
-type RolesToProcess struct {
-	Roles []string `toml:"roles"`
+type Roles struct {
+	Approve []string `toml:"approve"`
 }
 
 const NotifyServiceDefaultAnnotation = "pagerduty_notify_service"
@@ -76,8 +76,8 @@ output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/tele
 severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
 
 # Plugin will only process requests containing specified roles. If contains "*" (default) all requests will be processed.
-[roles_to_process]
-roles = [
+[roles]
+approve = [
   "role1", 
   "role2"
 ]
@@ -126,8 +126,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Log.Severity == "" {
 		c.Log.Severity = "info"
 	}
-	if len(c.RolesToProcess.Roles) == 0 {
-		c.RolesToProcess.Roles = append(c.RolesToProcess.Roles, "*")
+	if len(c.Roles.Approve) == 0 {
+		c.Roles.Approve = append(c.Roles.Approve, "*")
 	}
 	return nil
 }

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -292,7 +292,7 @@ func (s *PagerdutySuite) SetupTest() {
 	conf.Pagerduty.UserEmail = "bot@example.com"
 	conf.Pagerduty.RequestAnnotations.NotifyService = NotifyServiceDefaultAnnotation
 	conf.Pagerduty.RequestAnnotations.Services = ServicesDefaultAnnotation
-	conf.Roles.Approve = []string{"*"}
+	conf.Roles.Allowlist = []string{"*"}
 
 	s.appConfig = conf
 	s.currentRequestor = s.userNames.requestor

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -292,7 +292,7 @@ func (s *PagerdutySuite) SetupTest() {
 	conf.Pagerduty.UserEmail = "bot@example.com"
 	conf.Pagerduty.RequestAnnotations.NotifyService = NotifyServiceDefaultAnnotation
 	conf.Pagerduty.RequestAnnotations.Services = ServicesDefaultAnnotation
-	conf.RolesToProcess.Roles = []string{"*"}
+	conf.Roles.Approve = []string{"*"}
 
 	s.appConfig = conf
 	s.currentRequestor = s.userNames.requestor

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -292,6 +292,7 @@ func (s *PagerdutySuite) SetupTest() {
 	conf.Pagerduty.UserEmail = "bot@example.com"
 	conf.Pagerduty.RequestAnnotations.NotifyService = NotifyServiceDefaultAnnotation
 	conf.Pagerduty.RequestAnnotations.Services = ServicesDefaultAnnotation
+	conf.RolesToProcess.Roles = []string{"*"}
 
 	s.appConfig = conf
 	s.currentRequestor = s.userNames.requestor


### PR DESCRIPTION
Currently PagerDuty plugin will always create incidents if the source role is annotated with a service. To add more flexibility, this PR introduces config field allowing users to specify requests to what roles should trigger incident creation. Default behavior when the new config field is not set remains the same.