### PR TITLE
Show detailed errors when gRPC client fails to connect

### DIFF
--- a/access/email/app.go
+++ b/access/email/app.go
@@ -136,7 +136,10 @@ func (a *App) init(ctx context.Context) error {
 	if a.apiClient, err = client.New(ctx, client.Config{
 		Addrs:       a.conf.Teleport.GetAddrs(),
 		Credentials: a.conf.Teleport.Credentials(),
-		DialOpts:    []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout})},
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/access/jira/app.go
+++ b/access/jira/app.go
@@ -165,7 +165,10 @@ func (a *App) init(ctx context.Context) error {
 	if a.apiClient, err = client.New(ctx, client.Config{
 		Addrs:       a.conf.Teleport.GetAddrs(),
 		Credentials: a.conf.Teleport.Credentials(),
-		DialOpts:    []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout})},
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/access/mattermost/app.go
+++ b/access/mattermost/app.go
@@ -124,7 +124,10 @@ func (a *App) init(ctx context.Context) error {
 	if a.apiClient, err = client.New(ctx, client.Config{
 		Addrs:       a.conf.Teleport.GetAddrs(),
 		Credentials: a.conf.Teleport.Credentials(),
-		DialOpts:    []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout})},
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -144,7 +144,10 @@ func (a *App) init(ctx context.Context) error {
 	if a.apiClient, err = client.New(ctx, client.Config{
 		Addrs:       a.conf.Teleport.GetAddrs(),
 		Credentials: a.conf.Teleport.Credentials(),
-		DialOpts:    []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout})},
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/access/slack/app.go
+++ b/access/slack/app.go
@@ -123,7 +123,10 @@ func (a *App) init(ctx context.Context) error {
 	if a.apiClient, err = client.New(ctx, client.Config{
 		Addrs:       a.conf.Teleport.GetAddrs(),
 		Credentials: a.conf.Teleport.Credentials(),
-		DialOpts:    []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout})},
+		DialOpts: []grpc.DialOption{
+			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithReturnConnectionError(),
+		},
 	}); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/testing/integration/integration.go
+++ b/lib/testing/integration/integration.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/tctl"
@@ -399,6 +400,9 @@ func (integration *Integration) NewSignedClient(ctx context.Context, auth Auth, 
 		InsecureAddressDiscovery: true,
 		Addrs:                    []string{auth.AuthAddr().String()},
 		Credentials:              []client.Credentials{client.LoadIdentityFile(identityPath)},
+		DialOpts: []grpc.DialOption{
+			grpc.WithReturnConnectionError(),
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -273,6 +273,9 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	client, err := client.New(ctx, client.Config{
 		Addrs:       []string{addr},
 		Credentials: creds,
+		DialOpts: []grpc.DialOption{
+			grpc.WithReturnConnectionError(),
+		},
 	})
 
 	if err != nil {


### PR DESCRIPTION
When the gRPC fails to connect we received a generic `context deadline exceeded`
You can see an example here:
https://github.com/gravitational/teleport-plugins/issues/514

This PR changes the way we connect our gRPC client to request a detailed error.
Demo
When success (nothing changes)
```
DEBU   DEBUG logging enabled email/main.go:81
INFO   Starting Teleport Access Email Plugin Not specified, use --ldflags "-X main.Version "1.0.0"": email/app.go:92
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Checking Teleport server version email/app.go:166
INFO   Using Mailgun as email transport domain:sandboxabaac2b50352479aa6ae4ddcef6bf95d.mailgun.org email/client.go:62
DEBU   Watcher connected watcherjob/watcherjob.go:109
INFO   Plugin is ready email/app.go:113
```

When the cert is expired:
```
[root@ship /]# /workspace/teleport-email start -c /workspace/access-email.toml --debug
DEBU   DEBUG logging enabled email/main.go:81
INFO   Starting Teleport Access Email Plugin Not specified, use --ldflags "-X main.Version "1.0.0"": email/app.go:92
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
DEBU   Attempting GET 0.0.0.0:3025/webapi/find webclient/webclient.go:118
ERRO   Terminating with fatal error [1]... error:[
ERROR REPORT:
Original Error: *errors.errorString context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: Get \&#34;https://0.0.0.0:3025/webapi/find\&#34;: x509: cannot validate certificate for 0.0.0.0 because it doesn&#39;t contain any IP SANs&#34;
Stack Trace:
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:381 github.com/gravitational/teleport/api/client.(*Client).dialGRPC
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:324 github.com/gravitational/teleport/api/client.proxyConnect
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:167 github.com/gravitational/teleport/api/client.connect.func2.1
	/nix/store/91jh9xr26wwr35iad2k4bgxa26mr0zln-go-1.18.3/share/go/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: 
	failed to connect to addr 0.0.0.0:3025 as a web proxy
		context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: Get \&#34;https://0.0.0.0:3025/webapi/find\&#34;: x509: cannot validate certificate for 0.0.0.0 because it doesn&#39;t contain any IP SANs&#34;] lib/bail.go:14
ERRO   Terminating with fatal error [2]... error:[
ERROR REPORT:
Original Error: *errors.errorString context deadline exceeded: write tcp 127.0.0.1:38304-&gt;127.0.0.1:3025: write: broken pipe
Stack Trace:
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:381 github.com/gravitational/teleport/api/client.(*Client).dialGRPC
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:298 github.com/gravitational/teleport/api/client.authConnect
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:167 github.com/gravitational/teleport/api/client.connect.func2.1
	/nix/store/91jh9xr26wwr35iad2k4bgxa26mr0zln-go-1.18.3/share/go/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: 
	failed to connect to addr 0.0.0.0:3025 as an auth server
		context deadline exceeded: write tcp 127.0.0.1:38304-&gt;127.0.0.1:3025: write: broken pipe] lib/bail.go:14
ERRO   Terminating with fatal error [3]... error:[
ERROR REPORT:
Original Error: *errors.errorString context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: Get \&#34;https://0.0.0.0:3025/webapi/find\&#34;: x509: cannot validate certificate for 0.0.0.0 because it doesn&#39;t contain any IP SANs&#34;
Stack Trace:
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:381 github.com/gravitational/teleport/api/client.(*Client).dialGRPC
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:337 github.com/gravitational/teleport/api/client.tlsRoutingConnect
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:167 github.com/gravitational/teleport/api/client.connect.func2.1
	/nix/store/91jh9xr26wwr35iad2k4bgxa26mr0zln-go-1.18.3/share/go/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: 
	failed to connect to addr 0.0.0.0:3025 with TLS Routing dialer
		context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: Get \&#34;https://0.0.0.0:3025/webapi/find\&#34;: x509: cannot validate certificate for 0.0.0.0 because it doesn&#39;t contain any IP SANs&#34;] lib/bail.go:14
ERRO   Terminating with fatal error [4]... error:[
ERROR REPORT:
Original Error: *errors.errorString context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: ssh: handshake failed: EOF, close tcp 127.0.0.1:44202-&gt;127.0.0.1:3025: use of closed network connection&#34;
Stack Trace:
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:381 github.com/gravitational/teleport/api/client.(*Client).dialGRPC
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:311 github.com/gravitational/teleport/api/client.tunnelConnect
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:167 github.com/gravitational/teleport/api/client.connect.func2.1
	/nix/store/91jh9xr26wwr35iad2k4bgxa26mr0zln-go-1.18.3/share/go/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: 
	failed to connect to addr 0.0.0.0:3025 as a reverse tunnel proxy
		context deadline exceeded: connection error: desc = &#34;transport: Error while dialing failed to dial: ssh: handshake failed: EOF, close tcp 127.0.0.1:44202-&gt;127.0.0.1:3025: use of closed network connection&#34;] lib/bail.go:14
ERRO   Terminating with fatal error [5]... error:[
ERROR REPORT:
Original Error: context.deadlineExceededError context deadline exceeded
Stack Trace:
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:273 github.com/gravitational/teleport/api/client.connect
	/home/marco/go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20220701151950-c3f9fd84a104/client/client.go:105 github.com/gravitational/teleport/api/client.New
	/home/marco/gravitational/teleport-plugins/access/email/app.go:136 main.(*App).init
	/home/marco/gravitational/teleport-plugins/access/email/app.go:94 main.(*App).run
	/home/marco/gravitational/teleport-plugins/lib/process.go:216 github.com/gravitational/teleport-plugins/lib.NewServiceJob.func1
	/home/marco/gravitational/teleport-plugins/lib/process.go:237 github.com/gravitational/teleport-plugins/lib.(*serviceJob).DoJob
	/home/marco/gravitational/teleport-plugins/lib/process.go:83 github.com/gravitational/teleport-plugins/lib.NewProcess.func2.1
	/nix/store/91jh9xr26wwr35iad2k4bgxa26mr0zln-go-1.18.3/share/go/src/runtime/asm_amd64.s:1571 runtime.goexit
User Message: context deadline exceeded] lib/bail.go:14
```

We can try to parse the error and come up with a better message, unfortunately that seems quite tricky because we have no hint that this error was caused by an expired certificate

@stevenGravy 
If you don't think this is good enough, please let me know and I'll work on providing a better message

Closes #514 