### PR TITLE
Fix Mattermost plugin installation message

### DIFF
--- a/access/mattermost/install
+++ b/access/mattermost/install
@@ -15,5 +15,5 @@ cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR
 cp -f teleport-mattermost $BINDIR/ || exit 1
 
-echo "Teleport Jira Plugin binaries have been copied to $BINDIR"
+echo "Teleport Mattermost plugin binaries have been copied to $BINDIR"
 echo "You can run teleport-mattermost configure > /etc/teleport-mattermost.toml to bootstrap your config file."


### PR DESCRIPTION
When you run the Mattermost plugin installation script, a message says
that "Jira Plugin binaries have been copied", which made me wonder for a
moment whether I had installed the wrong plugin. This corrects the
message.