### PR TITLE
Update helm chart snapshots for aws ecr

### DIFF
--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,7 +28,7 @@ should be possible to override volume name (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -147,7 +147,7 @@ should match the snapshot (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -210,7 +210,7 @@ should match the snapshot (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -273,7 +273,7 @@ should mount external secret (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -336,7 +336,7 @@ should mount external secret (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
-            image: quay.io/gravitational/teleport-plugin-email:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/charts/access/email/values.schema.json
+++ b/charts/access/email/values.schema.json
@@ -26,7 +26,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/gravitational/teleport-plugin-email",
+                    "repository": "public.ecr.aws/gravitational/teleport-plugin-email",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -40,9 +40,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-plugin-email",
+                    "default": "public.ecr.aws/gravitational/teleport-plugin-email",
                     "examples": [
-                        "quay.io/gravitational/teleport-plugin-email"
+                        "public.ecr.aws/gravitational/teleport-plugin-email"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/email/values.yaml
+++ b/charts/access/email/values.yaml
@@ -43,7 +43,7 @@ log:
 # Deployment
 #
 image:
-  repository: quay.io/gravitational/teleport-plugin-email
+  repository: public.ecr.aws/gravitational/teleport-plugin-email
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/access/jira/values.schema.json
+++ b/charts/access/jira/values.schema.json
@@ -24,7 +24,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/teleport/access-plugin-email",
+                    "repository": "public.ecr.aws/teleport/access-plugin-email",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -38,9 +38,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/teleport/access-plugin-email",
+                    "default": "public.ecr.aws/teleport/access-plugin-email",
                     "examples": [
-                        "quay.io/teleport/access-plugin-email"
+                        "public.ecr.aws/teleport/access-plugin-email"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/jira/values.yaml
+++ b/charts/access/jira/values.yaml
@@ -42,7 +42,7 @@ tlsSecretVolumeName: "tls"
 # Deployment
 #
 image:
-  repository: quay.io/gravitational/teleport-plugin-jira
+  repository: public.ecr.aws/gravitational/teleport-plugin-jira
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -91,7 +91,7 @@ should mount external secret:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -154,7 +154,7 @@ should override volume name:
             - start
             - --config
             - /etc/teleport-mattermost.toml
-            image: quay.io/gravitational/teleport-plugin-mattermost:10.1.4
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:10.1.4
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/charts/access/mattermost/values.schema.json
+++ b/charts/access/mattermost/values.schema.json
@@ -24,7 +24,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/gravitational/teleport-plugin-mattermost",
+                    "repository": "public.ecr.aws/gravitational/teleport-plugin-mattermost",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -38,9 +38,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-plugin-mattermost",
+                    "default": "public.ecr.aws/gravitational/teleport-plugin-mattermost",
                     "examples": [
-                        "quay.io/gravitational/teleport-plugin-mattermost"
+                        "public.ecr.aws/gravitational/teleport-plugin-mattermost"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/mattermost/values.yaml
+++ b/charts/access/mattermost/values.yaml
@@ -24,7 +24,7 @@ log:
 secretVolumeName: "password-file"
 
 image:
-  repository: quay.io/gravitational/teleport-plugin-mattermost
+  repository: public.ecr.aws/gravitational/teleport-plugin-mattermost
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/access/pagerduty/values.schema.json
+++ b/charts/access/pagerduty/values.schema.json
@@ -24,7 +24,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/gravitational/teleport-plugin-pagerduty",
+                    "repository": "public.ecr.aws/gravitational/teleport-plugin-pagerduty",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -38,9 +38,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-plugin-pagerduty",
+                    "default": "public.ecr.aws/gravitational/teleport-plugin-pagerduty",
                     "examples": [
-                        "quay.io/gravitational/teleport-plugin-pagerduty"
+                        "public.ecr.aws/gravitational/teleport-plugin-pagerduty"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/pagerduty/values.yaml
+++ b/charts/access/pagerduty/values.yaml
@@ -26,7 +26,7 @@ secretVolumeName: "password-file"
 # Deployment
 #
 image:
-  repository: quay.io/gravitational/teleport-plugin-pagerduty
+  repository: public.ecr.aws/gravitational/teleport-plugin-pagerduty
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/access/slack/values.schema.json
+++ b/charts/access/slack/values.schema.json
@@ -25,7 +25,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/gravitational/teleport-plugin-slack",
+                    "repository": "public.ecr.aws/gravitational/teleport-plugin-slack",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -39,9 +39,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-plugin-slack",
+                    "default": "public.ecr.aws/gravitational/teleport-plugin-slack",
                     "examples": [
-                        "quay.io/gravitational/teleport-plugin-slack"
+                        "public.ecr.aws/gravitational/teleport-plugin-slack"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/access/slack/values.yaml
+++ b/charts/access/slack/values.yaml
@@ -27,7 +27,7 @@ secretVolumeName: "password-file"
 # Deployment
 #
 image:
-  repository: quay.io/gravitational/teleport-plugin-slack
+  repository: public.ecr.aws/gravitational/teleport-plugin-slack
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/event-handler/values.schema.json
+++ b/charts/event-handler/values.schema.json
@@ -23,7 +23,7 @@
             "default": {},
             "examples": [
                 {
-                    "repository": "quay.io/gravitational/teleport-plugin-event-handler",
+                    "repository": "public.ecr.aws/gravitational/teleport-plugin-event-handler",
                     "pullPolicy": "IfNotPresent",
                     "tag": ""
                 }
@@ -37,9 +37,9 @@
                 "repository": {
                     "$id": "#/properties/image/properties/repository",
                     "type": "string",
-                    "default": "quay.io/gravitational/teleport-plugin-event-handler",
+                    "default": "public.ecr.aws/gravitational/teleport-plugin-event-handler",
                     "examples": [
-                        "quay.io/gravitational/teleport-plugin-event-handler"
+                        "public.ecr.aws/gravitational/teleport-plugin-event-handler"
                     ]
                 },
                 "pullPolicy": {

--- a/charts/event-handler/values.yaml
+++ b/charts/event-handler/values.yaml
@@ -36,7 +36,7 @@ persistentVolumeClaim:
 # Deployment
 #
 image:
-  repository: quay.io/gravitational/teleport-plugin-event-handler
+  repository: public.ecr.aws/gravitational/teleport-plugin-event-handler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
This PR is a part of a broader documentation updates that update quay.io to amazon ECR. 

Helm snapshots were updated to reflect these changes.

## Related
* https://github.com/gravitational/cloud/issues/1839
* https://github.com/gravitational/teleport-plugins/pull/629