### PR TITLE
Msteams access request plugin: small improvements

### DIFF
--- a/access/ms-teams/_tpl/teleport-ms-teams-role.yaml
+++ b/access/ms-teams/_tpl/teleport-ms-teams-role.yaml
@@ -1,10 +1,3 @@
-kind: user
-metadata:
-  name: teleport-ms-teams
-spec:
-  roles: ['teleport-ms-teams']
-version: v2
----
 kind: role
 metadata:
   name: teleport-ms-teams
@@ -14,3 +7,10 @@ spec:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
 version: v5
+---
+kind: user
+metadata:
+  name: teleport-ms-teams
+spec:
+  roles: ['teleport-ms-teams']
+version: v2

--- a/access/ms-teams/_tpl/teleport-ms-teams.toml
+++ b/access/ms-teams/_tpl/teleport-ms-teams.toml
@@ -1,7 +1,10 @@
 # Example ms teams plugin configuration TOML file
 
-# If true, recipients existense got checked on plugin start
-preload = false
+# If true, recipients existence got checked on plugin start
+# When a recipient is checked, the app is installed for the user if it was not already.
+# This takes some time and does not fits well with HTTP timeouts, hence preload is necessary when a new
+# recipient is added.
+preload = true
 
 [teleport]
 # Teleport Auth/Proxy Server address.

--- a/access/ms-teams/msapi/token.go
+++ b/access/ms-teams/msapi/token.go
@@ -55,7 +55,8 @@ func (c *tokenWithTTL) Bearer(ctx context.Context, config Config) (string, error
 		defer c.mu.Unlock()
 
 		c.token = token
-		c.expiresAt = time.Now().UnixNano() + (token.ExpiresIn * int64(time.Second))
+		// We renew the token 1 minute before its expiration to deal with possible time skew
+		c.expiresAt = time.Now().UnixNano() + (token.ExpiresIn * int64(time.Second)) - int64(time.Minute)
 	}
 
 	return "Bearer " + c.token.AccessToken, nil

--- a/lib/plugindata/cas.go
+++ b/lib/plugindata/cas.go
@@ -116,7 +116,7 @@ func (c *CompareAndSwap[T]) Update(
 				return emptyData, trace.Wrap(err)
 			}
 
-			return emptyData, trace.Wrap(err)
+			continue
 		} else if err != nil {
 			return emptyData, trace.Wrap(err)
 		}


### PR DESCRIPTION
Followup of the big PR #617, Part of https://github.com/gravitational/teleport/issues/11818

This PR does the following changes I was not able to put in the main PR:
- order the users and role resources yielded by `configure` so we can `tctl create -f <file>`
- renew the token a bit before expiry to avoid time skew issues as we don't retry 4xx.
- `preload` by default (initial install can be very long and the default opportunistic strategy ends up with timeouts & missed events, not a good UX)
- fix compare and swap retry mechanism if `modifyT` returns a `CompareFailedError` + add test 