### PR TITLE
access/msteams: Add uninstall command

### DIFF
--- a/access/ms-teams/bot.go
+++ b/access/ms-teams/bot.go
@@ -140,8 +140,6 @@ func (b Bot) FetchUser(ctx context.Context, userIDOrEmail string) (*UserData, er
 		return &d, nil
 	}
 
-	userID := userIDOrEmail
-
 	userID, err := b.getUserID(ctx, userIDOrEmail)
 	if err != nil {
 		return &UserData{}, trace.Wrap(err)

--- a/access/ms-teams/main.go
+++ b/access/ms-teams/main.go
@@ -29,6 +29,12 @@ func main() {
 	appSecret := configureCmd.Flag("appSecret", "MS App Secret").Required().String()
 	tenantID := configureCmd.Flag("tenantID", "MS App Tenant ID").Required().String()
 
+	uninstallCmd := app.Command("uninstall", "Uninstall the application for all teams user.")
+	uninstallConfigPath := uninstallCmd.Flag("config", "TOML config file path").
+		Short('c').
+		Default(configPath).
+		String()
+
 	validateCmd := app.Command("validate", "Validate bot installation")
 	validateConfigPath := validateCmd.Flag("config", "TOML config file path").
 		Short('c').
@@ -54,6 +60,12 @@ func main() {
 	switch selectedCmd {
 	case "configure":
 		err := configure(*targetDir, *appID, *appSecret, *tenantID)
+		if err != nil {
+			lib.Bail(err)
+		}
+
+	case "uninstall":
+		err := uninstall(context.Background(), *uninstallConfigPath)
 		if err != nil {
 			lib.Bail(err)
 		}

--- a/access/ms-teams/msapi/graph_client.go
+++ b/access/ms-teams/msapi/graph_client.go
@@ -172,6 +172,25 @@ func (c *GraphClient) InstallAppForUser(ctx context.Context, userID, teamAppID s
 	return trace.Wrap(c.request(ctx, request))
 }
 
+// UninstallAppForUser returns installed apps for user
+func (c *GraphClient) UninstallAppForUser(ctx context.Context, userID, teamAppID string) error {
+	body := `
+		{
+			"teamsApp@odata.bind": "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/` + teamAppID + `"
+		}
+	`
+
+	request := request{
+		Method:      http.MethodDelete,
+		Path:        "users/" + userID + "/teamWork/installedApps/" + teamAppID,
+		Body:        body,
+		Err:         &graphError{},
+		SuccessCode: http.StatusNoContent,
+	}
+
+	return trace.Wrap(c.request(ctx, request))
+}
+
 // GetChatForInstalledApp returns a chat between user and installed app
 func (c *GraphClient) GetChatForInstalledApp(ctx context.Context, userID, installationID string) (Chat, error) {
 	var chat Chat

--- a/access/ms-teams/uninstall.go
+++ b/access/ms-teams/uninstall.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )

--- a/access/ms-teams/uninstall.go
+++ b/access/ms-teams/uninstall.go
@@ -7,7 +7,11 @@ import (
 )
 
 func uninstall(ctx context.Context, configPath string) error {
-	b, c, err := loadConfigAndCheckApp(configPath)
+	b, c, err := loadConfig(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = checkApp(ctx, b)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/access/ms-teams/uninstall.go
+++ b/access/ms-teams/uninstall.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+func uninstall(ctx context.Context, configPath string) error {
+	b, c, err := loadConfigAndCheckApp(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var errs []error
+	for _, userID := range c.Recipients.GetAllRecipients() {
+		errs = append(errs, b.UninstallAppForUser(ctx, userID))
+	}
+	err = trace.NewAggregate(errs...)
+	if err != nil {
+		log.Errorln("The following error(s) happened when uninstalling the Teams App:")
+		return err
+	}
+	log.Info("Successfully uninstalled app for all recipients")
+	return nil
+}

--- a/access/ms-teams/validate.go
+++ b/access/ms-teams/validate.go
@@ -20,26 +20,9 @@ func validate(configPath, userID string) error {
 	lib.PrintVersion(appName, Version, Gitref)
 	fmt.Println()
 
-	c, err := LoadConfig(configPath)
+	b, _, err := loadConfigAndCheckApp(configPath)
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	fmt.Printf(" - Checking application %v status...\n", c.MSAPI.TeamsAppID)
-
-	b, err := NewBot(c.MSAPI, "local", "")
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	teamApp, err := b.GetTeamsApp(context.Background())
-	if trace.IsNotFound(err) {
-		fmt.Printf("Application %v not found in the org app store. Please, ensure that you have the application uploaded and installed for your team.", c.MSAPI.TeamsAppID)
-		return nil
-	} else if err != nil {
-		return trace.Wrap(err)
-	} else {
-		fmt.Printf(" - Application found in the team app store (internal ID: %v)\n", teamApp.ID)
 	}
 
 	if lib.IsEmail(uid) {
@@ -133,4 +116,29 @@ func validate(configPath, userID string) error {
 	fmt.Println("Check your MS Teams!")
 
 	return nil
+}
+
+func loadConfigAndCheckApp(configPath string) (*Bot, *Config, error) {
+	c, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	fmt.Printf(" - Checking application %v status...\n", c.MSAPI.TeamsAppID)
+
+	b, err := NewBot(c.MSAPI, "local", "")
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	teamApp, err := b.GetTeamsApp(context.Background())
+	if trace.IsNotFound(err) {
+		fmt.Printf("Application %v not found in the org app store. Please, ensure that you have the application uploaded and installed for your team.", c.MSAPI.TeamsAppID)
+		return nil, nil, trace.Wrap(err)
+	} else if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	fmt.Printf(" - Application found in the team app store (internal ID: %v)\n", teamApp.ID)
+	return b, c, nil
 }


### PR DESCRIPTION
Followup of the `access/msteams` PR #617, part of https://github.com/gravitational/teleport/issues/11818

The way the personal teams notification system work is the following:
- add app to MsTeams instance catalog
- install the app without user interaction to all recipients (apps have to be enabled per-user)
- get the canal ID that was created during installation
- speak with the user through this cana

However if we want to uninstall the App (something went wrong, a new app instance was created, ...) we need to disable it for all users that were contacted or in the recipient list. This PR introduces a command that will uninstall the apps for all users in the `recipients` list.