### PR TITLE
access/ms-teams: make the plugin able to post to team channels

### DIFF
--- a/access/ms-teams/README.md
+++ b/access/ms-teams/README.md
@@ -102,6 +102,7 @@ Please note that you must have the appropriate Azure AD adminstrator permissions
 5. Go to "API permissions" section. Click "Add a permission". Choose "Microsoft Graph". Choose "Application permissions". Add the following permissions:
 
 * `TeamsAppInstallation.ReadWriteSelfForUser.All`
+* `TeamsAppInstallation.ReadWriteSelfForTeam.All`
 * `AppCatalog.Read.All`
 * `User.Read.All`
 

--- a/access/ms-teams/app.go
+++ b/access/ms-teams/app.go
@@ -148,7 +148,9 @@ func (a *App) initBot(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	log.WithField("name", teamsApp.DisplayName).WithField("id", teamsApp.ID).Info("MS Teams app found in org app store")
+	log.WithField("name", teamsApp.DisplayName).
+		WithField("id", teamsApp.ID).
+		Info("MS Teams app found in org app store")
 
 	if !a.conf.Preload {
 		return nil
@@ -161,7 +163,10 @@ func (a *App) initBot(ctx context.Context) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		log.WithField("recipient", recipient).WithField("chat_id", recipientData.Chat.ID).Info("Recipient found, chat found")
+		log.WithField("recipient", recipient).
+			WithField("chat_id", recipientData.Chat.ID).
+			WithField("kind", recipientData.Kind).
+			Info("Recipient found, chat found")
 	}
 
 	log.Info("Recipient data preloaded and cached.")
@@ -455,7 +460,7 @@ func (a *App) getMessageRecipients(ctx context.Context, req types.AccessRequest)
 	// This can happen if this set contains the channel `C` and the email for channel `C`.
 	recipientSet := stringset.New()
 
-	validEmailsSuggReviewers := []string{}
+	var validEmailsSuggReviewers []string
 	for _, reviewer := range req.GetSuggestedReviewers() {
 		if !lib.IsEmail(reviewer) {
 			log.Warningf("Failed to notify a suggested reviewer: %q does not look like a valid email", reviewer)

--- a/access/ms-teams/app.go
+++ b/access/ms-teams/app.go
@@ -154,17 +154,17 @@ func (a *App) initBot(ctx context.Context) error {
 		return nil
 	}
 
-	log.Info("Preloading user data...")
+	log.Info("Preloading recipient data...")
 
-	for _, userID := range a.conf.Recipients.GetAllRecipients() {
-		userData, err := a.bot.FetchUser(ctx, userID)
+	for _, recipient := range a.conf.Recipients.GetAllRecipients() {
+		recipientData, err := a.bot.FetchRecipient(ctx, recipient)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		log.WithField("user_id", userID).WithField("chat_id", userData.Chat.ID).Info("User found, chat found")
+		log.WithField("recipient", recipient).WithField("chat_id", recipientData.Chat.ID).Info("Recipient found, chat found")
 	}
 
-	log.Info("User data preloaded and cached.")
+	log.Info("Recipient data preloaded and cached.")
 
 	return nil
 }

--- a/access/ms-teams/bot.go
+++ b/access/ms-teams/bot.go
@@ -55,7 +55,7 @@ type Bot struct {
 	botClient *msapi.BotFrameworkClient
 	// mu recipients access mutex
 	mu *sync.RWMutex
-	// apps represents the cache of apps
+	// recipients represents the cache of potential message recipients
 	recipients map[string]RecipientData
 	// webProxyURL represents Web UI address, if enabled
 	webProxyURL *url.URL

--- a/access/ms-teams/bot_test.go
+++ b/access/ms-teams/bot_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport-plugins/access/ms-teams/msapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBot_CheckChannelURL(t *testing.T) {
+	b := Bot{}
+	tests := []struct {
+		name             string
+		url              string
+		expectedUserData *RecipientData
+		validURL         bool
+	}{
+		{
+			name: "Valid URL",
+			url:  "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded",
+			expectedUserData: &RecipientData{
+				ID:  "ff882432-09b0-437b-bd22-ca13c0037ded/f2b3c8ed-5502-4449-b76f-dc3acea81f1c/Approval%20Channel%202",
+				App: msapi.InstalledApp{},
+				Chat: msapi.Chat{
+					ID:       "19:e06a7383ed98468f90217a35fa1980d7@thread.tacv2",
+					TenantID: "ff882432-09b0-437b-bd22-ca13c0037ded",
+					WebURL:   "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded",
+				},
+			},
+			validURL: true,
+		},
+		{
+			name:             "Invalid URL (no tenant)",
+			url:              "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c",
+			expectedUserData: nil,
+			validURL:         false,
+		},
+		{
+			name:             "Invalid URL (wrong length)",
+			url:              "https://teams.microsoft.com/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded",
+			expectedUserData: nil,
+			validURL:         false,
+		},
+		{
+			name:             "Email",
+			url:              "foo@example.com",
+			expectedUserData: nil,
+			validURL:         false,
+		},
+		{
+			name:             "Not an URL",
+			url:              "This is not an url 🙂",
+			expectedUserData: nil,
+			validURL:         false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, ok := b.checkChannelURL(tc.url)
+			require.Equal(t, tc.validURL, ok)
+			if tc.validURL {
+				require.Equal(t, tc.expectedUserData, &data)
+			}
+		})
+	}
+}

--- a/access/ms-teams/bot_test.go
+++ b/access/ms-teams/bot_test.go
@@ -1,31 +1,34 @@
 package main
 
 import (
+	"net/url"
 	"testing"
 
-	"github.com/gravitational/teleport-plugins/access/ms-teams/msapi"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBot_CheckChannelURL(t *testing.T) {
-	b := Bot{}
+func mustParseURL(t *testing.T, urlString string) *url.URL {
+	parsedURL, err := url.Parse(urlString)
+	require.NoError(t, err)
+	return parsedURL
+}
+
+func Test_CheckChannelURL(t *testing.T) {
 	tests := []struct {
 		name             string
 		url              string
-		expectedUserData *RecipientData
+		expectedUserData *Channel
 		validURL         bool
 	}{
 		{
 			name: "Valid URL",
 			url:  "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded",
-			expectedUserData: &RecipientData{
-				ID:  "ff882432-09b0-437b-bd22-ca13c0037ded/f2b3c8ed-5502-4449-b76f-dc3acea81f1c/Approval%20Channel%202",
-				App: msapi.InstalledApp{},
-				Chat: msapi.Chat{
-					ID:       "19:e06a7383ed98468f90217a35fa1980d7@thread.tacv2",
-					TenantID: "ff882432-09b0-437b-bd22-ca13c0037ded",
-					WebURL:   "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded",
-				},
+			expectedUserData: &Channel{
+				Name:   "Approval%20Channel%202",
+				Group:  "f2b3c8ed-5502-4449-b76f-dc3acea81f1c",
+				Tenant: "ff882432-09b0-437b-bd22-ca13c0037ded",
+				URL:    *mustParseURL(t, "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded"),
+				ChatID: "19:e06a7383ed98468f90217a35fa1980d7@thread.tacv2",
 			},
 			validURL: true,
 		},
@@ -56,10 +59,10 @@ func TestBot_CheckChannelURL(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			data, ok := b.checkChannelURL(tc.url)
+			data, ok := checkChannelURL(tc.url)
 			require.Equal(t, tc.validURL, ok)
 			if tc.validURL {
-				require.Equal(t, tc.expectedUserData, &data)
+				require.Equal(t, tc.expectedUserData, data)
 			}
 		})
 	}

--- a/access/ms-teams/main.go
+++ b/access/ms-teams/main.go
@@ -41,7 +41,7 @@ func main() {
 		Default(configPath).
 		String()
 
-	validateUserID := validateCmd.Arg("userID", "Your User ID").Required().String()
+	validateRecipientID := validateCmd.Arg("recipient", "UserID, email or channel to notify").Required().String()
 
 	startCmd := app.Command("start", "Starts Teleport MS Teams plugin")
 	startConfigPath := startCmd.Flag("config", "TOML config file path").
@@ -71,7 +71,7 @@ func main() {
 		}
 
 	case "validate":
-		err := validate(*validateConfigPath, *validateUserID)
+		err := validate(*validateConfigPath, *validateRecipientID)
 		if err != nil {
 			lib.Bail(err)
 		}

--- a/access/ms-teams/msapi/graph_client.go
+++ b/access/ms-teams/msapi/graph_client.go
@@ -84,6 +84,15 @@ func (e *graphError) Error() string {
 	return e.E.Code + " " + e.E.Message
 }
 
+// GetErrorCode returns the
+func GetErrorCode(err error) string {
+	graphErr, ok := trace.Unwrap(err).(*graphError)
+	if !ok {
+		return ""
+	}
+	return graphErr.E.Code
+}
+
 // GetTeamsApp returns the list of installed team apps
 func (c *GraphClient) GetTeamsApp(ctx context.Context, teamsAppID string) (*TeamsApp, error) {
 	g := &genericGraphResponse{}

--- a/access/ms-teams/msapi/graph_client.go
+++ b/access/ms-teams/msapi/graph_client.go
@@ -84,7 +84,7 @@ func (e *graphError) Error() string {
 	return e.E.Code + " " + e.E.Message
 }
 
-// GetAppsForTeam returns the list of installed team apps
+// GetTeamsApp returns the list of installed team apps
 func (c *GraphClient) GetTeamsApp(ctx context.Context, teamsAppID string) (*TeamsApp, error) {
 	g := &genericGraphResponse{}
 

--- a/access/ms-teams/plugindata.go
+++ b/access/ms-teams/plugindata.go
@@ -41,7 +41,7 @@ func DecodePluginData(dataMap map[string]string) PluginData {
 	return data
 }
 
-// Encode serializes plugin data to a string map
+// EncodePluginData serializes plugin data to a string map
 func EncodePluginData(data PluginData) map[string]string {
 	result := plugindata.EncodeAccessRequestData(data.AccessRequestData)
 

--- a/access/ms-teams/uninstall.go
+++ b/access/ms-teams/uninstall.go
@@ -18,8 +18,11 @@ func uninstall(ctx context.Context, configPath string) error {
 	}
 
 	var errs []error
-	for _, userID := range c.Recipients.GetAllRecipients() {
-		errs = append(errs, b.UninstallAppForUser(ctx, userID))
+	for _, recipient := range c.Recipients.GetAllRecipients() {
+		_, isChannel := b.checkChannelURL(recipient)
+		if !isChannel {
+			errs = append(errs, b.UninstallAppForUser(ctx, recipient))
+		}
 	}
 	err = trace.NewAggregate(errs...)
 	if err != nil {

--- a/access/ms-teams/uninstall.go
+++ b/access/ms-teams/uninstall.go
@@ -19,7 +19,7 @@ func uninstall(ctx context.Context, configPath string) error {
 
 	var errs []error
 	for _, recipient := range c.Recipients.GetAllRecipients() {
-		_, isChannel := b.checkChannelURL(recipient)
+		_, isChannel := checkChannelURL(recipient)
 		if !isChannel {
 			errs = append(errs, b.UninstallAppForUser(ctx, recipient))
 		}

--- a/access/ms-teams/validate.go
+++ b/access/ms-teams/validate.go
@@ -14,8 +14,7 @@ import (
 )
 
 // validate installs the application for a user if required and sends the Hello, world! message
-func validate(configPath, userID string) error {
-	var uid = userID
+func validate(configPath, recipient string) error {
 
 	lib.PrintVersion(appName, Version, Gitref)
 	fmt.Println()
@@ -30,29 +29,29 @@ func validate(configPath, userID string) error {
 		return trace.Wrap(err)
 	}
 
-	if lib.IsEmail(uid) {
-		userID, err := b.GetUserIDByEmail(context.Background(), uid)
+	if lib.IsEmail(recipient) {
+		userID, err := b.GetUserIDByEmail(context.Background(), recipient)
 		if trace.IsNotFound(err) {
-			fmt.Printf(" - User %v not found! Try to use user ID instead\n", uid)
+			fmt.Printf(" - User %v not found! Try to use user ID instead\n", recipient)
 			return nil
 		}
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		fmt.Printf(" - User %v found: %v\n", uid, userID)
+		fmt.Printf(" - User %v found: %v\n", recipient, userID)
 
-		uid = userID
+		recipient = userID
 	}
 
-	userData, err := b.FetchUser(context.Background(), uid)
+	recipientData, err := b.FetchRecipient(context.Background(), recipient)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf(" - Application installation ID for user: %v\n", userData.App.ID)
-	fmt.Printf(" - Chat ID for user: %v\n", userData.Chat.ID)
-	fmt.Printf(" - Chat web URL: %v\n", userData.Chat.WebURL)
+	fmt.Printf(" - Application installation ID for recipient: %v\n", recipientData.App.ID)
+	fmt.Printf(" - Chat ID for recipient: %v\n", recipientData.Chat.ID)
+	fmt.Printf(" - Chat web URL: %v\n", recipientData.Chat.WebURL)
 
 	card := cards.New([]cards.Node{
 		&cards.TextBlock{
@@ -74,9 +73,9 @@ func validate(configPath, userID string) error {
 		return trace.Wrap(err)
 	}
 
-	fmt.Println(" - Hailing the user...")
+	fmt.Println(" - Sending the message...")
 
-	id, err := b.PostAdaptiveCardActivity(context.Background(), userData.ID, body, "")
+	id, err := b.PostAdaptiveCardActivity(context.Background(), recipient, body, "")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -112,7 +111,7 @@ func validate(configPath, userID string) error {
 		return trace.Wrap(err)
 	}
 
-	_, err = b.PostAdaptiveCardActivity(context.Background(), userData.ID, body, "")
+	_, err = b.PostAdaptiveCardActivity(context.Background(), recipient, body, "")
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/11818

This commit extends the user and userData concepts to support channels. They have been renamed respectively recipient and recipientData.

Channels can be specified in the configuration using their URL.
Everything is not perfect, Microsoft might change the URL format (though we'll still be able to parse old URLs, so service won't break if this happens, only new channel addition will be harder until we update our parsing logic), but this is the easiest way to have:
- a single string (to avoid having a custom `role_to_recipient` format)
- a way to uniquely point to a channel (channel names can change)
- a way for the user to look at the configuration and know what recipient this is
- have required information to check app installation (channel ID can be sufficient for the bot SDK, but not for the azure graph client).

This PR also adds teams/group app installation check. This is not mandatory (we could send message without) but this is a better User Experience to detect permissions issues on startup. With our permissions we could also install ourselves in the Team like we do for users but this feels a bit intrusive. If you think this is a good idea I'll do it.