### PR TITLE
Add role assumption to terraform artifact download

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1230,7 +1230,8 @@ steps:
           --registry-url https://terraform-staging.releases.teleport.dev/      \
           --namespace gravitational                                            \
           --name teleport                                                      \
-          --deployment-role $DEPLOYMENT_ROLE
+          --deployment-role $DEPLOYMENT_ROLE                                   \
+          --staging-role $STAGING_ROLE
 
     environment:
       STAGING_REGION: us-west-2
@@ -1240,6 +1241,8 @@ steps:
         from_secret: AWS_ACCESS_KEY_ID
       STAGING_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
+      STAGING_ROLE:
+        from_secret: AWS_ROLE
 
       PROD_REGION:
         from_secret: STAGING_TERRAFORM_AWS_REGION
@@ -1285,7 +1288,8 @@ steps:
           --registry-url https://terraform-staging.releases.teleport.dev/      \
           --namespace gravitational                                            \
           --name teleport                                                      \
-          --deployment-role $DEPLOYMENT_ROLE
+          --deployment-role $DEPLOYMENT_ROLE                                   \
+          --staging-role $STAGING_ROLE
 
     environment:
       STAGING_REGION: us-west-2
@@ -1295,6 +1299,8 @@ steps:
         from_secret: AWS_ACCESS_KEY_ID
       STAGING_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
+      STAGING_ROLE:
+        from_secret: AWS_ROLE
 
       PROD_REGION:
         from_secret: STAGING_TERRAFORM_AWS_REGION
@@ -1340,7 +1346,8 @@ steps:
           --registry-url https://terraform.releases.teleport.dev/      \
           --namespace gravitational                                    \
           --name teleport                                              \
-          --deployment-role $DEPLOYMENT_ROLE
+          --deployment-role $DEPLOYMENT_ROLE                           \
+          --staging-role $STAGING_ROLE
 
     environment:
       STAGING_REGION: us-west-2
@@ -1350,6 +1357,8 @@ steps:
         from_secret: AWS_ACCESS_KEY_ID
       STAGING_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
+      STAGING_ROLE:
+        from_secret: AWS_ROLE
 
       PROD_REGION:
         from_secret: PRODUCTION_TERRAFORM_AWS_REGION
@@ -1365,6 +1374,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 0465dcbc3015c8c78b82d2357a3686a9abc7faffc8c83c3cd1c519aa1363c95c
+hmac: 6745017aa43147d585f8f057aef66ddf695e6d9a198f0c10e1d6078d97c63187
 
 ...

--- a/tooling/bin/tf-release
+++ b/tooling/bin/tf-release
@@ -8,7 +8,8 @@ export STAGING_REGION=us-west-2
 export STAGING_BUCKET=$AWS_S3_BUCKET
 export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export STAGING_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-    
+export STAGING_ROLE=$AWS_ROLE
+
 export PROD_REGION=$PRODUCTION_TERRAFORM_AWS_REGION
 export PROD_BUCKET=$PRODUCTION_TERRAFORM_AWS_BUCKET
 export PROD_ACCESS_KEY_ID=$PRODUCTION_TERRAFORM_AWS_ACCESS_KEY_ID_nope
@@ -26,5 +27,6 @@ go run ./cmd/promote-terraform                                 \
   --registry-url https://terraform.releases.teleport.dev/      \
   --namespace gravitational                                    \
   --name teleport                                              \
-  --deployment-role $DEPLOYMENT_ROLE
+  --deployment-role $DEPLOYMENT_ROLE                           \
+  --staging-role $STAGING_ROLE
 

--- a/tooling/bin/tf-stage
+++ b/tooling/bin/tf-stage
@@ -2,7 +2,7 @@
 
 # NOTE: The variable mappings here need to match those in the
 #       tag-stage-terraform-provider and promote-staging-terraform-provider
-#       Drone pipelines. Any change here should be reflected there, and vice 
+#       Drone pipelines. Any change here should be reflected there, and vice
 #       versa.
 
 
@@ -10,7 +10,8 @@ export STAGING_REGION=us-west-2
 export STAGING_BUCKET=$AWS_S3_BUCKET
 export STAGING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export STAGING_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-    
+export STAGING_ROLE=$AWS_ROLE
+
 export PROD_REGION=$STAGING_TERRAFORM_AWS_REGION
 export PROD_BUCKET=$STAGING_TERRAFORM_AWS_BUCKET
 export PROD_ACCESS_KEY_ID=$STAGING_TERRAFORM_AWS_ACCESS_KEY_ID
@@ -28,4 +29,5 @@ go run ./cmd/promote-terraform                                         \
   --registry-url https://terraform-staging.releases.teleport.dev/      \
   --namespace gravitational                                            \
   --name teleport                                                      \
-  --deployment-role $DEPLOYMENT_ROLE
+  --deployment-role $DEPLOYMENT_ROLE                                   \
+  --staging-role $STAGING_ROLE

--- a/tooling/cmd/promote-terraform/args.go
+++ b/tooling/cmd/promote-terraform/args.go
@@ -71,6 +71,11 @@ func parseCommandLine() *args {
 		Required().
 		StringVar(&result.staging.secretAccessKey)
 
+	app.Flag("staging-role", "AWS role to use when interacting with the staging bucket.").
+		Required().
+		PlaceHolder("ARN").
+		StringVar(&result.staging.roleARN)
+
 	app.Flag("prod-bucket", "S3 production bucket url (where to push the resulting registry)").
 		Envar("PROD_BUCKET").
 		StringVar(&result.production.bucketName)


### PR DESCRIPTION
Fixes the permission error seen here:
    
https://drone.platform.teleport.sh/gravitational/teleport-plugins/1868/3/2

```
time="2022-10-14T21:07:08Z" level=info msg="Listing objects in ****** with key prefix teleport-plugins/tag/terraform-provider-teleport-v10.3.2/"
time="2022-10-14T21:07:08Z" level=fatal msg="Failed fetching artifacts" error="operation error S3: ListObjectsV2, https response error StatusCode: 403, RequestID: VE62QS78B41ERBNP, HostID: iwCkDSDNR4SpPwwHPquBXb3btnXg/4RQhFSG0pcdsuYDFDrEjgTngjC7vR7GFzuiBdEyn8Chpbg=, api error AccessDenied: Access Denied"
exit status 1
```

This failure is a result of detaching the policy from the default teleport plugins user here:

https://github.com/gravitational/cloud-terraform/commit/6e105428e0d23eb6e5e7b372c6f68c5f71ed8654#diff-5668f4e36fe9314e05892ec59fe217ec6d517a6d82a621dcd358ab0a3e538574

I missed this work in https://github.com/gravitational/teleport-plugins/pull/671, because Trent plumbed AWS roles through the terraform promotion logic for *uploading* artifacts, but not *downloading* artifacts.

Contributes to https://github.com/gravitational/SecOps/issues/213

## Testing
Tag: https://drone.platform.teleport.sh/gravitational/teleport-plugins/1881
Promote: https://drone.platform.teleport.sh/gravitational/teleport-plugins/1882