### PR TITLE
Terraform: remove requirement of `teams_to_logins` field in Github connector

### DIFF
--- a/terraform/example/github_connector.tf.example
+++ b/terraform/example/github_connector.tf.example
@@ -19,10 +19,10 @@ resource "teleport_github_connector" "github" {
     client_id = "client"
     client_secret = var.github_secret
 
-    teams_to_logins = [{
+    teams_to_roles = [{
        organization = "gravitational"
        team = "devs"
-       logins = ["example"]
+       roles = ["example"]
     }]
   }
 }

--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -254,9 +254,6 @@ required_fields:
     - "GithubConnectorV3.Spec"
     - "GithubConnectorV3.Spec.ClientID"
     - "GithubConnectorV3.Spec.ClientSecret"
-    - "GithubConnectorV3.Spec.TeamsToLogins"
-    - "GithubConnectorV3.Spec.TeamsToLogins.Team"
-    - "GithubConnectorV3.Spec.TeamsToLogins.Logins"
     - "GithubConnectorV3.Metadata.Name"
 
     # OIDC connector

--- a/terraform/test/fixtures/github_connector_teams_to_roles.tf
+++ b/terraform/test/fixtures/github_connector_teams_to_roles.tf
@@ -1,0 +1,35 @@
+resource "teleport_role" "myrole" {
+    metadata = {
+        name = "test"
+    }
+
+    spec = {
+        allow = {
+            logins = ["anonymous"]
+        }
+    }
+
+    version = "v4"
+}
+
+
+resource "teleport_github_connector" "test" {
+    metadata = {
+        name    = "test"
+        expires = "2032-10-12T07:20:50Z"
+        labels  = {
+            example = "yes"
+        }
+    }
+
+    spec = {
+        client_id = "Iv1.3386eee92ff932a4"
+        client_secret = "secret"
+    
+        teams_to_roles = [{
+            organization = "evilmartians"
+            team = "devs"
+            roles = ["myrole"]
+        }]
+    }
+}

--- a/terraform/test/fixtures/github_connector_without_mapping.tf
+++ b/terraform/test/fixtures/github_connector_without_mapping.tf
@@ -1,0 +1,17 @@
+resource "teleport_github_connector" "test" {
+    metadata = {
+        name    = "test"
+        expires = "2032-10-12T07:20:50Z"
+        labels  = {
+            example = "yes"
+        }
+    }
+
+    spec = {
+        client_id = "Iv1.3386eee92ff932a4"
+        client_secret = "secret"
+    
+        teams_to_roles = []
+        teams_to_logins = []
+    }
+}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -2423,7 +2423,7 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 						},
 						"logins": {
 							Description: "Logins is a list of allowed logins for this org/team.",
-							Required:    true,
+							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"organization": {
@@ -2433,12 +2433,12 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 						},
 						"team": {
 							Description: "Team is a team within the organization a user belongs to.",
-							Required:    true,
+							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
 					Description: "TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead.",
-					Required:    true,
+					Optional:    true,
 				},
 				"teams_to_roles": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{


### PR DESCRIPTION
Teleport is moving from `teams_to_logins` to `teams_to_roles`. As of V10, both are configurable but Terraform was requiring the deprecated one(`teams_to_logins`).

This commit allows for both to be set and paves the way for the removal of the property `teams_to_logins` when we release v12.

Fixes #687 