### PR TITLE
Terraform: allow identity to be provided as base64

### DIFF
--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/lib"
@@ -400,11 +401,13 @@ func (p *Provider) stringFromConfigOrEnv(value types.String, env string, def str
 		}
 	}
 
-	if value.Value == "" {
+	configValue := strings.TrimSpace(value.Value)
+
+	if configValue == "" {
 		return def
 	}
 
-	return value.Value
+	return configValue
 }
 
 // validateAddr validates passed addr


### PR DESCRIPTION
When configuring the Teleport Provider we have multiple methods. One of them is to provide the Identity as a file path.

With this PR we can now provide the identity as a base64 encoded string.

This PR also adds a `dial_timeout_duration` configuration for the provider to ensure we can set our own limit instead of always using 30s.

Fixes #693 