### PR TITLE
Introduced GitHub actions workflows

### DIFF
--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -1,0 +1,31 @@
+name: tests-helm
+run-name: Tests (helm)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - charts/**
+
+jobs:
+  test:
+    name: Tests (helm)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Teleport Plugins
+        uses: actions/checkout@v3
+
+      - name: Setup Helm 3.5.2
+        uses: azure/setup-helm@v3
+        with:
+          version: '3.5.2'
+
+      - name: Setup helm-unittest
+        run: |
+            helm plugin install --version=v1.0.16 https://github.com/vbehar/helm3-unittest
+            helm plugin list
+
+      - name: Run tests
+        run: make test-helm

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,44 @@
+name: tests-integration
+run-name: Tests (integration)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  TELEPORT_GET_VERSION: v10.2.0
+  TELEPORT_ENTERPRISE_LICENSE: ${{ secrets.TELEPORT_ENTERPRISE_LICENSE }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        plugin:
+          - access/discord
+          - access/email
+          - access/jira
+          - access/mattermost
+          - access/msteams
+          - access/pagerduty
+          - access/slack
+          - event-handler
+
+    steps:
+      - name: Checkout Teleport Plugins
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.19.3
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.3'
+
+      - name: Run tests (${{ matrix.plugin }})
+        run: |
+          make -C ${{ matrix.plugin }} test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+name: go-lint
+run-name: make lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    name: make lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport Plugins
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.19.3
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.3'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
+
+      - name: Run linter
+        run: make lint

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -1,0 +1,38 @@
+name: tests-terraform
+run-name: Tests (Terraform)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  TELEPORT_GET_VERSION: v10.2.0
+  TELEPORT_ENTERPRISE_LICENSE: ${{ secrets.TELEPORT_ENTERPRISE_LICENSE }}
+
+jobs:
+  test:
+    name: Tests (Terraform)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport Plugins
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.19.3
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.3'
+
+      - name: Setup Terraform 1.3.3
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.3.3'
+          terraform_wrapper: false
+
+      - name: make test-terraform
+        run: make test-terraform

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -31,5 +31,5 @@ jobs:
       - name: make test-tooling
         run: make test-tooling
 
-      - name: go test lib
-        run: cd lib && go test -v ./...
+      - name: make test-unit
+        run: make test-unit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,35 @@
+name: tests-unit
+run-name: Tests (unit)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  TELEPORT_GET_VERSION: v10.2.0
+  TELEPORT_ENTERPRISE_LICENSE: ${{ secrets.TELEPORT_ENTERPRISE_LICENSE }}
+
+jobs:
+  test:
+    name: Tests (unit)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Teleport Plugins
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.19.3
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.3'
+
+      - name: make test-tooling
+        run: make test-tooling
+
+      - name: go test lib
+        run: cd lib && go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -114,13 +114,17 @@ event-handler:
 
 # Run all tests
 .PHONY: test
-test: test-tooling test-terraform
+test: test-tooling test-unit test-terraform
 	@echo Testing plugins against Teleport $(TELEPORT_GET_VERSION)
-	go test -race -count 1 $(shell go list ./... | grep -v -e '/terraform/' -e '/tooling/')
+	go test -race -count 1 $(shell go list ./... | grep -v -e '/terraform/' -e '/tooling/' -e '/lib')
 
 .PHONY: test-tooling
 test-tooling:
 	(cd tooling; go test -v -race ./...)
+
+.PHONY: test-unit
+test-unit:
+	(cd lib; go test -v -race ./...)
 
 # Individual releases
 .PHONY: release/access-slack

--- a/access/jira/config.go
+++ b/access/jira/config.go
@@ -19,7 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -153,7 +153,7 @@ func (c *Config) LoadTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	caCerts, err := ioutil.ReadAll(caFile)
+	caCerts, err := io.ReadAll(caFile)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/access/jira/webhook_server.go
+++ b/access/jira/webhook_server.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync/atomic"
@@ -104,7 +103,7 @@ func (s *WebhookServer) processWebhook(rw http.ResponseWriter, r *http.Request, 
 
 	var webhook Webhook
 
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, jiraWebhookPayloadLimit+1))
+	body, err := io.ReadAll(io.LimitReader(r.Body, jiraWebhookPayloadLimit+1))
 	if err != nil {
 		log.WithError(err).Error("Failed to read webhook payload")
 		http.Error(rw, "", http.StatusInternalServerError)

--- a/event-handler/configure_cmd.go
+++ b/event-handler/configure_cmd.go
@@ -22,7 +22,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"os"
 	"path"
@@ -287,7 +287,7 @@ func (c *ConfigureCmd) getPwd() (string, error) {
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		// Get password from provided file
-		pwdFromStdin, err := ioutil.ReadAll(os.Stdin)
+		pwdFromStdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", err
 		}
@@ -311,7 +311,7 @@ func (c *ConfigureCmd) writeFile(path string, content []byte) error {
 		return nil
 	}
 
-	err := ioutil.WriteFile(path, content, perms)
+	err := os.WriteFile(path, content, perms)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/event-handler/fake_fluentd_test.go
+++ b/event-handler/fake_fluentd_test.go
@@ -21,9 +21,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -51,7 +51,7 @@ const (
 
 // NewFakeFluentd creates new unstarted fake server instance
 func NewFakeFluentd() (*FakeFluentd, error) {
-	dir, err := ioutil.TempDir("", "teleport-plugins-event-handler-*")
+	dir, err := os.MkdirTemp("", "teleport-plugins-event-handler-*")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -106,7 +106,7 @@ func (f *FakeFluentd) writeCerts() error {
 
 // createServer initialises new server instance
 func (f *FakeFluentd) createServer() error {
-	caCert, err := ioutil.ReadFile(f.caCertPath)
+	caCert, err := os.ReadFile(f.caCertPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/event-handler/fluentd_client.go
+++ b/event-handler/fluentd_client.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gravitational/teleport-plugins/event-handler/lib"
@@ -73,7 +73,7 @@ func getCertPool(c *FluentdConfig) (*x509.CertPool, error) {
 		return nil, nil
 	}
 
-	caCert, err := ioutil.ReadFile(c.FluentdCA)
+	caCert, err := os.ReadFile(c.FluentdCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/event-handler/mtls_certs.go
+++ b/event-handler/mtls_certs.go
@@ -22,8 +22,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"net"
+	"os"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -232,12 +232,12 @@ func (c *keyPair) WriteFile(certPath, keyPath, pwd string) error {
 		return trace.Wrap(err)
 	}
 
-	err = ioutil.WriteFile(certPath, bytesPEM, perms)
+	err = os.WriteFile(certPath, bytesPEM, perms)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = ioutil.WriteFile(keyPath, pkBytesPEM, perms)
+	err = os.WriteFile(keyPath, pkBytesPEM, perms)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/testing/integration/integration.go
+++ b/lib/testing/integration/integration.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -110,7 +109,7 @@ func New(ctx context.Context, paths BinPaths, licenseStr string) (*Integration, 
 		}
 	}()
 
-	integration.workDir, err = ioutil.TempDir("", "teleport-plugins-integration-*")
+	integration.workDir, err = os.MkdirTemp("", "teleport-plugins-integration-*")
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to initialize work directory")
 	}
@@ -546,7 +545,7 @@ func (integration *Integration) registerService(service Service) {
 }
 
 func (integration *Integration) tempFile(pattern string) (*os.File, error) {
-	file, err := ioutil.TempFile(integration.workDir, pattern)
+	file, err := os.CreateTemp(integration.workDir, pattern)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -555,7 +554,7 @@ func (integration *Integration) tempFile(pattern string) (*os.File, error) {
 }
 
 func (integration *Integration) tempDir(pattern string) (string, error) {
-	dir, err := ioutil.TempDir(integration.workDir, pattern)
+	dir, err := os.MkdirTemp(integration.workDir, pattern)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/testing/integration/suite.go
+++ b/lib/testing/integration/suite.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -140,7 +139,7 @@ func (s *Suite) NewTmpFile(pattern string) *os.File {
 	t := s.T()
 	t.Helper()
 
-	file, err := ioutil.TempFile("", pattern)
+	file, err := os.CreateTemp("", pattern)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := os.Remove(file.Name())

--- a/terraform/main.go
+++ b/terraform/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
What's inside:

- [x] GitHub workflows for unit tests.
- [x] GitHub workflows for golang lint.
- [x] Helm charts unit tests.
- [x] Fixes for linting errors.
- [x] Terraform tests.
- [x] GitHub workflows for integration tests.

Terraform test fails. Looks like my license is invalid for CI. 

`TELEPORT_ENTERPRISE_LICENSE` secret must be provided after this gets merged.

I found out that `Makefile` `make test` does not run either lib/* tests or specific plugins tests. I guess, this needs to be addressed in a separate PR.