### PR TITLE
Fix docs link for Slack plugin guide in README

### DIFF
--- a/access/slack/README.md
+++ b/access/slack/README.md
@@ -4,7 +4,7 @@ This package implements a simple Slack plugin using the Teleport Access API. A s
 
 ## Setup
 
-[See setup instructions on Teleport's website](https://goteleport.com/teleport/docs/enterprise/workflow/ssh_approval_slack/)
+[See setup instructions on Teleport's website](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-slack/)
 
 Detailed install steps are provided in our [docs](https://goteleport.com/docs/enterprise/workflow/ssh-approval-slack/).
 


### PR DESCRIPTION
Old link was broken, new link is not