### PR TITLE
terraform: add test showing IAM provision token support

### DIFF
--- a/terraform/test/fixtures/app_0_create.tf
+++ b/terraform/test/fixtures/app_0_create.tf
@@ -1,14 +1,14 @@
 resource "teleport_app" "test" {
-    metadata = {
-        name = "example"
-        description = "Test app"
-        labels  = {
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }    
+  metadata = {
+    name        = "example"
+    description = "Test app"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        uri = "localhost:3000"
-    }
+  spec = {
+    uri = "localhost:3000"
+  }
 }

--- a/terraform/test/fixtures/app_0_create_auth_b64.tf
+++ b/terraform/test/fixtures/app_0_create_auth_b64.tf
@@ -1,14 +1,14 @@
 resource "teleport_app" "test_auth_b64" {
-    metadata = {
-        name = "test_auth_b64"
-        description = "Test app"
-        labels  = {
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }    
+  metadata = {
+    name        = "test_auth_b64"
+    description = "Test app"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        uri = "localhost:3000"
-    }
+  spec = {
+    uri = "localhost:3000"
+  }
 }

--- a/terraform/test/fixtures/app_0_create_auth_files.tf
+++ b/terraform/test/fixtures/app_0_create_auth_files.tf
@@ -1,14 +1,14 @@
 resource "teleport_app" "test_auth_files" {
-    metadata = {
-        name = "test_auth_files"
-        description = "Test app"
-        labels  = {
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }    
+  metadata = {
+    name        = "test_auth_files"
+    description = "Test app"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        uri = "localhost:3000"
-    }
+  spec = {
+    uri = "localhost:3000"
+  }
 }

--- a/terraform/test/fixtures/app_0_create_with_cache.tf
+++ b/terraform/test/fixtures/app_0_create_with_cache.tf
@@ -1,14 +1,14 @@
 resource "teleport_app" "test_with_cache" {
-    metadata = {
-        name = "example"
-        description = "Test app"
-        labels  = {
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }    
+  metadata = {
+    name        = "example"
+    description = "Test app"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        uri = "localhost:3000"
-    }
+  spec = {
+    uri = "localhost:3000"
+  }
 }

--- a/terraform/test/fixtures/app_1_update.tf
+++ b/terraform/test/fixtures/app_1_update.tf
@@ -1,14 +1,14 @@
 resource "teleport_app" "test" {
-    metadata = {
-        name = "test"
-        description = "Test app"
-        labels  = {
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }    
+  metadata = {
+    name        = "test"
+    description = "Test app"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        uri = "localhost:3000"
-    }
+  spec = {
+    uri = "localhost:3000"
+  }
 }

--- a/terraform/test/fixtures/auth_preference_0_cluster.tf
+++ b/terraform/test/fixtures/auth_preference_0_cluster.tf
@@ -1,8 +1,8 @@
 resource "teleport_auth_preference" "cluster_auth_preference" {
-    version = "v2"
+  version = "v2"
 
-    spec = {
-        name = "auth_preference"
-        type = "oidc"
-    }
+  spec = {
+    name = "auth_preference"
+    type = "oidc"
+  }
 }

--- a/terraform/test/fixtures/auth_preference_0_set.tf
+++ b/terraform/test/fixtures/auth_preference_0_set.tf
@@ -1,12 +1,12 @@
 resource "teleport_auth_preference" "test" {
-    metadata = {
-        labels = {
-            "example" = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "example"             = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
-    
-    spec = {
-        disconnect_expired_cert = true
-    }			
+  }
+
+  spec = {
+    disconnect_expired_cert = true
+  }
 }

--- a/terraform/test/fixtures/auth_preference_1_cluster.tf
+++ b/terraform/test/fixtures/auth_preference_1_cluster.tf
@@ -1,15 +1,15 @@
 resource "teleport_auth_preference" "cluster_auth_preference" {
-    version = "v2"
+  version = "v2"
 
-    metadata = {
-        labels = {
-            provisioner = "terraform"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      provisioner           = "terraform"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        name = "auth_preference"
-        type = "oidc"
-    }
+  spec = {
+    name = "auth_preference"
+    type = "oidc"
+  }
 }

--- a/terraform/test/fixtures/auth_preference_1_update.tf
+++ b/terraform/test/fixtures/auth_preference_1_update.tf
@@ -1,11 +1,11 @@
 resource "teleport_auth_preference" "test" {
-    metadata = {
-        labels = {
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "teleport.dev/origin" = "dynamic"
     }
-    
-    spec = {
-        disconnect_expired_cert = false
-    }			
+  }
+
+  spec = {
+    disconnect_expired_cert = false
+  }
 }

--- a/terraform/test/fixtures/bot_0_create.tf
+++ b/terraform/test/fixtures/bot_0_create.tf
@@ -5,20 +5,20 @@ locals {
 resource "teleport_provision_token" "bot_test" {
   metadata = {
     expires = "2038-01-01T00:00:00Z"
-    name = "bot-test"
+    name    = "bot-test"
   }
 
   spec = {
-    roles = ["Bot"]
-    bot_name = local.bot_name
+    roles       = ["Bot"]
+    bot_name    = local.bot_name
     join_method = "token"
   }
 }
 
 resource "teleport_bot" "test" {
-  name = local.bot_name
+  name     = local.bot_name
   token_id = "bot-test"
-  roles = ["terraform"]
+  roles    = ["terraform"]
 
   depends_on = [
     teleport_provision_token.bot_test

--- a/terraform/test/fixtures/bot_1_update.tf
+++ b/terraform/test/fixtures/bot_1_update.tf
@@ -5,20 +5,20 @@ locals {
 resource "teleport_provision_token" "bot_test" {
   metadata = {
     expires = "2038-01-01T00:00:00Z"
-    name = "bot-test"
+    name    = "bot-test"
   }
 
   spec = {
-    roles = ["Bot"]
-    bot_name = local.bot_name
+    roles       = ["Bot"]
+    bot_name    = local.bot_name
     join_method = "token"
   }
 }
 
 resource "teleport_bot" "test" {
-  name = local.bot_name
+  name     = local.bot_name
   token_id = "bot-test"
-  roles = ["terraform"]
+  roles    = ["terraform"]
 
   depends_on = [
     teleport_provision_token.bot_test

--- a/terraform/test/fixtures/database_0_create.tf
+++ b/terraform/test/fixtures/database_0_create.tf
@@ -1,15 +1,15 @@
 resource "teleport_database" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {					
-            example = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example               = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
+  }
 
-    spec = {
-        protocol = "postgres"
-        uri = "localhost"
-    }
+  spec = {
+    protocol = "postgres"
+    uri      = "localhost"
+  }
 }

--- a/terraform/test/fixtures/database_1_update.tf
+++ b/terraform/test/fixtures/database_1_update.tf
@@ -1,15 +1,15 @@
 resource "teleport_database" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            "teleport.dev/origin" = "dynamic"
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      "teleport.dev/origin" = "dynamic"
+      example               = "yes"
     }
+  }
 
-    spec = {
-        protocol = "postgres"
-        uri = "example.com"
-    }
+  spec = {
+    protocol = "postgres"
+    uri      = "example.com"
+  }
 }

--- a/terraform/test/fixtures/github_connector_0_create.tf
+++ b/terraform/test/fixtures/github_connector_0_create.tf
@@ -1,20 +1,20 @@
 resource "teleport_github_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "Iv1.3386eee92ff932a4"
-        client_secret = "secret"
-    
-        teams_to_logins = [{
-            organization = "evilmartians"
-            team = "devs"
-            logins = ["terraform"]
-        }]
-    }
+  spec = {
+    client_id     = "Iv1.3386eee92ff932a4"
+    client_secret = "secret"
+
+    teams_to_logins = [{
+      organization = "evilmartians"
+      team         = "devs"
+      logins       = ["terraform"]
+    }]
+  }
 }

--- a/terraform/test/fixtures/github_connector_1_update.tf
+++ b/terraform/test/fixtures/github_connector_1_update.tf
@@ -1,20 +1,20 @@
 resource "teleport_github_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "Iv1.3386eee92ff932a4"
-        client_secret = "secret"
-    
-        teams_to_logins = [{
-            organization = "gravitational"
-            team = "devs"
-            logins = ["terraform"]
-        }]
-    }
+  spec = {
+    client_id     = "Iv1.3386eee92ff932a4"
+    client_secret = "secret"
+
+    teams_to_logins = [{
+      organization = "gravitational"
+      team         = "devs"
+      logins       = ["terraform"]
+    }]
+  }
 }

--- a/terraform/test/fixtures/github_connector_teams_to_roles.tf
+++ b/terraform/test/fixtures/github_connector_teams_to_roles.tf
@@ -1,35 +1,35 @@
 resource "teleport_role" "myrole" {
-    metadata = {
-        name = "test"
-    }
+  metadata = {
+    name = "test"
+  }
 
-    spec = {
-        allow = {
-            logins = ["anonymous"]
-        }
+  spec = {
+    allow = {
+      logins = ["anonymous"]
     }
+  }
 
-    version = "v4"
+  version = "v4"
 }
 
 
 resource "teleport_github_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "Iv1.3386eee92ff932a4"
-        client_secret = "secret"
-    
-        teams_to_roles = [{
-            organization = "evilmartians"
-            team = "devs"
-            roles = ["myrole"]
-        }]
-    }
+  spec = {
+    client_id     = "Iv1.3386eee92ff932a4"
+    client_secret = "secret"
+
+    teams_to_roles = [{
+      organization = "evilmartians"
+      team         = "devs"
+      roles        = ["myrole"]
+    }]
+  }
 }

--- a/terraform/test/fixtures/github_connector_without_mapping.tf
+++ b/terraform/test/fixtures/github_connector_without_mapping.tf
@@ -1,17 +1,17 @@
 resource "teleport_github_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "Iv1.3386eee92ff932a4"
-        client_secret = "secret"
-    
-        teams_to_roles = []
-        teams_to_logins = []
-    }
+  spec = {
+    client_id     = "Iv1.3386eee92ff932a4"
+    client_secret = "secret"
+
+    teams_to_roles  = []
+    teams_to_logins = []
+  }
 }

--- a/terraform/test/fixtures/networking_config_0_set.tf
+++ b/terraform/test/fixtures/networking_config_0_set.tf
@@ -1,12 +1,12 @@
 resource "teleport_cluster_networking_config" "test" {
-    metadata = {
-        labels = {
-            "example" = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "example"             = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
-                    
-    spec = {
-        client_idle_timeout = "30m"
-    }
+  }
+
+  spec = {
+    client_idle_timeout = "30m"
+  }
 }

--- a/terraform/test/fixtures/networking_config_1_update.tf
+++ b/terraform/test/fixtures/networking_config_1_update.tf
@@ -1,17 +1,17 @@
 resource "teleport_cluster_networking_config" "test" {
-    metadata = {
-        labels = {
-            "example" = "no"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "example"             = "no"
+      "teleport.dev/origin" = "dynamic"
     }
-    
-    spec = {
-        client_idle_timeout = "1h"
-        tunnel_strategy = {
-            proxy_peering = {
-                agent_connection_count = 5
-            }
-        }
+  }
+
+  spec = {
+    client_idle_timeout = "1h"
+    tunnel_strategy = {
+      proxy_peering = {
+        agent_connection_count = 5
+      }
     }
+  }
 }

--- a/terraform/test/fixtures/oidc_connector_0_create.tf
+++ b/terraform/test/fixtures/oidc_connector_0_create.tf
@@ -1,21 +1,21 @@
 resource "teleport_oidc_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "client"
-        client_secret = "value"
-    
-        claims_to_roles = [{
-            claim = "test"
-            roles = ["terraform"]
-        }]
-        
-        redirect_url = ["https://example.com/redirect"]
-    }
+  spec = {
+    client_id     = "client"
+    client_secret = "value"
+
+    claims_to_roles = [{
+      claim = "test"
+      roles = ["terraform"]
+    }]
+
+    redirect_url = ["https://example.com/redirect"]
+  }
 }

--- a/terraform/test/fixtures/oidc_connector_1_update.tf
+++ b/terraform/test/fixtures/oidc_connector_1_update.tf
@@ -1,21 +1,21 @@
 resource "teleport_oidc_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        client_id = "client"
-        client_secret = "value"
-    
-        claims_to_roles = [{
-            claim = "test"
-            roles = ["teleport"]
-        }]
-        
-        redirect_url = ["https://example.com/redirect"]
-    }
+  spec = {
+    client_id     = "client"
+    client_secret = "value"
+
+    claims_to_roles = [{
+      claim = "test"
+      roles = ["teleport"]
+    }]
+
+    redirect_url = ["https://example.com/redirect"]
+  }
 }

--- a/terraform/test/fixtures/provision_token_0_create.tf
+++ b/terraform/test/fixtures/provision_token_0_create.tf
@@ -1,12 +1,12 @@
 resource "teleport_provision_token" "test" {
-    metadata = {
-        name = "test"
-        expires = "2038-01-01T00:00:00Z"
-        labels = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2038-01-01T00:00:00Z"
+    labels = {
+      example = "yes"
     }
-    spec = {
-        roles = ["Node", "Auth"]
-    }
+  }
+  spec = {
+    roles = ["Node", "Auth"]
+  }
 }

--- a/terraform/test/fixtures/provision_token_1_update.tf
+++ b/terraform/test/fixtures/provision_token_1_update.tf
@@ -1,9 +1,9 @@
 resource "teleport_provision_token" "test" {
-    metadata = {
-        name = "test"
-        expires = "2038-01-01T00:00:00Z"
-    }
-    spec = {
-        roles = ["Node"]
-    }
+  metadata = {
+    name    = "test"
+    expires = "2038-01-01T00:00:00Z"
+  }
+  spec = {
+    roles = ["Node"]
+  }
 }

--- a/terraform/test/fixtures/provision_token_v2_0_create.tf
+++ b/terraform/test/fixtures/provision_token_v2_0_create.tf
@@ -1,17 +1,17 @@
 resource "teleport_provision_token" "test2" {
-    metadata = {
-        name = "test2"
-        expires = "2038-01-01T00:00:00Z"
-        labels = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test2"
+    expires = "2038-01-01T00:00:00Z"
+    labels = {
+      example = "yes"
     }
-    spec = {
-        roles = ["Node", "Auth"]
-        join_method = "iam"
-        allow = [
-            {
-                aws_account = "1234567890"
-            }]
-    }
+  }
+  spec = {
+    roles       = ["Node", "Auth"]
+    join_method = "iam"
+    allow = [
+      {
+        aws_account = "1234567890"
+    }]
+  }
 }

--- a/terraform/test/fixtures/provision_token_v2_0_create.tf
+++ b/terraform/test/fixtures/provision_token_v2_0_create.tf
@@ -1,0 +1,17 @@
+resource "teleport_provision_token" "test2" {
+    metadata = {
+        name = "test2"
+        expires = "2038-01-01T00:00:00Z"
+        labels = {
+            example = "yes"
+        }
+    }
+    spec = {
+        roles = ["Node", "Auth"]
+        join_method = "iam"
+        allow = [
+            {
+                aws_account = "1234567890"
+            }]
+    }
+}

--- a/terraform/test/fixtures/provision_token_v2_1_update.tf
+++ b/terraform/test/fixtures/provision_token_v2_1_update.tf
@@ -1,0 +1,20 @@
+resource "teleport_provision_token" "test2" {
+    metadata = {
+        name = "test2"
+        expires = "2038-01-01T00:00:00Z"
+        labels = {
+            example = "yes"
+        }
+    }
+    spec = {
+        roles = ["Node", "Auth"]
+        join_method = "iam"
+        allow = [
+            {
+                aws_account = "1234567890"
+            },
+            {
+                aws_account = "1111111111"
+            }]
+    }
+}

--- a/terraform/test/fixtures/provision_token_v2_1_update.tf
+++ b/terraform/test/fixtures/provision_token_v2_1_update.tf
@@ -1,20 +1,20 @@
 resource "teleport_provision_token" "test2" {
-    metadata = {
-        name = "test2"
-        expires = "2038-01-01T00:00:00Z"
-        labels = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test2"
+    expires = "2038-01-01T00:00:00Z"
+    labels = {
+      example = "yes"
     }
-    spec = {
-        roles = ["Node", "Auth"]
-        join_method = "iam"
-        allow = [
-            {
-                aws_account = "1234567890"
-            },
-            {
-                aws_account = "1111111111"
-            }]
-    }
+  }
+  spec = {
+    roles       = ["Node", "Auth"]
+    join_method = "iam"
+    allow = [
+      {
+        aws_account = "1234567890"
+      },
+      {
+        aws_account = "1111111111"
+    }]
+  }
 }

--- a/terraform/test/fixtures/role_0_create.tf
+++ b/terraform/test/fixtures/role_0_create.tf
@@ -1,13 +1,13 @@
 resource "teleport_role" "test" {
-    metadata = {
-        name = "test"
-    }
+  metadata = {
+    name = "test"
+  }
 
-    spec = {
-        allow = {
-            logins = ["anonymous"]
-        }
+  spec = {
+    allow = {
+      logins = ["anonymous"]
     }
+  }
 
-    version = "v4"
+  version = "v4"
 }

--- a/terraform/test/fixtures/role_1_update.tf
+++ b/terraform/test/fixtures/role_1_update.tf
@@ -1,31 +1,31 @@
 resource "teleport_role" "test" {
-    metadata = {
-        name = "test"
-        description = ""
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "test"
+    description = ""
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {
-            forward_agent = true
-            max_session_ttl = "2h3m"
-        }
-        allow = {
-            logins = ["known", "anonymous"]
-            request = {
-                roles = ["example"]
-                claims_to_roles = [
-                    {
-                        claim = "example"
-                        value = "example"
-                        roles = ["example"]
-                    },
-                ]
-            }
-
-            node_labels = {
-                "example" = ["yes", "no"]
-            }            
-        }
+  spec = {
+    options = {
+      forward_agent   = true
+      max_session_ttl = "2h3m"
     }
+    allow = {
+      logins = ["known", "anonymous"]
+      request = {
+        roles = ["example"]
+        claims_to_roles = [
+          {
+            claim = "example"
+            value = "example"
+            roles = ["example"]
+          },
+        ]
+      }
+
+      node_labels = {
+        "example" = ["yes", "no"]
+      }
+    }
+  }
 }

--- a/terraform/test/fixtures/role_2_update.tf
+++ b/terraform/test/fixtures/role_2_update.tf
@@ -1,30 +1,30 @@
 resource "teleport_role" "test" {
-    metadata = {
-        name = "test"
-        description = "Test role"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "test"
+    description = "Test role"
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {}
-        
-        allow = {
-            logins = ["anonymous"]
-            request = {
-                roles = ["example", "terraform"]
-                claims_to_roles = [
-                    {
-                        claim = "example"
-                        value = "example"
-                        roles = ["example"]
-                    },
-                ]
-            }
+  spec = {
+    options = {}
 
-            node_labels = {
-                "example" = ["no"]
-                "sample" = ["yes", "no"]
-            }            
-        }
+    allow = {
+      logins = ["anonymous"]
+      request = {
+        roles = ["example", "terraform"]
+        claims_to_roles = [
+          {
+            claim = "example"
+            value = "example"
+            roles = ["example"]
+          },
+        ]
+      }
+
+      node_labels = {
+        "example" = ["no"]
+        "sample"  = ["yes", "no"]
+      }
     }
+  }
 }

--- a/terraform/test/fixtures/role_3_update.tf
+++ b/terraform/test/fixtures/role_3_update.tf
@@ -1,14 +1,14 @@
 resource "teleport_role" "test" {
-    metadata = {
-        name = "test"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name    = "test"
+    expires = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        allow = {
-            logins = ["anonymous"]
-            request = {}
-            node_labels = {}
-        }
+  spec = {
+    allow = {
+      logins      = ["anonymous"]
+      request     = {}
+      node_labels = {}
     }
+  }
 }

--- a/terraform/test/fixtures/role_drift_0.tf
+++ b/terraform/test/fixtures/role_drift_0.tf
@@ -1,13 +1,13 @@
 resource "teleport_role" "splitbrain" {
-    metadata = {
-        name = "splitbrain"
-    }
+  metadata = {
+    name = "splitbrain"
+  }
 
-    spec = {
-        allow = {
-            logins = ["one"]
-        }
+  spec = {
+    allow = {
+      logins = ["one"]
     }
+  }
 
-    version = "v5"
+  version = "v5"
 }

--- a/terraform/test/fixtures/role_reviewers_0_two_roles.tf
+++ b/terraform/test/fixtures/role_reviewers_0_two_roles.tf
@@ -1,16 +1,16 @@
 resource "teleport_role" "test_decrease_reviewers" {
-    metadata = {
-        name = "test_decrease_reviewers"
-    }
+  metadata = {
+    name = "test_decrease_reviewers"
+  }
 
-    spec = {
-        allow = {
-            logins = ["anonymous"]
-            review_requests = {
-                roles = ["rolea", "roleb"]
-            }
-        }
+  spec = {
+    allow = {
+      logins = ["anonymous"]
+      review_requests = {
+        roles = ["rolea", "roleb"]
+      }
     }
+  }
 
-    version = "v5"
+  version = "v5"
 }

--- a/terraform/test/fixtures/role_reviewers_1_one_role.tf
+++ b/terraform/test/fixtures/role_reviewers_1_one_role.tf
@@ -1,16 +1,16 @@
 resource "teleport_role" "test_decrease_reviewers" {
-    metadata = {
-        name = "test_decrease_reviewers"
-    }
+  metadata = {
+    name = "test_decrease_reviewers"
+  }
 
-    spec = {
-        allow = {
-            logins = ["anonymous"]
-            review_requests = {
-                roles = ["roleb"]
-            }
-        }
+  spec = {
+    allow = {
+      logins = ["anonymous"]
+      review_requests = {
+        roles = ["roleb"]
+      }
     }
+  }
 
-    version = "v5"
+  version = "v5"
 }

--- a/terraform/test/fixtures/saml_connector_0_create.tf
+++ b/terraform/test/fixtures/saml_connector_0_create.tf
@@ -1,34 +1,34 @@
 resource "teleport_role" "admin" {
-    metadata = {
-        name = "admin"
-        description = "admin role"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "admin"
+    description = "admin role"
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {}
-        allow = {}
-    }
+  spec = {
+    options = {}
+    allow   = {}
+  }
 }
 
 resource "teleport_saml_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        attributes_to_roles = [{
-            name = "groups"
-            roles = ["admin"]
-            value = "okta-admin"
-        }]
-        
-        acs = "https://example.com/v1/webapi/saml/acs"
-        entity_descriptor = <<EOT
+  spec = {
+    attributes_to_roles = [{
+      name  = "groups"
+      roles = ["admin"]
+      value = "okta-admin"
+    }]
+
+    acs               = "https://example.com/v1/webapi/saml/acs"
+    entity_descriptor = <<EOT
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/exk1hqp7cwfwMSmWU5d7">
 <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 <md:KeyDescriptor use="signing">
@@ -44,5 +44,5 @@ resource "teleport_saml_connector" "test" {
 </md:IDPSSODescriptor>
 </md:EntityDescriptor>				
 EOT
-    }
+  }
 }

--- a/terraform/test/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
+++ b/terraform/test/fixtures/saml_connector_0_create_with_entitydescriptorurl.tf
@@ -1,33 +1,33 @@
 resource "teleport_role" "admin" {
-    metadata = {
-        name = "admin"
-        description = "admin role"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "admin"
+    description = "admin role"
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {}
-        allow = {}
-    }
+  spec = {
+    options = {}
+    allow   = {}
+  }
 }
 
 resource "teleport_saml_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        attributes_to_roles = [{
-            name = "groups"
-            roles = ["admin"]
-            value = "okta-admin"
-        }]
-        
-        acs = "https://example.com/v1/webapi/saml/acs"
-        entity_descriptor_url = "https://dev-84961217.okta.com/app/exk4d7tmnz9DEaEw85d7/sso/saml/metadata"
-    }
+  spec = {
+    attributes_to_roles = [{
+      name  = "groups"
+      roles = ["admin"]
+      value = "okta-admin"
+    }]
+
+    acs                   = "https://example.com/v1/webapi/saml/acs"
+    entity_descriptor_url = "https://dev-84961217.okta.com/app/exk4d7tmnz9DEaEw85d7/sso/saml/metadata"
+  }
 }

--- a/terraform/test/fixtures/saml_connector_0_create_without_entitydescriptor.tf
+++ b/terraform/test/fixtures/saml_connector_0_create_without_entitydescriptor.tf
@@ -1,32 +1,32 @@
 resource "teleport_role" "admin" {
-    metadata = {
-        name = "admin"
-        description = "admin role"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "admin"
+    description = "admin role"
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {}
-        allow = {}
-    }
+  spec = {
+    options = {}
+    allow   = {}
+  }
 }
 
 resource "teleport_saml_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
+  }
 
-    spec = {
-        attributes_to_roles = [{
-            name = "groups"
-            roles = ["admin"]
-            value = "okta-admin"
-        }]
+  spec = {
+    attributes_to_roles = [{
+      name  = "groups"
+      roles = ["admin"]
+      value = "okta-admin"
+    }]
 
-        acs = "https://example.com/v1/webapi/saml/acs"
-    }
+    acs = "https://example.com/v1/webapi/saml/acs"
+  }
 }

--- a/terraform/test/fixtures/saml_connector_1_update.tf
+++ b/terraform/test/fixtures/saml_connector_1_update.tf
@@ -1,34 +1,34 @@
 resource "teleport_role" "admin" {
-    metadata = {
-        name = "admin"
-        description = "admin role"
-        expires = "2032-12-12T00:00:00Z"
-    }
+  metadata = {
+    name        = "admin"
+    description = "admin role"
+    expires     = "2032-12-12T00:00:00Z"
+  }
 
-    spec = {
-        options = {}
-        allow = {}
-    }
+  spec = {
+    options = {}
+    allow   = {}
+  }
 }
 
 resource "teleport_saml_connector" "test" {
-    metadata = {
-        name    = "test"
-        expires = "2032-10-12T07:20:50Z"
-        labels  = {
-            example = "no"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2032-10-12T07:20:50Z"
+    labels = {
+      example = "no"
     }
+  }
 
-    spec = {
-        attributes_to_roles = [{
-            name = "groups"
-            roles = ["admin"]
-            value = "okta-admin"
-        }]
-                        
-        acs = "https://example.com/v1/webapi/saml/acs"
-        entity_descriptor = <<EOT
+  spec = {
+    attributes_to_roles = [{
+      name  = "groups"
+      roles = ["admin"]
+      value = "okta-admin"
+    }]
+
+    acs               = "https://example.com/v1/webapi/saml/acs"
+    entity_descriptor = <<EOT
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/exk1hqp7cwfwMSmWU5d7">
 <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 <md:KeyDescriptor use="signing">
@@ -44,5 +44,5 @@ resource "teleport_saml_connector" "test" {
 </md:IDPSSODescriptor>
 </md:EntityDescriptor>				
 EOT
-    }
+  }
 }

--- a/terraform/test/fixtures/session_recording_config_0_set.tf
+++ b/terraform/test/fixtures/session_recording_config_0_set.tf
@@ -1,13 +1,13 @@
 resource "teleport_session_recording_config" "test" {
-    metadata = {
-        labels = {
-            "example" = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "example"             = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
-                    
-    spec = {
-        mode = "node"
-        proxy_checks_host_keys = true
-    }		
+  }
+
+  spec = {
+    mode                   = "node"
+    proxy_checks_host_keys = true
+  }
 }

--- a/terraform/test/fixtures/session_recording_config_1_update.tf
+++ b/terraform/test/fixtures/session_recording_config_1_update.tf
@@ -1,13 +1,13 @@
 resource "teleport_session_recording_config" "test" {
-    metadata = {
-        labels = {
-            "example" = "yes"
-            "teleport.dev/origin" = "dynamic"
-        }
+  metadata = {
+    labels = {
+      "example"             = "yes"
+      "teleport.dev/origin" = "dynamic"
     }
-                    
-    spec = {
-        mode = "off"
-        proxy_checks_host_keys = true
-    }
+  }
+
+  spec = {
+    mode                   = "off"
+    proxy_checks_host_keys = true
+  }
 }

--- a/terraform/test/fixtures/user_0_create.tf
+++ b/terraform/test/fixtures/user_0_create.tf
@@ -1,33 +1,33 @@
-resource "teleport_user" "test" {    
-    metadata = {
-        name    = "test"			
-        expires = "2035-10-12T07:20:50Z"
-        labels  = {
-            example = "yes"
-        }
+resource "teleport_user" "test" {
+  metadata = {
+    name    = "test"
+    expires = "2035-10-12T07:20:50Z"
+    labels = {
+      example = "yes"
     }
-    
-    spec = {
-        roles = ["terraform"]
+  }
 
-        traits = {
-            logins1 = ["example"]
-            logins2 = ["example"]
-        }
-    
-        oidc_identities = [{
-            connector_id = "oidc"
-            username     = "example"
-        }]
-                
-        github_identities = [{
-            connector_id = "github"
-            username     = "example"
-        }]
-    
-        saml_identities = [{
-            connector_id = "saml"
-            username     = "example"
-        }]
+  spec = {
+    roles = ["terraform"]
+
+    traits = {
+      logins1 = ["example"]
+      logins2 = ["example"]
     }
+
+    oidc_identities = [{
+      connector_id = "oidc"
+      username     = "example"
+    }]
+
+    github_identities = [{
+      connector_id = "github"
+      username     = "example"
+    }]
+
+    saml_identities = [{
+      connector_id = "saml"
+      username     = "example"
+    }]
+  }
 }

--- a/terraform/test/fixtures/user_1_update.tf
+++ b/terraform/test/fixtures/user_1_update.tf
@@ -1,22 +1,22 @@
 resource "teleport_user" "test" {
-    metadata = {
-        name    = "test"			
-        expires = "2035-10-12T07:20:52Z"
-        labels  = {
-            example = "yes"
-        }
+  metadata = {
+    name    = "test"
+    expires = "2035-10-12T07:20:52Z"
+    labels = {
+      example = "yes"
     }
-    
-    spec = {
-        roles = ["terraform"]
-    
-        traits = {
-            logins2 = ["example"]
-        }
-    
-        oidc_identities = [{
-            connector_id = "oidc-2"
-            username     = "example"
-        }]	
+  }
+
+  spec = {
+    roles = ["terraform"]
+
+    traits = {
+      logins2 = ["example"]
     }
+
+    oidc_identities = [{
+      connector_id = "oidc-2"
+      username     = "example"
+    }]
+  }
 }


### PR DESCRIPTION
This PR adds a test demonstrating that the provider supports IAM provision tokens.

There was some confusion caused by a stale documentation whether this was supported or not.