### PR TITLE
Update minimum Go version to 1.19

### DIFF
--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,4 +1,4 @@
 steps:
-  - name: golangci/golangci-lint:v1.46.2
+  - name: golangci/golangci-lint:v1.50.1
     id: lint
     args: ["make", "lint"]

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ workspace:
 
 steps:
   - name: Run linter
-    image: golangci/golangci-lint:v1.46.2
+    image: golangci/golangci-lint:v1.50.1
     commands:
       - make lint
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport-plugins
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2


### PR DESCRIPTION
The API module for Teleport 11.2 requires Go 1.19. Also update the version of golangci-lint in Drone and GCB to match that of the GitHub Actions workflow. (The current version of the linter used in GCB does not support Go 1.19)