### PR TITLE
Decrease TestDecorr flakiness

### DIFF
--- a/lib/backoff/backoff_test.go
+++ b/lib/backoff/backoff_test.go
@@ -30,7 +30,7 @@ func TestDecorr(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	clock := clockwork.NewFakeClock()
+	clock := clockwork.NewFakeClockAt(time.Unix(0, 0))
 	base := 20 * time.Millisecond
 	cap := 2 * time.Second
 	backoff := NewDecorr(base, cap, clock)
@@ -40,7 +40,7 @@ func TestDecorr(t *testing.T) {
 		dur, err := measure(ctx, clock, func() error { return backoff.Do(ctx) })
 		require.NoError(t, err)
 		require.Greater(t, dur, base)
-		require.Less(t, dur, max)
+		require.LessOrEqual(t, dur, max)
 	}
 
 	// Check that exponential growth threshold.
@@ -48,6 +48,6 @@ func TestDecorr(t *testing.T) {
 		dur, err := measure(ctx, clock, func() error { return backoff.Do(ctx) })
 		require.NoError(t, err)
 		require.Greater(t, dur, base)
-		require.Less(t, dur, cap)
+		require.LessOrEqual(t, dur, cap)
 	}
 }

--- a/lib/backoff/measure.go
+++ b/lib/backoff/measure.go
@@ -38,14 +38,35 @@ func measure(ctx context.Context, clock clockwork.FakeClock, fn func() error) (t
 	}()
 	clock.BlockUntil(1)
 	for {
-		clock.Advance(5 * time.Millisecond)
-		runtime.Gosched() // Nothing works without it :(
+		/*
+			What does runtime.Gosched() do?
+			> Gosched yields the processor, allowing other goroutines to run. It does not
+			> suspend the current goroutine, so execution resumes automatically.
+
+			Why do we need it?
+			There are two concurrent goroutines at this point:
+			- this one
+			- the one that executes `fn()`
+			When this one is scheduled to run it advances the clock a bit more.
+			It might happen that this one keeps running over and over, while the other one is not scheduled.
+			When that happens, the other 'select' (the one in decorr.Do) gets called and returns nil,
+			the goroutine sets the `dur` value.
+			However, it's too late because the observed time (`dur`) is already larger than expected.
+
+			If both goroutines ran sequentially, this would work.
+			Calling runtime.Gosched here, tries to give priority to the other goroutine.
+			So, when the other goroutine's select is ready (the clock.After returns), it immediately returns and
+			`dur` has the expected value.
+		*/
+		runtime.Gosched()
 		select {
 		case <-done:
 			return dur, trace.Wrap(err)
 		case <-ctx.Done():
 			return time.Duration(0), trace.Wrap(ctx.Err())
 		default:
+			clock.Advance(5 * time.Millisecond)
+			runtime.Gosched()
 		}
 	}
 }


### PR DESCRIPTION
Fixes an off-by-one assertion by letting the sleep duration be as great as the configured max/cap.

It also explains why we need `runtime.Gosched`.

This test relies on some runtime assumptions that fail sometimes. I tried to keep the same base code because it seems to be correct, just that it's hard to prove.

Fixes #732