### PR TITLE
Improve TestSSH assertions

### DIFF
--- a/event-handler/event_handler_test.go
+++ b/event-handler/event_handler_test.go
@@ -279,9 +279,6 @@ func (s *EventHandlerSuite) TestEvents() {
 	t.Log("STDERR", cmdStderr.String())
 	require.NoError(t, err)
 
-	err = stdinPipe.Close()
-	require.NoError(t, err)
-
 	// Our test session is very simple. There would be to copies of the same messages: one copy is supposed to be received
 	// via audit log, other one - via session log.
 	counters := make(map[string]int)

--- a/lib/testing/integration/ssh_test.go
+++ b/lib/testing/integration/ssh_test.go
@@ -69,10 +69,10 @@ func (s *IntegrationSSHSuite) TestSSH() {
 	err = cmd.Start()
 	require.NoError(t, err)
 
-	_, err = stdinPipe.Write([]byte("whoami\n\r"))
+	_, err = stdinPipe.Write([]byte("echo MYUSER=$USER\r\n"))
 	require.NoError(t, err)
 
-	_, err = stdinPipe.Write([]byte("exit\n\r"))
+	_, err = stdinPipe.Write([]byte("exit\r\n"))
 	require.NoError(t, err)
 
 	err = cmd.Wait()
@@ -83,8 +83,5 @@ func (s *IntegrationSSHSuite) TestSSH() {
 	err = stdinPipe.Close()
 	require.NoError(t, err)
 
-	// Output has a lot of info: includes PS1 and a lot of escape colors depending on how fancy the prompt is.
-	// We can assert that there's at least one empty line with the result of `whoami`.
-	// Hopefully that's reliable enough.
-	require.Contains(t, cmdStdout.String(), fmt.Sprintf("\r%s\r\n", user.GetName()))
+	require.Contains(t, cmdStdout.String(), fmt.Sprintf("MYUSER=%s", user.GetName()))
 }

--- a/lib/testing/integration/ssh_test.go
+++ b/lib/testing/integration/ssh_test.go
@@ -80,8 +80,5 @@ func (s *IntegrationSSHSuite) TestSSH() {
 	t.Log("STDERR", cmdStderr.String())
 	require.NoError(t, err)
 
-	err = stdinPipe.Close()
-	require.NoError(t, err)
-
 	require.Contains(t, cmdStdout.String(), fmt.Sprintf("MYUSER=%s", user.GetName()))
 }


### PR DESCRIPTION
Uses a more deterministic way to assert that it printed the expected string.

The previous version was flaky based on the PS1 and how fancy the prompt was.
It failed when running on the Drone's Darwin machine.