### PR TITLE
Remove problematic "Zone:Identifier" file

### DIFF
--- a/apps/example-tomcat-jwt/eclipseproject/sampleaap/WebContent/img/genericperson.png:Zone.Identifier:$DATA
+++ b/apps/example-tomcat-jwt/eclipseproject/sampleaap/WebContent/img/genericperson.png:Zone.Identifier:$DATA
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=about:internet


### PR DESCRIPTION
This file in an example app prevents pulling `teleport-plugins` as a Go module:

```
$ go get github.com/gravitational/teleport-plugins@d3f2d5bf1e6aefd43faddd9b7da413551428b9d1
go: downloading github.com/gravitational/teleport-plugins v0.0.0-20230207175650-d3f2d5bf1e6a
go: github.com/gravitational/teleport-plugins@d3f2d5bf1e6aefd43faddd9b7da413551428b9d1: create zip: apps/example-tomcat-jwt/eclipseproject/sampleaap/WebContent/img/genericperson.png:Zone.Identifier:$DATA: malformed file path "apps/example-tomcat-jwt/eclipseproject/sampleaap/WebContent/img/genericperson.png:Zone.Identifier:$DATA": invalid char ':'
```

I am not sure what the file does, but it seems non-essential and unrelated to Tomcat itself? See: https://cloudbytes.dev/snippets/wsl2-find-and-delete-zoneidentifier-files

I tested the example app after removing this, it builds and runs.