### PR TITLE
Update go to 1.20.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ workspace:
 
 steps:
   - name: Run linter
-    image: golangci/golangci-lint:v1.51.1
+    image: golangci/golangci-lint:v1.51.2
     commands:
       - make lint
 
@@ -1386,6 +1386,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 08b0666a59ea5fbfd6f1b54c42dc1428a1e6c7d0ce5c146b48919f3ad6cc4f87
+hmac: 39bddb167178a83286fcc3e9db4b3d6562ea6ff1c61b57e06d13e8205ea66e8a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       - make lint
 
   - name: Run tests
-    image: golang:1.20.0
+    image: golang:1.20.1
     environment:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
@@ -67,7 +67,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.20.0
+      GO_VERSION: go1.20.1
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
       TERRAFORM_VERSION: 1.3.3
       TERRAFORM_ARCHIVE: terraform_1.3.3_darwin_amd64.zip
@@ -132,7 +132,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - make build-all
 
@@ -168,7 +168,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.20.0
+      GO_VERSION: go1.20.1
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -224,7 +224,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - mkdir -p build/
       - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
@@ -438,7 +438,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - mkdir -p build/
       - make release/terraform
@@ -511,7 +511,7 @@ trigger:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.20.0
+      GO_VERSION: go1.20.1
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
       - set -u
@@ -598,7 +598,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - mkdir -p build/
       - make release/event-handler
@@ -746,7 +746,7 @@ trigger:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.20.0
+      GO_VERSION: go1.20.1
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
       - set -u
@@ -1232,7 +1232,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - cd tooling
       - |
@@ -1290,7 +1290,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - cd tooling
       - |
@@ -1348,7 +1348,7 @@ concurrency:
 
 steps:
   - name: Promote terraform provider to public registry
-    image: golang:1.20.0
+    image: golang:1.20.1
     commands:
       - cd tooling
       - |
@@ -1386,6 +1386,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 5b1a5fd4928274d1f3eddea1250fee72f342fe1e7784978743360adc1ad3435a
+hmac: 08b0666a59ea5fbfd6f1b54c42dc1428a1e6c7d0ce5c146b48919f3ad6cc4f87
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,12 +19,12 @@ workspace:
 
 steps:
   - name: Run linter
-    image: golangci/golangci-lint:v1.50.1
+    image: golangci/golangci-lint:v1.51.1
     commands:
       - make lint
 
   - name: Run tests
-    image: golang:1.19.5
+    image: golang:1.20.0
     environment:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
@@ -67,7 +67,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.19.5
+      GO_VERSION: go1.20.0
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
       TERRAFORM_VERSION: 1.3.3
       TERRAFORM_ARCHIVE: terraform_1.3.3_darwin_amd64.zip
@@ -132,7 +132,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - make build-all
 
@@ -168,7 +168,7 @@ workspace:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.19.5
+      GO_VERSION: go1.20.0
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -224,7 +224,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - mkdir -p build/
       - export PLUGIN_TYPE=$(echo ${DRONE_TAG} | cut -d- -f2)
@@ -438,7 +438,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - mkdir -p build/
       - make release/terraform
@@ -511,7 +511,7 @@ trigger:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.19.5
+      GO_VERSION: go1.20.0
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
       - set -u
@@ -598,7 +598,7 @@ workspace:
 
 steps:
   - name: Build artifacts
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - mkdir -p build/
       - make release/event-handler
@@ -746,7 +746,7 @@ trigger:
 steps:
   - name: Install Go Toolchain
     environment:
-      GO_VERSION: go1.19.5
+      GO_VERSION: go1.20.0
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
       - set -u
@@ -1232,7 +1232,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - cd tooling
       - |
@@ -1290,7 +1290,7 @@ concurrency:
 
 steps:
   - name: Upload terraform provider to staging registry
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - cd tooling
       - |
@@ -1348,7 +1348,7 @@ concurrency:
 
 steps:
   - name: Promote terraform provider to public registry
-    image: golang:1.19.5
+    image: golang:1.20.0
     commands:
       - cd tooling
       - |
@@ -1386,6 +1386,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 67bab55d029dcadfcd411e4eada3126c5d23064a4a40d6a8fc8b6c9a885b2093
+hmac: 5b1a5fd4928274d1f3eddea1250fee72f342fe1e7784978743360adc1ad3435a
 
 ...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,15 +18,15 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.19.5
+      - name: Setup Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.5'
+          go-version: '1.20'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.1
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.20
+      - name: Setup Go 1.20.1
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.20.1'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.20.0
+      - name: Setup Go 1.20.1
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.0'
+          go-version: '1.20.1'
 
       - name: Setup Terraform 1.3.3
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.19.5
+      - name: Setup Go 1.20.0
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
 
       - name: Setup Terraform 1.3.3
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.19.5
+      - name: Setup Go 1.20.0
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
 
       - name: Run tests
         run: make test

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Teleport Plugins
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.20.0
+      - name: Setup Go 1.20.1
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.0'
+          go-version: '1.20.1'
 
       - name: Run tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 issues:
   exclude-rules:
-    - linters: gosimple
+    - linters:
+      - gosimple
       text: "S1002: should omit comparison to bool constant"
   exclude-use-default: true
   max-same-issues: 0
@@ -10,23 +11,57 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - errcheck
+    - depguard
+    - gci
     - goimports
-    - revive
     - gosimple
     - govet
     - ineffassign
     - misspell
+    - nolintlint
+    - revive
     - staticcheck
-    - typecheck
-    - unused
     - unconvert
+    # Re-add the `unused` linter when this issue is fixed and released in the golangci-lint
+    # https://github.com/dominikh/go-tools/issues/1361
+    # - unused
 
+linters-settings:
+  depguard:
+    list-type: denylist
+    include-go-root: true # check against stdlib
+    packages-with-error-message:
+      - io/ioutil: 'use "io" or "os" packages instead'
+      - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
+      - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
+      - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
+      - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
+      - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
+      - go.uber.org/atomic: 'use "sync/atomic" instead'
+  misspell:
+    locale: US
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/gravitational/teleport-plugins) # Custom section: groups all imports with the specified Prefix.
+    skip-generated: true # Skip generated files.
+    custom-order: true # Required for "sections" to take effect.
+  nolintlint:
+    allow-unused: true # Enabled because of conditional builds / build tags.
+    require-explanation: true
+    require-specific: true
 output:
   uniq-by-line: false
 
 run:
+  go: '1.19'
   skip-dirs:
-    - pkg/mod
+    - (^|/)node_modules/
+    - ^api/gen/
+    - ^docs/
+    - ^gen/
+    - ^rfd/
+    - ^web/
   skip-dirs-use-default: false
   timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,6 @@ update-goversion:
 	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/email/Makefile
 	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' event-handler/Makefile
 	$(SED) 's/^RUNTIME ?= go.*/RUNTIME ?= go$(GOVERSION)/' docker/Makefile
-	$(SED) 's/- name: golang:.*/- name: golang:$(GOVERSION)/' .cloudbuild/ci/unit-tests-linux.yaml
 	$(SED) 's/Setup Go .*/Setup Go $(GOVERSION)/g' .github/workflows/unit-tests.yaml
 	$(SED) 's/Setup Go .*/Setup Go $(GOVERSION)/g' .github/workflows/terraform-tests.yaml
 	$(SED) 's/Setup Go .*/Setup Go $(GOVERSION)/g' .github/workflows/lint.yaml

--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,14 @@ fix-license: $(ADDLICENSE)
 $(ADDLICENSE):
 	cd && go install github.com/google/addlicense@v1.0.0
 
+GCI := $(GOPATH)/bin/gci
+$(GCI):
+	cd && go install github.com/daixiang0/gci@latest
+
+.PHONY: fix-imports
+fix-imports: $(GCI)
+	$(GCI) write -s 'standard,default,prefix(github.com/gravitational/teleport-plugins)' --skip-generated .
+
 .PHONY: test-helm-%
 test-helm-%:
 	helm unittest ./charts/$(subst access-,access/,$*)

--- a/access/common/app.go
+++ b/access/common/app.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/access/common/teleport"
-	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
-	"github.com/gravitational/teleport-plugins/lib/watcherjob"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport-plugins/access/common/teleport"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/trace"
+	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
+	"github.com/gravitational/teleport-plugins/lib/watcherjob"
 )
 
 const (

--- a/access/common/auth/token_provider.go
+++ b/access/common/auth/token_provider.go
@@ -19,11 +19,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/access/common/auth/oauth"
-	"github.com/gravitational/teleport-plugins/access/common/auth/storage"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/access/common/auth/oauth"
+	"github.com/gravitational/teleport-plugins/access/common/auth/storage"
 )
 
 const defaultRefreshRetryInterval = 5 * time.Minute

--- a/access/common/auth/token_provider_test.go
+++ b/access/common/auth/token_provider_test.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/access/common/auth/oauth"
-	"github.com/gravitational/teleport-plugins/access/common/auth/storage"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport-plugins/access/common/auth/oauth"
+	"github.com/gravitational/teleport-plugins/access/common/auth/storage"
 )
 
 type mockRefresher struct {

--- a/access/common/bot.go
+++ b/access/common/bot.go
@@ -17,9 +17,10 @@ limitations under the License.
 package common
 
 import (
-	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/gravitational/teleport/api/types"
 	"golang.org/x/net/context"
+
+	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 // MessagingBot is a generic interface with all methods required to send notifications through a messaging service.

--- a/access/common/config.go
+++ b/access/common/config.go
@@ -19,15 +19,16 @@ package common
 import (
 	"context"
 
-	"github.com/gravitational/teleport-plugins/access/common/teleport"
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/credentials"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	grpcbackoff "google.golang.org/grpc/backoff"
+
+	"github.com/gravitational/teleport-plugins/access/common/teleport"
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/credentials"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type PluginConfiguration interface {

--- a/access/common/message.go
+++ b/access/common/message.go
@@ -23,10 +23,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 // Slack has a 4000 character limit for message texts and 3000 character limit

--- a/access/common/recipient.go
+++ b/access/common/recipient.go
@@ -19,8 +19,9 @@ package common
 import (
 	"fmt"
 
-	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/teleport/api/types"
+
+	"github.com/gravitational/teleport-plugins/lib/stringset"
 )
 
 // RawRecipientsMap is a mapping of roles to recipient(s).

--- a/access/common/teleport/client.go
+++ b/access/common/teleport/client.go
@@ -17,9 +17,10 @@ package teleport
 import (
 	"context"
 
-	"github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+
+	"github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 // Client aggregates the parts of Teleport API client interface

--- a/access/discord/Makefile
+++ b/access/discord/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-discord

--- a/access/discord/Makefile
+++ b/access/discord/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-discord

--- a/access/discord/bot.go
+++ b/access/discord/bot.go
@@ -23,13 +23,13 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/access/common"
-	"github.com/gravitational/teleport-plugins/lib"
-	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
+	"github.com/go-resty/resty/v2"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 
-	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/teleport-plugins/access/common"
+	"github.com/gravitational/teleport-plugins/lib"
+	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 const discordMaxConns = 100

--- a/access/discord/config.go
+++ b/access/discord/config.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
 
 	"github.com/gravitational/teleport-plugins/access/common"
 	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const discordAPIUrl = "https://discord.com/api/"

--- a/access/discord/fake_discord_test.go
+++ b/access/discord/fake_discord_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-
 	log "github.com/sirupsen/logrus"
 )
 

--- a/access/discord/main.go
+++ b/access/discord/main.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 //go:embed example_config.toml

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-email

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-email

--- a/access/email/app.go
+++ b/access/email/app.go
@@ -20,17 +20,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	grpcbackoff "google.golang.org/grpc/backoff"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/credentials"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"google.golang.org/grpc"
-	grpcbackoff "google.golang.org/grpc/backoff"
-
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/email/client.go
+++ b/access/email/client.go
@@ -24,10 +24,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 var reviewReplyTemplate = template.Must(template.New("review reply").Parse(

--- a/access/email/config.go
+++ b/access/email/config.go
@@ -20,6 +20,7 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
 	"gopkg.in/mail.v2"
@@ -27,7 +28,6 @@ import (
 	"github.com/gravitational/teleport-plugins/access/common"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport/api/types"
 )
 
 // DeliveryConfig represents email recipients config

--- a/access/email/config_test.go
+++ b/access/email/config_test.go
@@ -21,11 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gravitational/teleport-plugins/access/common"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/mail.v2"
+
+	"github.com/gravitational/teleport-plugins/access/common"
 )
 
 func TestRecipients(t *testing.T) {

--- a/access/email/email_test.go
+++ b/access/email/email_test.go
@@ -29,17 +29,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/testing/integration"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 const (

--- a/access/email/main.go
+++ b/access/email/main.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 func main() {

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-jira

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-jira

--- a/access/jira/app.go
+++ b/access/jira/app.go
@@ -24,6 +24,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 	grpcbackoff "google.golang.org/grpc/backoff"
@@ -33,12 +38,6 @@ import (
 	"github.com/gravitational/teleport-plugins/lib/credentials"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
-
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/jira/client.go
+++ b/access/jira/client.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/jira/config.go
+++ b/access/jira/config.go
@@ -23,10 +23,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type Config struct {

--- a/access/jira/fake_jira_test.go
+++ b/access/jira/fake_jira_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-
 	log "github.com/sirupsen/logrus"
 )
 

--- a/access/jira/jira_test.go
+++ b/access/jira/jira_test.go
@@ -31,17 +31,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/testing/integration"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type JiraSuite struct {

--- a/access/jira/main.go
+++ b/access/jira/main.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 const (

--- a/access/jira/webhook_server.go
+++ b/access/jira/webhook_server.go
@@ -26,10 +26,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 const (

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-mattermost

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-mattermost

--- a/access/mattermost/app.go
+++ b/access/mattermost/app.go
@@ -19,6 +19,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 	grpcbackoff "google.golang.org/grpc/backoff"
@@ -29,10 +33,6 @@ import (
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/mattermost/bot.go
+++ b/access/mattermost/bot.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/mailgun/holster/v3/collections"
 
 	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/mattermost/config.go
+++ b/access/mattermost/config.go
@@ -17,10 +17,11 @@ package main
 import (
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type Config struct {

--- a/access/mattermost/fake_mattermost_test.go
+++ b/access/mattermost/fake_mattermost_test.go
@@ -25,10 +25,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/gravitational/trace"
 )
 
 type FakeMattermost struct {

--- a/access/mattermost/main.go
+++ b/access/mattermost/main.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 func main() {

--- a/access/mattermost/mattermost_test.go
+++ b/access/mattermost/mattermost_test.go
@@ -27,17 +27,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/testing/integration"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 var msgFieldRegexp = regexp.MustCompile(`(?im)^\*\*([a-zA-Z ]+)\*\*:\ +(.+)$`)

--- a/access/msteams/Makefile
+++ b/access/msteams/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-msteams

--- a/access/msteams/Makefile
+++ b/access/msteams/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-msteams

--- a/access/msteams/app.go
+++ b/access/msteams/app.go
@@ -18,6 +18,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
 	grpcbackoff "google.golang.org/grpc/backoff"
 
@@ -27,10 +31,6 @@ import (
 	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/msteams/card.go
+++ b/access/msteams/card.go
@@ -21,9 +21,10 @@ import (
 	"time"
 
 	cards "github.com/DanielTitkov/go-adaptive-cards"
+	"github.com/gravitational/teleport/api/types"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/plugindata"
-	"github.com/gravitational/teleport/api/types"
 )
 
 // BuildCard builds the MS Teams message from a request data

--- a/access/msteams/config.go
+++ b/access/msteams/config.go
@@ -17,13 +17,14 @@ package main
 import (
 	"strings"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/pelletier/go-toml"
+
 	"github.com/gravitational/teleport-plugins/access/common"
 	"github.com/gravitational/teleport-plugins/access/msteams/msapi"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
-	"github.com/pelletier/go-toml"
 )
 
 // Config represents plugin configuration

--- a/access/msteams/configure.go
+++ b/access/msteams/configure.go
@@ -24,8 +24,9 @@ import (
 	"path"
 
 	"github.com/google/uuid"
-	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
 )
 
 const (

--- a/access/msteams/main.go
+++ b/access/msteams/main.go
@@ -20,9 +20,10 @@ import (
 	"time"
 
 	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/trace"
 )
 
 var (

--- a/access/msteams/mock_ms_teams_api_test.go
+++ b/access/msteams/mock_ms_teams_api_test.go
@@ -28,11 +28,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/gravitational/teleport-plugins/access/msteams/msapi"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/access/msteams/msapi"
 )
 
 type response struct {

--- a/access/msteams/msapi/client.go
+++ b/access/msteams/msapi/client.go
@@ -23,9 +23,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/lib/backoff"
 )
 
 // Client represents generic MS API client

--- a/access/msteams/msapi/token.go
+++ b/access/msteams/msapi/token.go
@@ -25,9 +25,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/lib/backoff"
 )
 
 const (

--- a/access/msteams/plugindata_test.go
+++ b/access/msteams/plugindata_test.go
@@ -17,8 +17,9 @@ package main
 import (
 	"testing"
 
-	"github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 var samplePluginData = PluginData{

--- a/access/msteams/validate.go
+++ b/access/msteams/validate.go
@@ -21,10 +21,11 @@ import (
 
 	cards "github.com/DanielTitkov/go-adaptive-cards"
 	"github.com/google/uuid"
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/plugindata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 // validate installs the application for a user if required and sends the Hello, world! message

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-pagerduty

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-pagerduty

--- a/access/pagerduty/app.go
+++ b/access/pagerduty/app.go
@@ -23,6 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 	grpcbackoff "google.golang.org/grpc/backoff"
@@ -32,10 +36,6 @@ import (
 	"github.com/gravitational/teleport-plugins/lib/credentials"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/watcherjob"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/pagerduty/client.go
+++ b/access/pagerduty/client.go
@@ -27,12 +27,12 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/stringset"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -19,10 +19,11 @@ package main
 import (
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type Config struct {

--- a/access/pagerduty/fake_pagerduty_test.go
+++ b/access/pagerduty/fake_pagerduty_test.go
@@ -28,11 +28,11 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/lib/stringset"
 )
 
 type FakePagerduty struct {

--- a/access/pagerduty/main.go
+++ b/access/pagerduty/main.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 func main() {

--- a/access/pagerduty/pagerduty_test.go
+++ b/access/pagerduty/pagerduty_test.go
@@ -27,18 +27,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport-plugins/lib/testing/integration"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/trace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
+	"github.com/gravitational/teleport-plugins/lib/testing/integration"
 )
 
 const (

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-slack

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-slack

--- a/access/slack/bot.go
+++ b/access/slack/bot.go
@@ -22,13 +22,13 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/access/common"
-	"github.com/gravitational/teleport-plugins/lib"
-	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
+	"github.com/go-resty/resty/v2"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 
-	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/teleport-plugins/access/common"
+	"github.com/gravitational/teleport-plugins/lib"
+	pd "github.com/gravitational/teleport-plugins/lib/plugindata"
 )
 
 const slackMaxConns = 100

--- a/access/slack/cmd/slack/main.go
+++ b/access/slack/cmd/slack/main.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/access/slack"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-
-	"github.com/gravitational/kingpin"
-	"github.com/gravitational/trace"
 )
 
 //go:embed example_config.toml

--- a/access/slack/config.go
+++ b/access/slack/config.go
@@ -21,14 +21,13 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/pelletier/go-toml"
 
 	"github.com/gravitational/teleport-plugins/access/common"
 	"github.com/gravitational/teleport-plugins/access/common/auth"
-
 	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport/api/types"
 )
 
 // Config stores the full configuration for the teleport-slack plugin to run.

--- a/access/slack/fake_slack_test.go
+++ b/access/slack/fake_slack_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-
 	log "github.com/sirupsen/logrus"
 )
 

--- a/access/slack/oauth.go
+++ b/access/slack/oauth.go
@@ -19,9 +19,10 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/access/common/auth/oauth"
 	"github.com/gravitational/teleport-plugins/access/common/auth/storage"
-	"github.com/gravitational/trace"
 )
 
 // Authorizer implements oauth2.Authorizer for Slack API.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 # enterprise version, but has to be available on get.gravitational.com
 RELEASE ?= teleport-ent-v6.0.2-linux-amd64-bin
 
-RUNTIME ?= go1.19.5
+RUNTIME ?= go1.20.0
 BBOX ?= quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 
 # Teleport CLI and plugins CLI flags to pass to them on start

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 # enterprise version, but has to be available on get.gravitational.com
 RELEASE ?= teleport-ent-v6.0.2-linux-amd64-bin
 
-RUNTIME ?= go1.20.0
+RUNTIME ?= go1.20.1
 BBOX ?= quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 
 # Teleport CLI and plugins CLI flags to pass to them on start

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.19.5
+GO_VERSION=1.20.0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -1,5 +1,5 @@
 VERSION=12.0.2
-GO_VERSION=1.20.0
+GO_VERSION=1.20.1
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/event-handler/app.go
+++ b/event-handler/app.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/backoff"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/backoff"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 // App is the app structure

--- a/event-handler/cli.go
+++ b/event-handler/cli.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kong"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/event-handler/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/stringset"
-
-	"github.com/alecthomas/kong"
-	"github.com/gravitational/trace"
 )
 
 // FluentdConfig represents fluentd instance configuration

--- a/event-handler/configure_cmd.go
+++ b/event-handler/configure_cmd.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport-plugins/event-handler/lib"
 )
 
-// ConfigureCmd represents configure command behaviour.
+// ConfigureCmd represents configure command behavior.
 //
 // teleport-event-handler configure .
 //

--- a/event-handler/event_handler_test.go
+++ b/event-handler/event_handler_test.go
@@ -25,14 +25,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/testing/integration"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
-
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type EventHandlerSuite struct {

--- a/event-handler/events_job.go
+++ b/event-handler/events_job.go
@@ -17,11 +17,12 @@ package main
 import (
 	"context"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	limiter "github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/memorystore"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 // EventsJob incapsulates audit log event consumption logic
@@ -70,7 +71,7 @@ func (j *EventsJob) run(ctx context.Context) error {
 		case trace.IsEOF(err):
 			log.WithError(err).Error("Watcher stream closed. Reconnecting...")
 		case lib.IsCanceled(err):
-			log.Debug("Watcher context is cancelled")
+			log.Debug("Watcher context is canceled")
 			j.app.Terminate()
 			return nil
 		default:

--- a/event-handler/fake_fluentd_test.go
+++ b/event-handler/fake_fluentd_test.go
@@ -28,8 +28,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type FakeFluentd struct {
@@ -104,7 +105,7 @@ func (f *FakeFluentd) writeCerts() error {
 	return nil
 }
 
-// createServer initialises new server instance
+// createServer initializes new server instance
 func (f *FakeFluentd) createServer() error {
 	caCert, err := os.ReadFile(f.caCertPath)
 	if err != nil {

--- a/event-handler/fluentd_client.go
+++ b/event-handler/fluentd_client.go
@@ -25,10 +25,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/event-handler/lib"
-	tlib "github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/event-handler/lib"
+	tlib "github.com/gravitational/teleport-plugins/lib"
 )
 
 const (

--- a/event-handler/main.go
+++ b/event-handler/main.go
@@ -24,9 +24,10 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/trace"
 )
 
 // cli is CLI configuration

--- a/event-handler/mtls_certs.go
+++ b/event-handler/mtls_certs.go
@@ -213,7 +213,7 @@ func (c *keyPair) EncodeToMemory(pwd string) ([]byte, []byte, error) {
 
 	// Encrypt with passphrase
 	if pwd != "" {
-		//nolint // deprecated, but we still need it to be encrypted because of fluentd requirements
+		//nolint:staticcheck // deprecated, but we still need it to be encrypted because of fluentd requirements
 		pkBlock, err = x509.EncryptPEMBlock(rand.Reader, pkBlock.Type, pkBlock.Bytes, []byte(pwd), x509.PEMCipherAES256)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)

--- a/event-handler/session_events_job.go
+++ b/event-handler/session_events_job.go
@@ -18,14 +18,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/event-handler/state.go
+++ b/event-handler/state.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/event-handler/lib"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
 	"github.com/peterbourgon/diskv/v3"
+
+	"github.com/gravitational/teleport-plugins/event-handler/lib"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 const (

--- a/event-handler/teleport_event.go
+++ b/event-handler/teleport_event.go
@@ -21,9 +21,10 @@ import (
 	"encoding/hex"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/event-handler/lib"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/event-handler/lib"
 )
 
 const (

--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -20,14 +20,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/credentials"
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+
+	"github.com/gravitational/teleport-plugins/lib/credentials"
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 const (
@@ -301,7 +302,7 @@ func (t *TeleportEventsWatcher) UpsertLock(ctx context.Context, user string, log
 
 	if period > 0 {
 		t := time.Now()
-		t.Add(period)
+		t = t.Add(period)
 		expires = &t
 	}
 

--- a/event-handler/teleport_events_watcher_test.go
+++ b/event-handler/teleport_events_watcher_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
-
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"

--- a/lib/backoff/decorr.go
+++ b/lib/backoff/decorr.go
@@ -21,9 +21,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 // Decorr is a "decorrelated jitter" inspired by https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.

--- a/lib/config.go
+++ b/lib/config.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/trace"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/lib/stringset"
 )
 
 // TeleportConfig stores config options for where

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"io"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TODO: remove this when trail.FromGRPC will understand additional error codes

--- a/lib/http.go
+++ b/lib/http.go
@@ -63,7 +63,7 @@ type HTTPBasicAuthConfig struct {
 // HTTP is a tiny wrapper around standard net/http.
 // It starts either insecure server or secure one with TLS, depending on the settings.
 // It also adds a context to its handlers and the server itself has context to.
-// So you are guaranteed that server will be closed when the context is cancelled.
+// So you are guaranteed that server will be closed when the context is canceled.
 type HTTP struct {
 	HTTPConfig
 	mu      sync.Mutex

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-
 	log "github.com/sirupsen/logrus"
 )
 

--- a/lib/plugindata/cas.go
+++ b/lib/plugindata/cas.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/lib/backoff"
 )
 
 const (

--- a/lib/tar/extract.go
+++ b/lib/tar/extract.go
@@ -25,8 +25,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gravitational/teleport-plugins/lib/stringset"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/stringset"
 )
 
 // Compression is a compression flag.

--- a/lib/tctl/resources.go
+++ b/lib/tctl/resources.go
@@ -21,10 +21,9 @@ import (
 	"io"
 
 	"github.com/ghodss/yaml"
-	kyaml "k8s.io/apimachinery/pkg/util/yaml"
-
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func writeResourcesYAML(w io.Writer, resources []types.Resource) error {

--- a/lib/tctl/tctl.go
+++ b/lib/tctl/tctl.go
@@ -21,9 +21,10 @@ import (
 	"os/exec"
 	"regexp"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 var regexpStatusCAPin = regexp.MustCompile(`CA pin +(sha256:[a-zA-Z0-9]+)`)

--- a/lib/testing/integration/auth_test.go
+++ b/lib/testing/integration/auth_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/api/types"
-
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/lib/testing/integration/authservice.go
+++ b/lib/testing/integration/authservice.go
@@ -28,8 +28,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 var regexpAuthStarting = regexp.MustCompile(`Auth service [^ ]+ is starting on [^ ]+:(\d+)`)
@@ -121,7 +122,7 @@ func (auth *AuthService) Run(ctx context.Context) error {
 			if err := cmd.Process.Signal(syscall.SIGQUIT); err != nil {
 				log.Warn(err)
 			}
-			// If we're not done in 5 minutes, just kill the process by cancelling its context.
+			// If we're not done in 5 minutes, just kill the process by canceling its context.
 			go func() {
 				select {
 				case <-auth.doneCh:

--- a/lib/testing/integration/download.go
+++ b/lib/testing/integration/download.go
@@ -28,12 +28,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/backoff"
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/tar"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 type downloadVersionKey struct {

--- a/lib/testing/integration/integration.go
+++ b/lib/testing/integration/integration.go
@@ -31,16 +31,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/go-version"
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/teleport-plugins/lib/tctl"
 	"github.com/gravitational/teleport-plugins/lib/tsh"
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/trace"
 )
 
 const IntegrationAdminRole = "integration-admin"

--- a/lib/testing/integration/integration_test.go
+++ b/lib/testing/integration/integration_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/lib/testing/integration/proxyservice.go
+++ b/lib/testing/integration/proxyservice.go
@@ -29,8 +29,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 var regexpWebProxyStarting = regexp.MustCompile(`Web proxy service [^ ]+ is starting on [^ ]+:(\d+)`)
@@ -126,7 +127,7 @@ func (proxy *ProxyService) Run(ctx context.Context) error {
 			if err := cmd.Process.Signal(syscall.SIGQUIT); err != nil {
 				log.Warn(err)
 			}
-			// If we're not done in 5 minutes, just kill the process by cancelling its context.
+			// If we're not done in 5 minutes, just kill the process by canceling its context.
 			go func() {
 				select {
 				case <-proxy.doneCh:

--- a/lib/testing/integration/setup.go
+++ b/lib/testing/integration/setup.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 type BaseSetup struct {

--- a/lib/testing/integration/sshservice.go
+++ b/lib/testing/integration/sshservice.go
@@ -28,8 +28,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 var regexpSSHStarting = regexp.MustCompile(`Service [^ ]+ is starting on [^ ]+:(\d+)`)
@@ -121,7 +122,7 @@ func (ssh *SSHService) Run(ctx context.Context) error {
 			if err := cmd.Process.Signal(syscall.SIGQUIT); err != nil {
 				log.Warn(err)
 			}
-			// If we're not done in 5 minutes, just kill the process by cancelling its context.
+			// If we're not done in 5 minutes, just kill the process by canceling its context.
 			go func() {
 				select {
 				case <-ssh.doneCh:

--- a/lib/testing/integration/suite.go
+++ b/lib/testing/integration/suite.go
@@ -23,11 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 // Suite is a basic testing suite enhanced with context management.
@@ -63,7 +63,7 @@ type contexts struct {
 	appCtx context.Context
 
 	// testCtx inherits from baseCtx. Its purpose is to limit the lifetime of the test method.
-	// This context is guaranteed to be cancelled earlier than appCtx for better error reporting (see explanation above).
+	// This context is guaranteed to be canceled earlier than appCtx for better error reporting (see explanation above).
 	testCtx context.Context
 }
 

--- a/lib/tsh/tsh.go
+++ b/lib/tsh/tsh.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/gravitational/teleport-plugins/lib/logger"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport-plugins/lib/logger"
 )
 
 // Tsh is a runner of tsh command.

--- a/lib/versions.go
+++ b/lib/versions.go
@@ -17,7 +17,6 @@ package lib
 import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/trace"
-
 	"github.com/hashicorp/go-version"
 )
 

--- a/lib/watcherjob/helpers_test.go
+++ b/lib/watcherjob/helpers_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport-plugins/lib"
 )
 
 // MockWatcher is a mock events watcher.

--- a/lib/watcherjob/watcherjob.go
+++ b/lib/watcherjob/watcherjob.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport-plugins/access/common/teleport"
 	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport-plugins/lib/logger"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
 )
 
 const DefaultMaxConcurrency = 128
@@ -89,7 +90,7 @@ func NewJobWithEvents(events types.Events, config Config, fn EventFunc) lib.Serv
 			case trace.IsEOF(err):
 				log.WithError(err).Error("Watcher stream closed. Reconnecting...")
 			case lib.IsCanceled(err):
-				log.Debug("Watcher context is cancelled")
+				log.Debug("Watcher context is canceled")
 				// Context cancellation is not an error
 				return nil
 			default:
@@ -219,7 +220,7 @@ func (job job) eventLoop(ctx context.Context) error {
 				delete(queues, key)
 			}
 
-		case <-ctx.Done(): // Stop processing immediately because the context was cancelled.
+		case <-ctx.Done(): // Stop processing immediately because the context was canceled.
 			return trace.Wrap(ctx.Err())
 		}
 	}

--- a/lib/watcherjob/watcherjob_test.go
+++ b/lib/watcherjob/watcherjob_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/terraform/_gen/schema_dump.go
+++ b/terraform/_gen/schema_dump.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 var (

--- a/terraform/main.go
+++ b/terraform/main.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/gravitational/teleport-plugins/terraform/provider"
-
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+
+	"github.com/gravitational/teleport-plugins/terraform/provider"
 )
 
 func main() {

--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -29,16 +29,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/lib"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
+
+	"github.com/gravitational/teleport-plugins/lib"
 )
 
 const (

--- a/terraform/provider/resource_teleport_bot.go
+++ b/terraform/provider/resource_teleport_bot.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/trace"
@@ -28,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 func GenSchemaBot(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {

--- a/terraform/test/main_test.go
+++ b/terraform/test/main_test.go
@@ -23,9 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gravitational/teleport-plugins/lib"
-	"github.com/gravitational/teleport-plugins/lib/testing/integration"
-	"github.com/gravitational/teleport-plugins/terraform/provider"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
@@ -34,6 +31,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/gravitational/teleport-plugins/lib"
+	"github.com/gravitational/teleport-plugins/lib/testing/integration"
+	"github.com/gravitational/teleport-plugins/terraform/provider"
 )
 
 //go:embed fixtures/*

--- a/tooling/cmd/promote-terraform/args.go
+++ b/tooling/cmd/promote-terraform/args.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/cmd/promote-terraform/main.go
+++ b/tooling/cmd/promote-terraform/main.go
@@ -37,11 +37,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gravitational/teleport-plugins/tooling/internal/staging"
 	"github.com/gravitational/teleport-plugins/tooling/internal/terraform/registry"
-	"github.com/gravitational/trace"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/tooling/internal/filename/parse.go
+++ b/tooling/internal/filename/parse.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/filename/parse_test.go
+++ b/tooling/internal/filename/parse_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/staging/staging_test.go
+++ b/tooling/internal/staging/staging_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/terraform/registry/archives.go
+++ b/tooling/internal/terraform/registry/archives.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/terraform/registry/protocol.go
+++ b/tooling/internal/terraform/registry/protocol.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -123,7 +123,8 @@ type Download struct {
 
 // Save serializes a Download record to JSON and writes it to the appropriate
 // Provider Registry Protocol-defined location in a registry directory tree, i.e.
-//   indexDir/:namespace/:name/:version/download/:os/:arch
+//
+//	indexDir/:namespace/:name/:version/download/:os/:arch
 func (dl *Download) Save(indexDir, namespace, name string, version semver.Version) (string, error) {
 	filename := filepath.Join(indexDir, namespace, name, version.String(), "download", dl.OS, dl.Arch)
 

--- a/tooling/internal/terraform/registry/protocol_test.go
+++ b/tooling/internal/terraform/registry/protocol_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/terraform/registry/sha.go
+++ b/tooling/internal/terraform/registry/sha.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tooling/internal/terraform/registry/sign.go
+++ b/tooling/internal/terraform/registry/sign.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,9 +24,10 @@ import (
 	"path/filepath"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/gravitational/teleport-plugins/tooling/internal/filename"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport-plugins/tooling/internal/filename"
 )
 
 // FileNames describes the location of a registry-compatible zipfile and its
@@ -77,7 +78,8 @@ func (r *RepackResult) Sha256String() string {
 //
 // For more information on the output files, see the Terraform Provider Registry
 // Protocol documentation:
-//    https://www.terraform.io/internals/provider-registry-protocol
+//
+//	https://www.terraform.io/internals/provider-registry-protocol
 func RepackProvider(dstDir string, srcFileName string, signingEntity *openpgp.Entity) (*RepackResult, error) {
 	info, err := filename.Parse(srcFileName)
 	if err != nil {

--- a/tooling/internal/terraform/registry/sign_test.go
+++ b/tooling/internal/terraform/registry/sign_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,8 +28,9 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/coreos/go-semver/semver"
-	"github.com/gravitational/teleport-plugins/tooling/internal/filename"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport-plugins/tooling/internal/filename"
 )
 
 const (


### PR DESCRIPTION
This also changes the golangci-lint rules to match those of the main teleport repo.
Most of the changes are imports re-ordering to comply with above rules.