### PR TITLE
[jira-plugin] Make service type configurable

### DIFF
--- a/charts/access/jira/templates/service.yaml
+++ b/charts/access/jira/templates/service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     {{- include "jira.selectorLabels" . | nindent 4 }}
-  type: LoadBalancer
+  type: {{ .Values.serviceType }}
   ports:
   - name: https
     port: 443

--- a/charts/access/jira/tests/service_test.yaml
+++ b/charts/access/jira/tests/service_test.yaml
@@ -19,3 +19,12 @@ tests:
             service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
             service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
             service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+  - it: should be possible to change service type
+    set:
+      serviceType: "ClusterIP"
+    asserts:
+      - equal:
+          path: spec.type
+          value:
+            ClusterIP

--- a/charts/access/jira/values.yaml
+++ b/charts/access/jira/values.yaml
@@ -66,3 +66,5 @@ tolerations: []
 affinity: {}
 
 serviceAnnotations: {}
+
+serviceType: LoadBalancer


### PR DESCRIPTION
Hi! 

I deployed Jira plugin to AWS with ALB instead of NLB. This chart doesn't allow to override the service type and force to request a LoadBalancer. It doesn't look right to me as it won't work in the self-hosted Kubernetes installations. 

This PR intents to fix such behaviour.


Tested:
```
$ helm template teleport-plugin-jira .
# Source: teleport-plugin-jira/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: teleport-plugin-jira
spec:
  selector:
    app.kubernetes.io/name: teleport-plugin-jira
    app.kubernetes.io/instance: teleport-plugin-jira
  type: LoadBalancer
  ports:
  - name: https
    port: 443
    targetPort: 8443

$ helm template teleport-plugin-jira . --set serviceType=ClusterIP
# Source: teleport-plugin-jira/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: teleport-plugin-jira
spec:
  selector:
    app.kubernetes.io/name: teleport-plugin-jira
    app.kubernetes.io/instance: teleport-plugin-jira
  type: ClusterIP
  ports:
  - name: https
    port: 443
    targetPort: 8443
```

There are some unit tests failing but it doesn't look connected with my PR:
```
helm unittest ./charts/access/jira

### Chart [ teleport-plugin-jira ] ./charts/access/jira

 PASS  Test configmap   charts/access/jira/tests/configmap_test.yaml
 FAIL  Test deployment  charts/access/jira/tests/deployment_test.yaml
        - should match the snapshot

                - asserts[0] `matchSnapshot` fail
                        Template:       teleport-plugin-jira/templates/deployment.yaml
                        DocumentIndex:  0
                        Path:
                        Expected to match snapshot 1:
                                --- Expected
                                +++ Actual
                                @@ -23,50 +23,50 @@
                                       containers:
                                -      - command:
                                -        - /usr/local/bin/teleport-plugin
                                -        - start
                                -        - --config
                                -        - /etc/teleport-jira.toml
                                -        image: gcr.io/overridden/repository:v98.76.54
                                -        imagePullPolicy: IfNotPresent
                                -        name: teleport-plugin-jira
                                -        ports:
                                -        - containerPort: 8443
                                -          name: http
                                -          protocol: TCP
                                -        resources: {}
                                -        securityContext: {}
                                -        volumeMounts:
                                -        - mountPath: /etc/teleport-jira.toml
                                -          name: config
                                -          subPath: teleport-jira.toml
                                -        - mountPath: /var/lib/teleport/plugins/jira/auth_id
                                -          name: auth-id
                                -          subPath: auth_id
                                -        - mountPath: /var/lib/teleport/plugins/jira/jira_api_token
                                -          name: password-file
                                -          subPath: jiraApiToken
                                -        - mountPath: /var/lib/teleport/plugins/jira/tls/tls.key
                                -          name: tls
                                -          subPath: server.key
                                -        - mountPath: /var/lib/teleport/plugins/jira/tls/tls.crt
                                -          name: tls
                                -          subPath: server.crt
                                +        - command:
                                +            - /usr/local/bin/teleport-plugin
                                +            - start
                                +            - --config
                                +            - /etc/teleport-jira.toml
                                +          image: gcr.io/overridden/repository:v98.76.54
                                +          imagePullPolicy: IfNotPresent
                                +          name: teleport-plugin-jira
                                +          ports:
                                +            - containerPort: 8443
                                +              name: http
                                +              protocol: TCP
                                +          resources: {}
                                +          securityContext: {}
                                +          volumeMounts:
                                +            - mountPath: /etc/teleport-jira.toml
                                +              name: config
                                +              subPath: teleport-jira.toml
                                +            - mountPath: /var/lib/teleport/plugins/jira/auth_id
                                +              name: auth-id
                                +              subPath: auth_id
                                +            - mountPath: /var/lib/teleport/plugins/jira/jira_api_token
                                +              name: password-file
                                +              subPath: jiraApiToken
                                +            - mountPath: /var/lib/teleport/plugins/jira/tls/tls.key
                                +              name: tls
                                +              subPath: server.key
                                +            - mountPath: /var/lib/teleport/plugins/jira/tls/tls.crt
                                +              name: tls
                                +              subPath: server.crt
                                       securityContext: {}
                                       volumes:
                                -      - configMap:
                                -          defaultMode: 384
                                -          name: RELEASE-NAME-teleport-plugin-jira
                                -        name: config
                                -      - name: auth-id
                                -        secret:
                                -          defaultMode: 384
                                -          secretName: ""
                                -      - name: password-file
                                -        secret:
                                -          defaultMode: 384
                                -          secretName: RELEASE-NAME-teleport-plugin-jira-secret
                                -      - name: tls
                                -        secret:
                                -          defaultMode: 384
                                -          secretName: jira-tls-secret
                                +        - configMap:
                                +            defaultMode: 384
                                +            name: RELEASE-NAME-teleport-plugin-jira
                                +          name: config
                                +        - name: auth-id
                                +          secret:
                                +            defaultMode: 384
                                +            secretName: ""
                                +        - name: password-file
                                +          secret:
                                +            defaultMode: 384
                                +            secretName: RELEASE-NAME-teleport-plugin-jira-secret
                                +        - name: tls
                                +          secret:
                                +            defaultMode: 384
                                +            secretName: jira-tls-secret

 PASS  Test secret      charts/access/jira/tests/secret_test.yaml
 FAIL  Test service     charts/access/jira/tests/service_test.yaml
        - should be possible to add custom annotations

                - asserts[0] `matchSnapshot` fail
                        Template:       teleport-plugin-jira/templates/service.yaml
                        DocumentIndex:  0
                        Path:
                        Expected to match snapshot 1:
                                --- Expected
                                +++ Actual
                                @@ -8,5 +8,5 @@
                                   ports:
                                -  - name: https
                                -    port: 443
                                -    targetPort: 8443
                                +    - name: https
                                +      port: 443
                                +      targetPort: 8443
                                   selector:


Snapshot Summary: 2 snapshot failed in 2 test suite. Check changes and use `-u` to update snapshot.

Charts:      1 failed, 0 passed, 1 total
Test Suites: 2 failed, 2 passed, 4 total
Tests:       2 failed, 5 passed, 7 total
Snapshot:    2 failed, 2 passed, 4 total
Time:        18.363417ms
```