### PR TITLE
Align helm unittest versions + buddy-765

### DIFF
--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Setup helm-unittest
         run: |
-            helm plugin install --version=v1.0.16 https://github.com/vbehar/helm3-unittest
+            helm plugin install --version=v0.2.11 https://github.com/quintush/helm-unittest
             helm plugin list
 
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ fix-imports: $(GCI)
 
 .PHONY: test-helm-%
 test-helm-%:
-	helm unittest ./charts/$(subst access-,access/,$*)
+	helm unittest -3 ./charts/$(subst access-,access/,$*)
 
 .PHONY: test-helm
 test-helm:

--- a/charts/access/jira/templates/service.yaml
+++ b/charts/access/jira/templates/service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     {{- include "jira.selectorLabels" . | nindent 4 }}
-  type: LoadBalancer
+  type: {{ .Values.serviceType }}
   ports:
   - name: https
     port: 443

--- a/charts/access/jira/tests/service_test.yaml
+++ b/charts/access/jira/tests/service_test.yaml
@@ -19,3 +19,12 @@ tests:
             service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
             service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
             service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+  - it: should be possible to change service type
+    set:
+      serviceType: "ClusterIP"
+    asserts:
+      - equal:
+          path: spec.type
+          value:
+            ClusterIP

--- a/charts/access/jira/values.schema.json
+++ b/charts/access/jira/values.schema.json
@@ -10,6 +10,7 @@
         "podAnnotations",
         "podSecurityContext",
         "securityContext",
+        "serviceType",
         "nodeSelector",
         "tolerations",
         "affinity",
@@ -131,6 +132,11 @@
                 }
             },
             "additionalProperties": true
+        },
+        "serviceType": {
+            "$id": "#/properties/serviceType",
+            "type": "string",
+            "default": "LoadBalancer"
         },
         "resources": {
             "$id": "#/properties/resources",

--- a/charts/access/jira/values.yaml
+++ b/charts/access/jira/values.yaml
@@ -66,3 +66,5 @@ tolerations: []
 affinity: {}
 
 serviceAnnotations: {}
+
+serviceType: LoadBalancer


### PR DESCRIPTION
This PR contains two changes:
- align helm-unittest plugin version with what we are using for charts in the `teleport` repo
- Buddy PR for https://github.com/gravitational/teleport-plugins/pull/765/files