### PR TITLE
CodeQL: Switch from `make` to auto build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,27 +29,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: 'go.mod'
-      if: ${{ matrix.language == 'go' }}
-
     - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+      timeout-minutes: 5
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-      if: ${{ matrix.language != 'go' }}
-
-    - name: Build all Go plugins
-      run: |
-        make build-all
-      if: ${{ matrix.language == 'go' }}
+      timeout-minutes: 30
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
+      timeout-minutes: 10


### PR DESCRIPTION
In `teleport` we saw a significant speed increase in using the autobuild.  In testing in this repo we see the build time cut in half (4min reduction), while still scanning just as much code (actually slightly more).  So it appears that this change makes sense for this repo too.

PR proposed as part of this issue: https://github.com/gravitational/SecOps/issues/269