### PR TITLE
Warn users when an unsupported event is received by `event-handler`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ $(GCI):
 
 .PHONY: fix-imports
 fix-imports: $(GCI)
-	$(GCI) write -s 'standard,default,prefix(github.com/gravitational/teleport-plugins)' --skip-generated .
+	$(GCI) write -s standard -s default -s 'prefix(github.com/gravitational/teleport-plugins)' --skip-generated .
 
 .PHONY: test-helm-%
 test-helm-%:

--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -133,23 +133,23 @@ func (t *TeleportEventsWatcher) flipPage() bool {
 func (t *TeleportEventsWatcher) fetch(ctx context.Context) error {
 	log := logger.Get(ctx)
 	b, nextCursor, err := t.getEvents(ctx)
-	// When a trace.BadParameter error is returned, it means that the teleport-plugins
+	// When a trace.BadParameter error is returned, it means that the Teleport event handler
 	// protobuf version is incompatible with the Teleport Auth protobuf version.
-	// This is a fatal error and the plugin should exit because it won't be able to parse the
+	// This is a fatal error and the event handler should exit because it won't be able to parse the
 	// event that is supported by the newer version of Teleport Auth but not by the
-	// older version of teleport-plugins.
-	// teleport-plugins compatibility is strictly tied to the Teleport Auth version
-	// and the plugin should be updated to the latest version when the Teleport Auth
-	// version is updated. plugins breaks our compatibility promise of supporting
-	// clients 1 major version behind Auth. We don't support older versions of teleport-plugins
+	// older version of Teleport event handler.
+	// Teleport event handler compatibility is strictly tied to the Teleport Auth version
+	// and it should be updated to the latest version when the Teleport Auth
+	// version is updated. Event handler breaks our compatibility promise of supporting
+	// clients 1 major version behind Auth. We don't support older versions of event handler
 	// with newer versions of Teleport Auth even if they are in the same major version
-	// because we can not guarantee that the plugin will be able to parse the events
+	// because we can not guarantee that the handler will be able to parse the events
 	// introduced between minor or patch versions of Teleport Auth.
 	// This is a temporary solution until we have a better way to handle this.
 	if trace.IsBadParameter(err) {
 		return trace.BadParameter(
-			"teleport-plugins version is incompatible with the Teleport Auth version. " +
-				"Please update teleport-plugins to the same version as the Teleport Auth server to resume operations. \n" +
+			"Teleport event handler version is incompatible with the Teleport Auth version. " +
+				"Please update Teleport event handler to the same version as the Teleport Auth server to resume operations. \n" +
 				authServerVersionMessage(ctx, t.client),
 		)
 	} else if err != nil {
@@ -352,5 +352,5 @@ func authServerVersionMessage(ctx context.Context, client TeleportSearchEventsCl
 		log.WithError(err).Warn("unable to get auth server version")
 		return ""
 	}
-	return fmt.Sprintf("Auth server version %v; teleport-plugins version %v", rsp.ServerVersion, Version)
+	return fmt.Sprintf("Auth server version %v; Teleport event handler version %v", rsp.ServerVersion, Version)
 }

--- a/event-handler/teleport_events_watcher_test.go
+++ b/event-handler/teleport_events_watcher_test.go
@@ -19,7 +19,7 @@ package main
 import (
 	"testing"
 	"time"
-	
+
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"

--- a/event-handler/teleport_events_watcher_test.go
+++ b/event-handler/teleport_events_watcher_test.go
@@ -19,7 +19,8 @@ package main
 import (
 	"testing"
 	"time"
-
+	
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/trace"
@@ -48,6 +49,12 @@ func (c *mockTeleportEventWatcher) StreamSessionEvents(ctx context.Context, sess
 // UsertLock is mock UpsertLock method
 func (c *mockTeleportEventWatcher) UpsertLock(ctx context.Context, lock types.Lock) error {
 	return nil
+}
+
+func (c *mockTeleportEventWatcher) Ping(ctx context.Context) (proto.PingResponse, error) {
+	return proto.PingResponse{
+		ServerVersion: Version,
+	}, nil
 }
 
 // Close is mock close method
@@ -115,65 +122,66 @@ func TestValidateConfig(t *testing.T) {
 		name      string
 		cfg       StartCmdConfig
 		wantError bool
-	}{{
-		name: "Identity file configured",
-		cfg: StartCmdConfig{
-			FluentdConfig{},
-			TeleportConfig{
-				TeleportIdentityFile: "not_empty_string",
+	}{
+		{
+			name: "Identity file configured",
+			cfg: StartCmdConfig{
+				FluentdConfig{},
+				TeleportConfig{
+					TeleportIdentityFile: "not_empty_string",
+				},
+				IngestConfig{},
+				LockConfig{},
 			},
-			IngestConfig{},
-			LockConfig{},
-		},
-		wantError: false,
-	}, {
-		name: "Cert, key, ca files configured",
-		cfg: StartCmdConfig{
-			FluentdConfig{},
-			TeleportConfig{
-				TeleportCA:   "not_empty_string",
-				TeleportCert: "not_empty_string",
-				TeleportKey:  "not_empty_string",
+			wantError: false,
+		}, {
+			name: "Cert, key, ca files configured",
+			cfg: StartCmdConfig{
+				FluentdConfig{},
+				TeleportConfig{
+					TeleportCA:   "not_empty_string",
+					TeleportCert: "not_empty_string",
+					TeleportKey:  "not_empty_string",
+				},
+				IngestConfig{},
+				LockConfig{},
 			},
-			IngestConfig{},
-			LockConfig{},
-		},
-		wantError: false,
-	}, {
-		name: "Identity and teleport cert/ca/key files configured",
-		cfg: StartCmdConfig{
-			FluentdConfig{},
-			TeleportConfig{
-				TeleportIdentityFile: "not_empty_string",
-				TeleportCA:           "not_empty_string",
-				TeleportCert:         "not_empty_string",
-				TeleportKey:          "not_empty_string",
+			wantError: false,
+		}, {
+			name: "Identity and teleport cert/ca/key files configured",
+			cfg: StartCmdConfig{
+				FluentdConfig{},
+				TeleportConfig{
+					TeleportIdentityFile: "not_empty_string",
+					TeleportCA:           "not_empty_string",
+					TeleportCert:         "not_empty_string",
+					TeleportKey:          "not_empty_string",
+				},
+				IngestConfig{},
+				LockConfig{},
 			},
-			IngestConfig{},
-			LockConfig{},
-		},
-		wantError: true,
-	}, {
-		name: "None set",
-		cfg: StartCmdConfig{
-			FluentdConfig{},
-			TeleportConfig{},
-			IngestConfig{},
-			LockConfig{},
-		},
-		wantError: true,
-	}, {
-		name: "Some of teleport cert/key/ca unset",
-		cfg: StartCmdConfig{
-			FluentdConfig{},
-			TeleportConfig{
-				TeleportCA: "not_empty_string",
+			wantError: true,
+		}, {
+			name: "None set",
+			cfg: StartCmdConfig{
+				FluentdConfig{},
+				TeleportConfig{},
+				IngestConfig{},
+				LockConfig{},
 			},
-			IngestConfig{},
-			LockConfig{},
+			wantError: true,
+		}, {
+			name: "Some of teleport cert/key/ca unset",
+			cfg: StartCmdConfig{
+				FluentdConfig{},
+				TeleportConfig{
+					TeleportCA: "not_empty_string",
+				},
+				IngestConfig{},
+				LockConfig{},
+			},
+			wantError: true,
 		},
-		wantError: true,
-	},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cfg.Validate()


### PR DESCRIPTION
When a trace.BadParameter error is returned from SearchEvents, which means that the teleport-plugins protobuf version is incompatible with the Teleport Auth protobuf version. This is a fatal error and the plugin should exit because it won't be able to parse the event that is supported by the newer version of Teleport Auth but not by the older version of teleport-plugins.
teleport-plugins compatibility is strictly tied to the Teleport Auth version and the plugin should be updated to the latest version when the Teleport Auth version is updated. plugins break our compatibility promise of supporting clients 1 major version behind Auth. We don't support older versions of teleport-plugins with newer versions of Teleport Auth even if they are in the same major version because we can not guarantee that the plugin will be able to parse the events introduced between minor or patch versions of Teleport Auth. This is a temporary solution until we have a better way to handle this.

Fixes #783