### PR TITLE
Bump Teleport reference to v12.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/gravitational/kingpin v2.1.11-0.20220901134012-2a1956e29525+incompatible
-	github.com/gravitational/teleport v0.0.0-20230329091501-300bc0bb5ba8 // ref: heads/branch/v12, TODO: set to v12.1.2 when it's out
+	github.com/gravitational/teleport v0.0.0-20230401004908-54e910b0192e // ref: tags/v12.1.5
 	github.com/gravitational/teleport/api v0.0.0 // replaced
 	github.com/gravitational/trace v1.2.1
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
@@ -129,6 +129,6 @@ require (
 
 replace (
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
-	github.com/gravitational/teleport/api => github.com/gravitational/teleport/api v0.0.0-20230329091501-300bc0bb5ba8 // ref: heads/branch/v12, TODO: set to v12.1.2 when it's out
+	github.com/gravitational/teleport/api => github.com/gravitational/teleport/api v0.0.0-20230401004908-54e910b0192e // ref: tags/v12.1.5
 	github.com/julienschmidt/httprouter => github.com/rw-access/httprouter v1.3.1-0.20210321233808-98e93175c124
 )

--- a/go.sum
+++ b/go.sum
@@ -266,10 +266,10 @@ github.com/gravitational/kingpin v2.1.11-0.20220901134012-2a1956e29525+incompati
 github.com/gravitational/kingpin v2.1.11-0.20220901134012-2a1956e29525+incompatible/go.mod h1:LWxG30M3FcrjhOn3T4zz7JmBoQJ45MWZmOXgy9Ganoc=
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf h1:MQ4e8XcxvZTeuOmRl7yE519vcWc2h/lyvYzsvt41cdY=
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gravitational/teleport v0.0.0-20230329091501-300bc0bb5ba8 h1:LtbI1PY+XSVVTpIJ4WIE+g6HH9blohzFRUb+vcgrMJY=
-github.com/gravitational/teleport v0.0.0-20230329091501-300bc0bb5ba8/go.mod h1:yZjUeFt5j7ZG3JoUpKuCFnOY6WPcsq+t2hlEuVgaxLA=
-github.com/gravitational/teleport/api v0.0.0-20230329091501-300bc0bb5ba8 h1:7MgFrtdVy2c7lN1013C6+wrbZDg/YBpKGiJB1z6PZBk=
-github.com/gravitational/teleport/api v0.0.0-20230329091501-300bc0bb5ba8/go.mod h1:T/zz2cKNBC22GvChCGtTJk7BbYdjK8CRlfwLaZrHOT0=
+github.com/gravitational/teleport v0.0.0-20230401004908-54e910b0192e h1:3E2z42qKCgCLnM6p8gz0/YIvYsjJswXWjTRvZjHwgbo=
+github.com/gravitational/teleport v0.0.0-20230401004908-54e910b0192e/go.mod h1:yZjUeFt5j7ZG3JoUpKuCFnOY6WPcsq+t2hlEuVgaxLA=
+github.com/gravitational/teleport/api v0.0.0-20230401004908-54e910b0192e h1:6MLOxH8ze/gw1VXEisWh7T92PlmVPpA3Pcr44mmRwA4=
+github.com/gravitational/teleport/api v0.0.0-20230401004908-54e910b0192e/go.mod h1:T/zz2cKNBC22GvChCGtTJk7BbYdjK8CRlfwLaZrHOT0=
 github.com/gravitational/trace v1.2.1 h1:Iaf43aqbKV5H8bdiRs1qByjEHgAfADJ0lt0JwRyu+q8=
 github.com/gravitational/trace v1.2.1/go.mod h1:n0ijrq6psJY0sOI/NzLp+xdd8xl79jjwzVOFHDY6+kQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=


### PR DESCRIPTION
Automatic update via:

```console
$ make update-teleport-dep-version TELEPORT_DEP_VERSION=v12.1.5
```