### PR TITLE
Apt install add `--no-install-recommends`

### DIFF
--- a/docker/plugins/Dockerfile
+++ b/docker/plugins/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update
 ENV DEBUG=1 GOPATH=/root/go PATH=$PATH:/root/go/src/github.com/gravitational/teleport/build:/root/go/src/github.com/gravitational/teleport-plugins/access/slack/build:/root/go/bin
 
 # htop is useful for testing terminal resizing
-RUN apt-get update; apt-get install -y htop vim screen;
+RUN apt-get update; apt-get install --no-install-recommends -y htop vim screen;
 
 # allows ansible and ssh testing
-RUN apt-get install -y ansible ssh inetutils-syslogd
+RUN apt-get install --no-install-recommends -y ansible ssh inetutils-syslogd
 
 RUN mkdir /run/sshd
 

--- a/event-handler/build.assets/Dockerfile
+++ b/event-handler/build.assets/Dockerfile
@@ -5,7 +5,7 @@ ARG UID
 ARG GID
 ARG ARCH
 
-RUN set -ex && apt-get -q -y update --fix-missing && apt-get -q -y install unzip dumb-init libc6
+RUN set -ex && apt-get -q -y update --fix-missing && apt-get -q -y --no-install-recommends install unzip dumb-init libc6
 
 RUN set -ex && \
     getent group  $GID || groupadd builder --gid=$GID -o; \


### PR DESCRIPTION
This flag is designed to help make sure our images are minimized. Addresses the following code scanning alerts:
* https://github.com/gravitational/teleport-plugins/security/code-scanning/9
* https://github.com/gravitational/teleport-plugins/security/code-scanning/8
* https://github.com/gravitational/teleport-plugins/security/code-scanning/7