### PR TITLE
TF: use Teleport Token.ID as TF Token's ID instead of name

### DIFF
--- a/terraform/_gen/main.go
+++ b/terraform/_gen/main.go
@@ -73,6 +73,8 @@ type payload struct {
 	// IsPlainStruct states whether the resource type used by the API methods
 	// for this resource is a plain struct, rather than an interface.
 	IsPlainStruct bool
+	// ExtraImports contains a list of imports that are being used.
+	ExtraImports []string
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -202,10 +204,11 @@ var (
 		CreateMethod:       "UpsertToken",
 		UpdateMethod:       "UpsertToken",
 		DeleteMethod:       "DeleteToken",
-		ID:                 "provisionToken.Metadata.Name",
+		ID:                 "strconv.FormatInt(provisionToken.Metadata.ID, 10)", // must be a string
 		RandomMetadataName: true,
 		Kind:               "token",
 		HasStaticID:        false,
+		ExtraImports:       []string{"strconv"},
 	}
 
 	role = payload{
@@ -298,7 +301,6 @@ func main() {
 	generate(oidcConnector, pluralDataSource, "provider/data_source_teleport_oidc_connector.go")
 	generate(samlConnector, pluralResource, "provider/resource_teleport_saml_connector.go")
 	generate(samlConnector, pluralDataSource, "provider/data_source_teleport_saml_connector.go")
-	// Provision Token code is an exception because it requires custom id generation TODO: generalize
 	generate(provisionToken, pluralResource, "provider/resource_teleport_provision_token.go")
 	generate(provisionToken, pluralDataSource, "provider/data_source_teleport_provision_token.go")
 	generate(role, pluralResource, "provider/resource_teleport_role.go")

--- a/terraform/_gen/plural_resource.go.tpl
+++ b/terraform/_gen/plural_resource.go.tpl
@@ -24,6 +24,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 {{- end}}
+{{- range $i, $a := .ExtraImports}}
+	"{{$a}}"
+{{- end}}
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"

--- a/terraform/provider/resource_teleport_provision_token.go
+++ b/terraform/provider/resource_teleport_provision_token.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"crypto/rand"
 	"encoding/hex"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -153,7 +154,7 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	plan.Attrs["id"] = types.String{Value: provisionToken.Metadata.Name}
+	plan.Attrs["id"] = types.String{Value: strconv.FormatInt(provisionToken.Metadata.ID, 10)}
 
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)

--- a/terraform/test/fixtures/provision_token_secret_0_create.tf
+++ b/terraform/test/fixtures/provision_token_secret_0_create.tf
@@ -1,0 +1,12 @@
+resource "teleport_provision_token" "test" {
+  metadata = {
+    name    = "thisisasecretandmustnotbelogged"
+    expires = "2038-01-01T00:00:00Z"
+    labels = {
+      example = "yes"
+    }
+  }
+  spec = {
+    roles = ["Node", "Auth"]
+  }
+}


### PR DESCRIPTION
We were using the token name as its ID.
So, running the following command would show the token secret:
```
$ terraform state show teleport_provision_token.example
...
id = "tokensecret"
...
name = (sensitive value)
...
```

This PR changes the ID to be the Teleport's Resource ID. This way, when running the same command as above we'll get something like this:
```
id = 1683217963807545240
```

Demo:
```
~/p/terraform-token > terraform apply
...
teleport_provision_token.example: Creating...
teleport_provision_token.example: Creation complete after 0s [id=56pgQjlambn0BpmsCfDg70DNZixM9TO0]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

~/p/terraform-token > terraform state show teleport_provision_token.example
resource "teleport_provision_token" "example" {
    id       = "56pgQjlambn0BpmsCfDg70DNZixM9TO0"
    ...
}

~/p/terraform-token > terraform plan # no change
teleport_provision_token.example: Refreshing state... [id=56pgQjlambn0BpmsCfDg70DNZixM9TO0]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

~/p/terraform-token > terraform apply
teleport_provision_token.example: Refreshing state... [id=56pgQjlambn0BpmsCfDg70DNZixM9TO0]
...
teleport_provision_token.example2: Creating...
teleport_provision_token.example2: Creation complete after 0s [id=1683217963807545240]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

~/p/terraform-token > terraform state show teleport_provision_token.example
resource "teleport_provision_token" "example" {
    id       = "56pgQjlambn0BpmsCfDg70DNZixM9TO0"
    kind     = "token"
    metadata = {
        expires   = "2023-06-03T16:25:56Z"
        labels    = {
            "example" = "yes"
        }
        name      = (sensitive value)
        namespace = "default"
    }
    ...
    version  = "v2"
}

~/p/terraform-token > terraform state show teleport_provision_token.example2
resource "teleport_provision_token" "example2" {
    id       = "1683217963807545240"
    kind     = "token"
    metadata = {
        ...
        name      = (sensitive value)
    }
    version  = "v2"
}
```

We can't however use this method to import a token into terraform. Teleport's API only gives us a Token's Get method using its name/secret as input. We can't fetch tokens by their Resource's ID.

Only new resources will hide their token.
Current Terraform resources will keep showing the token.

Fixes: https://github.com/gravitational/teleport-plugins/issues/372