### PR TITLE
tf-provider: fix already exists error message

### DIFF
--- a/terraform/_gen/main.go
+++ b/terraform/_gen/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -75,6 +76,10 @@ type payload struct {
 	IsPlainStruct bool
 	// ExtraImports contains a list of imports that are being used.
 	ExtraImports []string
+	// TerraformResourceType represents the resource type in Terraform code.
+	// e.g. `terraform import <resource_type>.<resource_name> identifier`.
+	// This is also used to name the generated files.
+	TerraformResourceType string
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -94,225 +99,249 @@ func (p *payload) CheckAndSetDefaults() error {
 }
 
 const (
-	pluralResource     = "plural_resource.go.tpl"
-	pluralDataSource   = "plural_data_source.go.tpl"
-	singularResource   = "singular_resource.go.tpl"
-	singularDataSource = "singular_data_source.go.tpl"
+	pluralResource          = "plural_resource.go.tpl"
+	pluralDataSource        = "plural_data_source.go.tpl"
+	singularResource        = "singular_resource.go.tpl"
+	singularDataSource      = "singular_data_source.go.tpl"
+	outFileResourceFormat   = "provider/resource_%s.go"
+	outFileDataSourceFormat = "provider/data_source_%s.go"
 )
 
 var (
 	app = payload{
-		Name:         "App",
-		TypeName:     "AppV3",
-		VarName:      "app",
-		IfaceName:    "Application",
-		GetMethod:    "GetApp",
-		CreateMethod: "CreateApp",
-		UpdateMethod: "UpdateApp",
-		DeleteMethod: "DeleteApp",
-		ID:           `app.Metadata.Name`,
-		Kind:         "app",
-		HasStaticID:  false,
+		Name:                  "App",
+		TypeName:              "AppV3",
+		VarName:               "app",
+		IfaceName:             "Application",
+		GetMethod:             "GetApp",
+		CreateMethod:          "CreateApp",
+		UpdateMethod:          "UpdateApp",
+		DeleteMethod:          "DeleteApp",
+		ID:                    `app.Metadata.Name`,
+		Kind:                  "app",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_app",
 	}
 
 	authPreference = payload{
-		Name:         "AuthPreference",
-		TypeName:     "AuthPreferenceV2",
-		VarName:      "authPreference",
-		GetMethod:    "GetAuthPreference",
-		CreateMethod: "SetAuthPreference",
-		UpdateMethod: "SetAuthPreference",
-		DeleteMethod: "ResetAuthPreference",
-		ID:           `"auth_preference"`,
-		Kind:         "cluster_auth_preference",
-		HasStaticID:  false,
+		Name:                  "AuthPreference",
+		TypeName:              "AuthPreferenceV2",
+		VarName:               "authPreference",
+		GetMethod:             "GetAuthPreference",
+		CreateMethod:          "SetAuthPreference",
+		UpdateMethod:          "SetAuthPreference",
+		DeleteMethod:          "ResetAuthPreference",
+		ID:                    `"auth_preference"`,
+		Kind:                  "cluster_auth_preference",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_auth_preference",
 	}
 
 	clusterNetworking = payload{
-		Name:         "ClusterNetworkingConfig",
-		TypeName:     "ClusterNetworkingConfigV2",
-		VarName:      "clusterNetworkingConfig",
-		GetMethod:    "GetClusterNetworkingConfig",
-		CreateMethod: "SetClusterNetworkingConfig",
-		UpdateMethod: "SetClusterNetworkingConfig",
-		DeleteMethod: "ResetClusterNetworkingConfig",
-		ID:           `"cluster_networking_config"`,
-		Kind:         "cluster_networking_config",
-		HasStaticID:  false,
+		Name:                  "ClusterNetworkingConfig",
+		TypeName:              "ClusterNetworkingConfigV2",
+		VarName:               "clusterNetworkingConfig",
+		GetMethod:             "GetClusterNetworkingConfig",
+		CreateMethod:          "SetClusterNetworkingConfig",
+		UpdateMethod:          "SetClusterNetworkingConfig",
+		DeleteMethod:          "ResetClusterNetworkingConfig",
+		ID:                    `"cluster_networking_config"`,
+		Kind:                  "cluster_networking_config",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_cluster_networking_config",
 	}
 
 	database = payload{
-		Name:         "Database",
-		TypeName:     "DatabaseV3",
-		VarName:      "database",
-		GetMethod:    "GetDatabase",
-		CreateMethod: "CreateDatabase",
-		UpdateMethod: "UpdateDatabase",
-		DeleteMethod: "DeleteDatabase",
-		ID:           `database.Metadata.Name`,
-		Kind:         "db",
-		HasStaticID:  false,
+		Name:                  "Database",
+		TypeName:              "DatabaseV3",
+		VarName:               "database",
+		GetMethod:             "GetDatabase",
+		CreateMethod:          "CreateDatabase",
+		UpdateMethod:          "UpdateDatabase",
+		DeleteMethod:          "DeleteDatabase",
+		ID:                    `database.Metadata.Name`,
+		Kind:                  "db",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_database",
 	}
 
 	githubConnector = payload{
-		Name:         "GithubConnector",
-		TypeName:     "GithubConnectorV3",
-		VarName:      "githubConnector",
-		GetMethod:    "GetGithubConnector",
-		CreateMethod: "UpsertGithubConnector",
-		UpdateMethod: "UpsertGithubConnector",
-		DeleteMethod: "DeleteGithubConnector",
-		WithSecrets:  "true",
-		ID:           "githubConnector.Metadata.Name",
-		Kind:         "github",
-		HasStaticID:  true,
+		Name:                  "GithubConnector",
+		TypeName:              "GithubConnectorV3",
+		VarName:               "githubConnector",
+		GetMethod:             "GetGithubConnector",
+		CreateMethod:          "UpsertGithubConnector",
+		UpdateMethod:          "UpsertGithubConnector",
+		DeleteMethod:          "DeleteGithubConnector",
+		WithSecrets:           "true",
+		ID:                    "githubConnector.Metadata.Name",
+		Kind:                  "github",
+		HasStaticID:           true,
+		TerraformResourceType: "teleport_github_connector",
 	}
 
 	oidcConnector = payload{
-		Name:         "OIDCConnector",
-		TypeName:     "OIDCConnectorV3",
-		VarName:      "oidcConnector",
-		GetMethod:    "GetOIDCConnector",
-		CreateMethod: "UpsertOIDCConnector",
-		UpdateMethod: "UpsertOIDCConnector",
-		DeleteMethod: "DeleteOIDCConnector",
-		WithSecrets:  "true",
-		ID:           "oidcConnector.Metadata.Name",
-		Kind:         "oidc",
-		HasStaticID:  true,
+		Name:                  "OIDCConnector",
+		TypeName:              "OIDCConnectorV3",
+		VarName:               "oidcConnector",
+		GetMethod:             "GetOIDCConnector",
+		CreateMethod:          "UpsertOIDCConnector",
+		UpdateMethod:          "UpsertOIDCConnector",
+		DeleteMethod:          "DeleteOIDCConnector",
+		WithSecrets:           "true",
+		ID:                    "oidcConnector.Metadata.Name",
+		Kind:                  "oidc",
+		HasStaticID:           true,
+		TerraformResourceType: "teleport_oidc_connector",
 	}
 
 	samlConnector = payload{
-		Name:         "SAMLConnector",
-		TypeName:     "SAMLConnectorV2",
-		VarName:      "samlConnector",
-		GetMethod:    "GetSAMLConnector",
-		CreateMethod: "UpsertSAMLConnector",
-		UpdateMethod: "UpsertSAMLConnector",
-		DeleteMethod: "DeleteSAMLConnector",
-		WithSecrets:  "true",
-		ID:           "samlConnector.Metadata.Name",
-		Kind:         "saml",
-		HasStaticID:  true,
+		Name:                  "SAMLConnector",
+		TypeName:              "SAMLConnectorV2",
+		VarName:               "samlConnector",
+		GetMethod:             "GetSAMLConnector",
+		CreateMethod:          "UpsertSAMLConnector",
+		UpdateMethod:          "UpsertSAMLConnector",
+		DeleteMethod:          "DeleteSAMLConnector",
+		WithSecrets:           "true",
+		ID:                    "samlConnector.Metadata.Name",
+		Kind:                  "saml",
+		HasStaticID:           true,
+		TerraformResourceType: "teleport_saml_connector",
 	}
 
 	provisionToken = payload{
-		Name:               "ProvisionToken",
-		TypeName:           "ProvisionTokenV2",
-		VarName:            "provisionToken",
-		GetMethod:          "GetToken",
-		CreateMethod:       "UpsertToken",
-		UpdateMethod:       "UpsertToken",
-		DeleteMethod:       "DeleteToken",
-		ID:                 "strconv.FormatInt(provisionToken.Metadata.ID, 10)", // must be a string
-		RandomMetadataName: true,
-		Kind:               "token",
-		HasStaticID:        false,
-		ExtraImports:       []string{"strconv"},
+		Name:                   "ProvisionToken",
+		TypeName:               "ProvisionTokenV2",
+		VarName:                "provisionToken",
+		GetMethod:              "GetToken",
+		CreateMethod:           "UpsertToken",
+		UpdateMethod:           "UpsertToken",
+		DeleteMethod:           "DeleteToken",
+		ID:                     "strconv.FormatInt(provisionToken.Metadata.ID, 10)", // must be a string
+		RandomMetadataName:     true,
+		Kind:                   "token",
+		HasStaticID:            false,
+		ExtraImports:           []string{"strconv"},
+		TerraformResourceType: "teleport_provision_token",
 	}
 
 	role = payload{
-		Name:         "Role",
-		TypeName:     "RoleV6",
-		VarName:      "role",
-		GetMethod:    "GetRole",
-		CreateMethod: "UpsertRole",
-		UpdateMethod: "UpsertRole",
-		DeleteMethod: "DeleteRole",
-		ID:           "role.Metadata.Name",
-		Kind:         "role",
-		HasStaticID:  false,
+		Name:                  "Role",
+		TypeName:              "RoleV6",
+		VarName:               "role",
+		GetMethod:             "GetRole",
+		CreateMethod:          "UpsertRole",
+		UpdateMethod:          "UpsertRole",
+		DeleteMethod:          "DeleteRole",
+		ID:                    "role.Metadata.Name",
+		Kind:                  "role",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_role",
 	}
 
 	sessionRecording = payload{
-		Name:         "SessionRecordingConfig",
-		TypeName:     "SessionRecordingConfigV2",
-		VarName:      "sessionRecordingConfig",
-		GetMethod:    "GetSessionRecordingConfig",
-		CreateMethod: "SetSessionRecordingConfig",
-		UpdateMethod: "SetSessionRecordingConfig",
-		DeleteMethod: "ResetSessionRecordingConfig",
-		ID:           `"session_recording_config"`,
-		Kind:         "session_recording_config",
-		HasStaticID:  false,
+		Name:                  "SessionRecordingConfig",
+		TypeName:              "SessionRecordingConfigV2",
+		VarName:               "sessionRecordingConfig",
+		GetMethod:             "GetSessionRecordingConfig",
+		CreateMethod:          "SetSessionRecordingConfig",
+		UpdateMethod:          "SetSessionRecordingConfig",
+		DeleteMethod:          "ResetSessionRecordingConfig",
+		ID:                    `"session_recording_config"`,
+		Kind:                  "session_recording_config",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_session_recording_config",
 	}
 
 	trustedCluster = payload{
-		Name:              "TrustedCluster",
-		TypeName:          "TrustedClusterV2",
-		VarName:           "trustedCluster",
-		GetMethod:         "GetTrustedCluster",
-		CreateMethod:      "UpsertTrustedCluster",
-		UpdateMethod:      "UpsertTrustedCluster",
-		DeleteMethod:      "DeleteTrustedCluster",
-		UpsertMethodArity: 2,
-		ID:                "trustedCluster.Metadata.Name",
-		Kind:              "trusted_cluster",
-		HasStaticID:       false,
+		Name:                  "TrustedCluster",
+		TypeName:              "TrustedClusterV2",
+		VarName:               "trustedCluster",
+		GetMethod:             "GetTrustedCluster",
+		CreateMethod:          "UpsertTrustedCluster",
+		UpdateMethod:          "UpsertTrustedCluster",
+		DeleteMethod:          "DeleteTrustedCluster",
+		UpsertMethodArity:     2,
+		ID:                    "trustedCluster.Metadata.Name",
+		Kind:                  "trusted_cluster",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_trusted_cluster",
 	}
 
 	user = payload{
-		Name:              "User",
-		TypeName:          "UserV2",
-		VarName:           "user",
-		GetMethod:         "GetUser",
-		CreateMethod:      "CreateUser",
-		UpdateMethod:      "UpdateUser",
-		DeleteMethod:      "DeleteUser",
-		WithSecrets:       "false",
-		GetWithoutContext: true,
-		ID:                "user.Metadata.Name",
-		Kind:              "user",
-		HasStaticID:       false,
+		Name:                  "User",
+		TypeName:              "UserV2",
+		VarName:               "user",
+		GetMethod:             "GetUser",
+		CreateMethod:          "CreateUser",
+		UpdateMethod:          "UpdateUser",
+		DeleteMethod:          "DeleteUser",
+		WithSecrets:           "false",
+		GetWithoutContext:     true,
+		ID:                    "user.Metadata.Name",
+		Kind:                  "user",
+		HasStaticID:           false,
+		TerraformResourceType: "teleport_user",
 	}
 
 	loginRule = payload{
-		Name:              "LoginRule",
-		TypeName:          "LoginRule",
-		VarName:           "loginRule",
-		GetMethod:         "GetLoginRule",
-		CreateMethod:      "UpsertLoginRule",
-		UpsertMethodArity: 2,
-		UpdateMethod:      "UpsertLoginRule",
-		DeleteMethod:      "DeleteLoginRule",
-		ID:                "loginRule.Metadata.Name",
-		Kind:              "login_rule",
-		HasStaticID:       false,
-		ProtoPackage:      "loginrulev1",
-		ProtoPackagePath:  "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1",
-		SchemaPackage:     "schemav1",
-		SchemaPackagePath: "github.com/gravitational/teleport-plugins/terraform/tfschema/loginrule/v1",
-		IsPlainStruct:     true,
+		Name:                  "LoginRule",
+		TypeName:              "LoginRule",
+		VarName:               "loginRule",
+		GetMethod:             "GetLoginRule",
+		CreateMethod:          "UpsertLoginRule",
+		UpsertMethodArity:     2,
+		UpdateMethod:          "UpsertLoginRule",
+		DeleteMethod:          "DeleteLoginRule",
+		ID:                    "loginRule.Metadata.Name",
+		Kind:                  "login_rule",
+		HasStaticID:           false,
+		ProtoPackage:          "loginrulev1",
+		ProtoPackagePath:      "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1",
+		SchemaPackage:         "schemav1",
+		SchemaPackagePath:     "github.com/gravitational/teleport-plugins/terraform/tfschema/loginrule/v1",
+		IsPlainStruct:         true,
+		TerraformResourceType: "teleport_login_rule",
 	}
 )
 
 func main() {
-	generate(app, pluralResource, "provider/resource_teleport_app.go")
-	generate(app, pluralDataSource, "provider/data_source_teleport_app.go")
-	generate(authPreference, singularResource, "provider/resource_teleport_auth_preference.go")
-	generate(authPreference, singularDataSource, "provider/data_source_teleport_auth_preference.go")
-	generate(clusterNetworking, singularResource, "provider/resource_teleport_cluster_networking_config.go")
-	generate(clusterNetworking, singularDataSource, "provider/data_source_teleport_cluster_networking_config.go")
-	generate(database, pluralResource, "provider/resource_teleport_database.go")
-	generate(database, pluralDataSource, "provider/data_source_teleport_database.go")
-	generate(githubConnector, pluralResource, "provider/resource_teleport_github_connector.go")
-	generate(githubConnector, pluralDataSource, "provider/data_source_teleport_github_connector.go")
-	generate(oidcConnector, pluralResource, "provider/resource_teleport_oidc_connector.go")
-	generate(oidcConnector, pluralDataSource, "provider/data_source_teleport_oidc_connector.go")
-	generate(samlConnector, pluralResource, "provider/resource_teleport_saml_connector.go")
-	generate(samlConnector, pluralDataSource, "provider/data_source_teleport_saml_connector.go")
-	generate(provisionToken, pluralResource, "provider/resource_teleport_provision_token.go")
-	generate(provisionToken, pluralDataSource, "provider/data_source_teleport_provision_token.go")
-	generate(role, pluralResource, "provider/resource_teleport_role.go")
-	generate(role, pluralDataSource, "provider/data_source_teleport_role.go")
-	generate(trustedCluster, pluralResource, "provider/resource_teleport_trusted_cluster.go")
-	generate(trustedCluster, pluralDataSource, "provider/data_source_teleport_trusted_cluster.go")
-	generate(sessionRecording, singularResource, "provider/resource_teleport_session_recording_config.go")
-	generate(sessionRecording, singularDataSource, "provider/data_source_teleport_session_recording_config.go")
-	generate(user, pluralResource, "provider/resource_teleport_user.go")
-	generate(user, pluralDataSource, "provider/data_source_teleport_user.go")
-	generate(loginRule, pluralResource, "provider/resource_teleport_login_rule.go")
-	generate(loginRule, pluralDataSource, "provider/data_source_teleport_login_rule.go")
+	generateResource(app, pluralResource)
+	generateDataSource(app, pluralDataSource)
+	generateResource(authPreference, singularResource)
+	generateDataSource(authPreference, singularDataSource)
+	generateResource(clusterNetworking, singularResource)
+	generateDataSource(clusterNetworking, singularDataSource)
+	generateResource(database, pluralResource)
+	generateDataSource(database, pluralDataSource)
+	generateResource(githubConnector, pluralResource)
+	generateDataSource(githubConnector, pluralDataSource)
+	generateResource(oidcConnector, pluralResource)
+	generateDataSource(oidcConnector, pluralDataSource)
+	generateResource(samlConnector, pluralResource)
+	generateDataSource(samlConnector, pluralDataSource)
+	generateResource(provisionToken, pluralResource)
+	generateDataSource(provisionToken, pluralDataSource)
+	generateResource(role, pluralResource)
+	generateDataSource(role, pluralDataSource)
+	generateResource(trustedCluster, pluralResource)
+	generateDataSource(trustedCluster, pluralDataSource)
+	generateResource(sessionRecording, singularResource)
+	generateDataSource(sessionRecording, singularDataSource)
+	generateResource(user, pluralResource)
+	generateDataSource(user, pluralDataSource)
+	generateResource(loginRule, pluralResource)
+	generateDataSource(loginRule, pluralDataSource)
+}
+
+func generateResource(p payload, tpl string) {
+	outFile := fmt.Sprintf(outFileResourceFormat, p.TerraformResourceType)
+	generate(p, tpl, outFile)
+}
+func generateDataSource(p payload, tpl string) {
+	outFile := fmt.Sprintf(outFileDataSourceFormat, p.TerraformResourceType)
+	generate(p, tpl, outFile)
 }
 
 func generate(p payload, tpl, outFile string) {

--- a/terraform/_gen/plural_resource.go.tpl
+++ b/terraform/_gen/plural_resource.go.tpl
@@ -102,7 +102,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		if err == nil {
 			n := {{.VarName}}.Metadata.Name
 			existErr := fmt.Sprintf("{{.Name}} exists in Teleport. Either remove it (tctl rm {{.Kind}}/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import {{.TerraformResourceType}}.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("{{.Name}} exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_database.go
+++ b/terraform/provider/resource_teleport_database.go
@@ -80,7 +80,7 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		if err == nil {
 			n := database.Metadata.Name
 			existErr := fmt.Sprintf("Database exists in Teleport. Either remove it (tctl rm db/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_database.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("Database exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_github_connector.go
+++ b/terraform/provider/resource_teleport_github_connector.go
@@ -80,7 +80,7 @@ func (r resourceTeleportGithubConnector) Create(ctx context.Context, req tfsdk.C
 		if err == nil {
 			n := githubConnector.Metadata.Name
 			existErr := fmt.Sprintf("GithubConnector exists in Teleport. Either remove it (tctl rm github/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_github_connector.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("GithubConnector exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_login_rule.go
+++ b/terraform/provider/resource_teleport_login_rule.go
@@ -80,7 +80,7 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 		if err == nil {
 			n := loginRule.Metadata.Name
 			existErr := fmt.Sprintf("LoginRule exists in Teleport. Either remove it (tctl rm login_rule/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_login_rule.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("LoginRule exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_oidc_connector.go
+++ b/terraform/provider/resource_teleport_oidc_connector.go
@@ -80,7 +80,7 @@ func (r resourceTeleportOIDCConnector) Create(ctx context.Context, req tfsdk.Cre
 		if err == nil {
 			n := oidcConnector.Metadata.Name
 			existErr := fmt.Sprintf("OIDCConnector exists in Teleport. Either remove it (tctl rm oidc/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_oidc_connector.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("OIDCConnector exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_provision_token.go
+++ b/terraform/provider/resource_teleport_provision_token.go
@@ -92,7 +92,7 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		if err == nil {
 			n := provisionToken.Metadata.Name
 			existErr := fmt.Sprintf("ProvisionToken exists in Teleport. Either remove it (tctl rm token/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_provision_token.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("ProvisionToken exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_role.go
+++ b/terraform/provider/resource_teleport_role.go
@@ -80,7 +80,7 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		if err == nil {
 			n := role.Metadata.Name
 			existErr := fmt.Sprintf("Role exists in Teleport. Either remove it (tctl rm role/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_role.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("Role exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_saml_connector.go
+++ b/terraform/provider/resource_teleport_saml_connector.go
@@ -80,7 +80,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		if err == nil {
 			n := samlConnector.Metadata.Name
 			existErr := fmt.Sprintf("SAMLConnector exists in Teleport. Either remove it (tctl rm saml/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_saml_connector.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("SAMLConnector exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/terraform/provider/resource_teleport_trusted_cluster.go
@@ -80,7 +80,7 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		if err == nil {
 			n := trustedCluster.Metadata.Name
 			existErr := fmt.Sprintf("TrustedCluster exists in Teleport. Either remove it (tctl rm trusted_cluster/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_trusted_cluster.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("TrustedCluster exists in Teleport", trace.Errorf(existErr)))
 			return

--- a/terraform/provider/resource_teleport_user.go
+++ b/terraform/provider/resource_teleport_user.go
@@ -80,7 +80,7 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		if err == nil {
 			n := user.Metadata.Name
 			existErr := fmt.Sprintf("User exists in Teleport. Either remove it (tctl rm user/%v)"+
-				" or import it to the existing state (terraform import teleport_app.%v %v)", n, n, n)
+				" or import it to the existing state (terraform import teleport_user.%v %v)", n, n, n)
 
 			resp.Diagnostics.Append(diagFromErr("User exists in Teleport", trace.Errorf(existErr)))
 			return


### PR DESCRIPTION
All error messages were telling users to run `terraform import teleport_app.<resource_name>`, regardless of the resource type. This PR introduces the concept of `TerraformResourceName` in the code generator. By convention, the resource name is also used in the go file name.

Fixes [this issue reported on the Community Slack](https://goteleport.slack.com/archives/CEZH6UL64/p1683225731451069).

Note for reviewers: the diff looks huge because of go fmt. Only the first commit can be reviewed, the second is the result of the generation.