### PR TITLE
Fixes arm64 terraform provider promotion

### DIFF
--- a/tooling/internal/filename/parse.go
+++ b/tooling/internal/filename/parse.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	filenamePattern *regexp.Regexp = regexp.MustCompile(`^(?P<plugin>.*)-teleport-v(?P<version>.*)-(?P<os>linux|darwin|windows)-(?P<arch>amd64|arm|aarch)-bin.tar.gz$`)
+	filenamePattern *regexp.Regexp = regexp.MustCompile(`^(?P<plugin>.*)-teleport-v(?P<version>.*)-(?P<os>linux|darwin|windows)-(?P<arch>amd64|arm|arm64)-bin.tar.gz$`)
 )
 
 // Info holds information about a plugin, deduced from from its Houston-compatible

--- a/tooling/internal/filename/parse_test.go
+++ b/tooling/internal/filename/parse_test.go
@@ -33,6 +33,26 @@ func TestParseFilename(t *testing.T) {
 		require.Equal(t, "amd64", info.Arch)
 	})
 
+	t.Run("WithDarwinAmd64", func(t *testing.T) {
+		info, err := Parse("terraform-provider-teleport-v13.0.0-darwin-amd64-bin.tar.gz")
+		require.NoError(t, err)
+
+		require.Equal(t, "terraform-provider", info.Type)
+		require.Equal(t, *semver.New("13.0.0"), info.Version)
+		require.Equal(t, "darwin", info.OS)
+		require.Equal(t, "amd64", info.Arch)
+	})
+
+	t.Run("WithDarwinArm64", func(t *testing.T) {
+		info, err := Parse("terraform-provider-teleport-v13.0.0-darwin-arm64-bin.tar.gz")
+		require.NoError(t, err)
+
+		require.Equal(t, "terraform-provider", info.Type)
+		require.Equal(t, *semver.New("13.0.0"), info.Version)
+		require.Equal(t, "darwin", info.OS)
+		require.Equal(t, "arm64", info.Arch)
+	})
+
 	t.Run("WithoutLeadingPath", func(t *testing.T) {
 		info, err := Parse("terraform-provider-teleport-v1.2.3-linux-arm-bin.tar.gz")
 		require.NoError(t, err)


### PR DESCRIPTION
The code used to deduce the CPU architecture from a filename used `aarch64` as a 64-bit ARM architecture tag. The terraform provider (and other Teleport artifacts) uses `arm64` to mean the same thing.

This patch updates the plugin filename parser to match.