### PR TITLE
Fix incorrect helm repo URL in email plugin doc

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -68,7 +68,7 @@ kubectl create secret generic teleport-plugin-email-identity --from-file=auth_id
 ### Installing the plugin
 
 ```
-helm repo add teleport https://charts.teleport.sh/
+helm repo add teleport https://charts.releases.teleport.dev/
 ```
 
 ```shell


### PR DESCRIPTION
Fix Teleport Access Requests with Email plugin documentation which includes wrong URL to Teleport Helm repo 
