### PR TITLE
Fix email plugin values.yaml example in the doc

### DIFF
--- a/charts/access/email/README.md
+++ b/charts/access/email/README.md
@@ -87,8 +87,8 @@ mailgun:
   domain: sandboxbd81caddef744a69be0e5b544ab0c3bd.mailgun.org
   privateKey: supersecretprivatekey
 
-role_to_recipients:
-  '*': access-requests@example.com
+roleToRecipients:
+  '*': ["access-requests@example.com"]
 ```
 
 Alternatively, you can pass arguments from the command line (useful for one-liners or scripts):


### PR DESCRIPTION
There is a wrong key used in the teleport-plugin-email-values.yaml example