### PR TITLE
TF Ref Docs: Update to 13.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,8 @@ update-version:
 	$(SED) '1s/.*/VERSION=$(VERSION)/' access/email/Makefile
 	$(SED) '1s/.*/VERSION=$(VERSION)/' terraform/install.mk
 	$(MAKE) update-helm-version
-	$(MAKE) terraform-gen-tfschema
 	$(MAKE) update-teleport-dep-version
+	$(MAKE) terraform-gen-tfschema
 
 # Update all charts to VERSION
 .PHONY: update-helm-version

--- a/terraform/reference.mdx
+++ b/terraform/reference.mdx
@@ -95,13 +95,13 @@ provider "teleport" {
 
 Metadata is the app resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -111,8 +111,8 @@ Spec is the app resource spec.
 |----------------------|--------|----------|--------------------------------------------------------------------------|
 | aws                  | object |          | AWS contains additional options for AWS applications.                    |
 | cloud                | string |          | Cloud identifies the cloud instance the app represents.                  |
-| dynamic_labels       | object |          | DynamicLabels are the app&#39;s command labels.                          |
-| insecure_skip_verify | bool   |          | InsecureSkipVerify disables app&#39;s TLS certificate verification.      |
+| dynamic_labels       | object |          | DynamicLabels are the app's command labels.                              |
+| insecure_skip_verify | bool   |          | InsecureSkipVerify disables app's TLS certificate verification.          |
 | public_addr          | string |          | PublicAddr is the public address the application is accessible at.       |
 | rewrite              | object |          | Rewrite is a list of rewriting rules to apply to requests and responses. |
 | uri                  | string |          | URI is the web app endpoint.                                             |
@@ -139,10 +139,10 @@ DynamicLabels are the app's command labels.
 
 Rewrite is a list of rewriting rules to apply to requests and responses.
 
-|   Name   |       Type       | Required |                                                                    Description                                                                    |
-|----------|------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| headers  | object           |          | Headers is a list of headers to inject when passing the request over to the application.                                                          |
-| redirect | array of strings |          | Redirect defines a list of hosts which will be rewritten to the public address of the application if they occur in the &#34;Location&#34; header. |
+|   Name   |       Type       | Required |                                                                Description                                                                |
+|----------|------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| headers  | object           |          | Headers is a list of headers to inject when passing the request over to the application.                                                  |
+| redirect | array of strings |          | Redirect defines a list of hosts which will be rewritten to the public address of the application if they occur in the "Location" header. |
 
 ##### spec.rewrite.headers
 
@@ -186,12 +186,12 @@ resource "teleport_app" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -218,10 +218,10 @@ Spec is an AuthPreference specification
 
 DeviceTrust holds settings related to trusted device verification. Requires Teleport Enterprise.
 
-|    Name     |  Type  | Required |                                                                                                                                                                                                                                             Description                                                                                                                                                                                                                                              |
-|-------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| auto_enroll | bool   |          | Enable device auto-enroll. Auto-enroll lets any user issue a device enrollment token for a known device that is not already enrolled. `tsh` takes advantage of auto-enroll to automatically enroll devices on user login, when appropriate. The effective cluster Mode still applies: AutoEnroll=true is meaningless if Mode=&#34;off&#34;.                                                                                                                                                          |
-| mode        | string |          | Mode of verification for trusted devices.  The following modes are supported:  - &#34;off&#34;: disables both device authentication and authorization. - &#34;optional&#34;: allows both device authentication and authorization, but doesn&#39;t enforce the presence of device extensions for sensitive endpoints. - &#34;required&#34;: enforces the presence of device extensions for sensitive endpoints.  Mode is always &#34;off&#34; for OSS. Defaults to &#34;optional&#34; for Enterprise. |
+|    Name     |  Type  | Required |                                                                                                                                                                                                                       Description                                                                                                                                                                                                                        |
+|-------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| auto_enroll | bool   |          | Enable device auto-enroll. Auto-enroll lets any user issue a device enrollment token for a known device that is not already enrolled. `tsh` takes advantage of auto-enroll to automatically enroll devices on user login, when appropriate. The effective cluster Mode still applies: AutoEnroll=true is meaningless if Mode="off".                                                                                                                      |
+| mode        | string |          | Mode of verification for trusted devices.  The following modes are supported:  - "off": disables both device authentication and authorization. - "optional": allows both device authentication and authorization, but doesn't enforce the presence of device extensions for sensitive endpoints. - "required": enforces the presence of device extensions for sensitive endpoints.  Mode is always "off" for OSS. Defaults to "optional" for Enterprise. |
 
 #### spec.idp
 
@@ -253,11 +253,11 @@ U2F are the settings for the U2F device.
 
 Webauthn are the settings for server-side Web Authentication support.
 
-|          Name           |       Type       | Required |                                                                                                                                                                                                                       Description                                                                                                                                                                                                                       |
-|-------------------------|------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| attestation_allowed_cas | array of strings |          | Allow list of device attestation CAs in PEM format. If present, only devices whose attestation certificates match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationDeniedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default all devices are allowed.         |
-| attestation_denied_cas  | array of strings |          | Deny list of device attestation CAs in PEM format. If present, only devices whose attestation certificates don&#39;t match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationAllowedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default no devices are denied. |
-| rp_id                   | string           |          | RPID is the ID of the Relying Party. It should be set to the domain name of the Teleport installation.  IMPORTANT: RPID must never change in the lifetime of the cluster, because it&#39;s recorded in the registration data on the WebAuthn device. If the RPID changes, all existing WebAuthn key registrations will become invalid and all users who use WebAuthn as the second factor will need to re-register.                                     |
+|          Name           |       Type       | Required |                                                                                                                                                                                                                     Description                                                                                                                                                                                                                     |
+|-------------------------|------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| attestation_allowed_cas | array of strings |          | Allow list of device attestation CAs in PEM format. If present, only devices whose attestation certificates match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationDeniedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default all devices are allowed.     |
+| attestation_denied_cas  | array of strings |          | Deny list of device attestation CAs in PEM format. If present, only devices whose attestation certificates don't match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationAllowedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default no devices are denied. |
+| rp_id                   | string           |          | RPID is the ID of the Relying Party. It should be set to the domain name of the Teleport installation.  IMPORTANT: RPID must never change in the lifetime of the cluster, because it's recorded in the registration data on the WebAuthn device. If the RPID changes, all existing WebAuthn key registrations will become invalid and all users who use WebAuthn as the second factor will need to re-register.                                     |
 
 Example:
 
@@ -346,12 +346,12 @@ resource "teleport_bot" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -428,13 +428,13 @@ resource "teleport_cluster_networking_config" "example" {
 
 Metadata is the database metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -510,12 +510,13 @@ MemoryDB contains AWS MemoryDB specific metadata.
 
 RDS contains RDS specific metadata.
 
-|    Name     |  Type  | Required |                            Description                            |
-|-------------|--------|----------|-------------------------------------------------------------------|
-| cluster_id  | string |          | ClusterID is the RDS cluster (Aurora) identifier.                 |
-| iam_auth    | bool   |          | IAMAuth indicates whether database IAM authentication is enabled. |
-| instance_id | string |          | InstanceID is the RDS instance identifier.                        |
-| resource_id | string |          | ResourceID is the RDS instance resource identifier (db-xxx).      |
+|    Name     |       Type       | Required |                            Description                            |
+|-------------|------------------|----------|-------------------------------------------------------------------|
+| cluster_id  | string           |          | ClusterID is the RDS cluster (Aurora) identifier.                 |
+| iam_auth    | bool             |          | IAMAuth indicates whether database IAM authentication is enabled. |
+| instance_id | string           |          | InstanceID is the RDS instance identifier.                        |
+| resource_id | string           |          | ResourceID is the RDS instance resource identifier (db-xxx).      |
+| subnets     | array of strings |          | Subnets is a list of subnets for the RDS instance.                |
 
 ##### spec.aws.rdsproxy
 
@@ -644,13 +645,13 @@ resource "teleport_database" "example" {
 
 Metadata holds resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -737,13 +738,13 @@ resource "teleport_github_connector" "github" {
 
 Metadata is resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         |          | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         |          | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### traits_map
 
@@ -798,13 +799,13 @@ resource "teleport_login_rule" "example" {
 
 Metadata holds resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -826,7 +827,7 @@ Spec is an OIDC connector specification.
 | provider                   | string           |          | Provider is the external identity provider.                                                                                                   |
 | redirect_url               | array of strings |          |                                                                                                                                               |
 | scope                      | array of strings |          | Scope specifies additional scopes set by provider.                                                                                            |
-| username_claim             | string           |          | UsernameClaim specifies the name of the claim from the OIDC connector to be used as the user&#39;s username.                                  |
+| username_claim             | string           |          | UsernameClaim specifies the name of the claim from the OIDC connector to be used as the user's username.                                      |
 
 #### spec.claims_to_roles
 
@@ -976,44 +977,44 @@ resource "teleport_okta_import_rule" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   | *        | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         |          | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   | *        | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         |          | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
 Spec is a provisioning token V2 spec
 
-|              Name              |         Type         | Required |                                                                        Description                                                                         |
-|--------------------------------|----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| allow                          | object               |          | Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.                                                         |
-| aws_iid_ttl                    | duration             |          | AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.                                              |
-| azure                          | object               |          | Azure allows the configuration of options specific to the &#34;azure&#34; join method.                                                                     |
-| bot_name                       | string               |          | BotName is the name of the bot this token grants access to, if any                                                                                         |
-| circleci                       | object               |          | CircleCI allows the configuration of options specific to the &#34;circleci&#34; join method.                                                               |
-| gcp                            | object               |          | GCP allows the configuration of options specific to the &#34;gcp&#34; join method.                                                                         |
-| github                         | object               |          | GitHub allows the configuration of options specific to the &#34;github&#34; join method.                                                                   |
-| gitlab                         | object               |          | GitLab allows the configuration of options specific to the &#34;gitlab&#34; join method.                                                                   |
-| join_method                    | string               |          | JoinMethod is the joining method required in order to use this token. Supported joining methods include &#34;token&#34;, &#34;ec2&#34;, and &#34;iam&#34;. |
-| kubernetes                     | object               |          | Kubernetes allows the configuration of options specific to the &#34;kubernetes&#34; join method.                                                           |
-| roles                          | array of strings     | *        | Roles is a list of roles associated with the token, that will be converted to metadata in the SSH and X509 certificates issued to the user of the token    |
-| suggested_agent_matcher_labels | map of string arrays |          |                                                                                                                                                            |
-| suggested_labels               | map of string arrays |          |                                                                                                                                                            |
+|              Name              |         Type         | Required |                                                                       Description                                                                       |
+|--------------------------------|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| allow                          | object               |          | Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.                                                      |
+| aws_iid_ttl                    | duration             |          | AWSIIDTTL is the TTL to use for AWS EC2 Instance Identity Documents used to join the cluster with this token.                                           |
+| azure                          | object               |          | Azure allows the configuration of options specific to the "azure" join method.                                                                          |
+| bot_name                       | string               |          | BotName is the name of the bot this token grants access to, if any                                                                                      |
+| circleci                       | object               |          | CircleCI allows the configuration of options specific to the "circleci" join method.                                                                    |
+| gcp                            | object               |          | GCP allows the configuration of options specific to the "gcp" join method.                                                                              |
+| github                         | object               |          | GitHub allows the configuration of options specific to the "github" join method.                                                                        |
+| gitlab                         | object               |          | GitLab allows the configuration of options specific to the "gitlab" join method.                                                                        |
+| join_method                    | string               |          | JoinMethod is the joining method required in order to use this token. Supported joining methods include "token", "ec2", and "iam".                      |
+| kubernetes                     | object               |          | Kubernetes allows the configuration of options specific to the "kubernetes" join method.                                                                |
+| roles                          | array of strings     | *        | Roles is a list of roles associated with the token, that will be converted to metadata in the SSH and X509 certificates issued to the user of the token |
+| suggested_agent_matcher_labels | map of string arrays |          |                                                                                                                                                         |
+| suggested_labels               | map of string arrays |          |                                                                                                                                                         |
 
 #### spec.allow
 
 Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.
 
-|    Name     |       Type       | Required |                                                                  Description                                                                   |
-|-------------|------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| aws_account | string           |          | AWSAccount is the AWS account ID.                                                                                                              |
-| aws_arn     | string           |          | AWSARN is used for the IAM join method, the AWS identity of joining nodes must match this ARN. Supports wildcards &#34;*&#34; and &#34;?&#34;. |
-| aws_regions | array of strings |          | AWSRegions is used for the EC2 join method and is a list of AWS regions a node is allowed to join from.                                        |
-| aws_role    | string           |          | AWSRole is used for the EC2 join method and is the the ARN of the AWS role that the auth server will assume in order to call the ec2 API.      |
+|    Name     |       Type       | Required |                                                                Description                                                                |
+|-------------|------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| aws_account | string           |          | AWSAccount is the AWS account ID.                                                                                                         |
+| aws_arn     | string           |          | AWSARN is used for the IAM join method, the AWS identity of joining nodes must match this ARN. Supports wildcards "*" and "?".            |
+| aws_regions | array of strings |          | AWSRegions is used for the EC2 join method and is a list of AWS regions a node is allowed to join from.                                   |
+| aws_role    | string           |          | AWSRole is used for the EC2 join method and is the the ARN of the AWS role that the auth server will assume in order to call the ec2 API. |
 
 #### spec.azure
 
@@ -1062,11 +1063,11 @@ GCP allows the configuration of options specific to the "gcp" join method.
 
 Allow is a list of Rules, nodes using this token must match one allow rule to use this token.
 
-|       Name       |       Type       | Required |                                                            Description                                                             |
-|------------------|------------------|----------|------------------------------------------------------------------------------------------------------------------------------------|
-| locations        | array of strings |          | Locations is a list of regions (e.g. &#34;us-west1&#34;) and/or zones (e.g. &#34;us-west1-b&#34;).                                 |
-| project_ids      | array of strings |          | ProjectIDs is a list of project IDs (e.g. &#34;&lt;example-id-123456&gt;&#34;).                                                    |
-| service_accounts | array of strings |          | ServiceAccounts is a list of service account emails (e.g. &#34;&lt;project-number&gt;-compute@developer.gserviceaccount.com&#34;). |
+|       Name       |       Type       | Required |                                                        Description                                                         |
+|------------------|------------------|----------|----------------------------------------------------------------------------------------------------------------------------|
+| locations        | array of strings |          | Locations is a list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").                                         |
+| project_ids      | array of strings |          | ProjectIDs is a list of project IDs (e.g. "&lt;example-id-123456&gt;").                                                    |
+| service_accounts | array of strings |          | ServiceAccounts is a list of service account emails (e.g. "&lt;project-number&gt;-compute@developer.gserviceaccount.com"). |
 
 #### spec.github
 
@@ -1086,7 +1087,7 @@ Allow is a list of TokenRules, nodes using this token must match one allow rule 
 | actor            | string |          | The personal account that initiated the workflow run.                                                                                                      |
 | environment      | string |          | The name of the environment used by the job.                                                                                                               |
 | ref              | string |          | The git ref that triggered the workflow run.                                                                                                               |
-| ref_type         | string |          | The type of ref, for example: &#34;branch&#34;.                                                                                                            |
+| ref_type         | string |          | The type of ref, for example: "branch".                                                                                                                    |
 | repository       | string |          | The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`                                        |
 | repository_owner | string |          | The name of the organization in which the repository is stored.                                                                                            |
 | sub              | string |          | Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run. |
@@ -1108,7 +1109,7 @@ Allow is a list of TokenRules, nodes using this token must match one allow rule 
 |      Name       |  Type  | Required |                                                                                    Description                                                                                     |
 |-----------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | environment     | string |          | Environment limits access by the environment the job deploys to (if one is associated)                                                                                             |
-| namespace_path  | string |          | NamespacePath is used to limit access to jobs in a group or user&#39;s projects. Example: `mygroup`                                                                                |
+| namespace_path  | string |          | NamespacePath is used to limit access to jobs in a group or user's projects. Example: `mygroup`                                                                                    |
 | pipeline_source | string |          | PipelineSource limits access by the job pipeline source type. https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules Example: `web`                       |
 | project_path    | string |          | ProjectPath is used to limit access to jobs belonging to an individual project. Example: `mygroup/myproject`                                                                       |
 | ref             | string |          | Ref allows access to be limited to jobs triggered by a specific git ref. Ensure this is used in combination with ref_type.                                                         |
@@ -1127,9 +1128,9 @@ Kubernetes allows the configuration of options specific to the "kubernetes" join
 
 Allow is a list of Rules, nodes using this token must match one allow rule to use this token.
 
-|      Name       |  Type  | Required |                                                         Description                                                         |
-|-----------------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| service_account | string |          | ServiceAccount is the namespaced name of the Kubernetes service account. Its format is &#34;namespace:service-account&#34;. |
+|      Name       |  Type  | Required |                                                     Description                                                     |
+|-----------------|--------|----------|---------------------------------------------------------------------------------------------------------------------|
+| service_account | string |          | ServiceAccount is the namespaced name of the Kubernetes service account. Its format is "namespace:service-account". |
 
 Example:
 
@@ -1167,13 +1168,13 @@ resource "teleport_provision_token" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -1244,11 +1245,11 @@ JoinSessions specifies policies to allow users to join other sessions.
 
 KubernetesResources is the Kubernetes Resources this Role grants access to.
 
-|   Name    |  Type  | Required |                                         Description                                         |
-|-----------|--------|----------|---------------------------------------------------------------------------------------------|
-| kind      | string |          | Kind specifies the Kubernetes Resource type. At the moment only &#34;pod&#34; is supported. |
-| name      | string |          | Name is the resource name. It supports wildcards.                                           |
-| namespace | string |          | Namespace is the resource namespace. It supports wildcards.                                 |
+|   Name    |  Type  | Required |                                     Description                                     |
+|-----------|--------|----------|-------------------------------------------------------------------------------------|
+| kind      | string |          | Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported. |
+| name      | string |          | Name is the resource name. It supports wildcards.                                   |
+| namespace | string |          | Namespace is the resource namespace. It supports wildcards.                         |
 
 ##### spec.allow.request
 
@@ -1288,14 +1289,14 @@ Thresholds is a list of thresholds, one of which must be met in order for review
 
 RequireSessionJoin specifies policies for required users to start a session.
 
-|   Name   |       Type       | Required |                                             Description                                             |
-|----------|------------------|----------|-----------------------------------------------------------------------------------------------------|
-| count    | number           |          | Count is the amount of people that need to be matched for this policy to be fulfilled.              |
-| filter   | string           |          | Filter is a predicate that determines what users count towards this policy.                         |
-| kinds    | array of strings |          | Kinds are the session kinds this policy applies to.                                                 |
-| modes    | array of strings |          | Modes is the list of modes that may be used to fulfill this policy.                                 |
-| name     | string           |          | Name is the name of the policy.                                                                     |
-| on_leave | string           |          | OnLeave is the behaviour that&#39;s used when the policy is no longer fulfilled for a live session. |
+|   Name   |       Type       | Required |                                           Description                                           |
+|----------|------------------|----------|-------------------------------------------------------------------------------------------------|
+| count    | number           |          | Count is the amount of people that need to be matched for this policy to be fulfilled.          |
+| filter   | string           |          | Filter is a predicate that determines what users count towards this policy.                     |
+| kinds    | array of strings |          | Kinds are the session kinds this policy applies to.                                             |
+| modes    | array of strings |          | Modes is the list of modes that may be used to fulfill this policy.                             |
+| name     | string           |          | Name is the name of the policy.                                                                 |
+| on_leave | string           |          | OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session. |
 
 ##### spec.allow.review_requests
 
@@ -1388,11 +1389,11 @@ JoinSessions specifies policies to allow users to join other sessions.
 
 KubernetesResources is the Kubernetes Resources this Role grants access to.
 
-|   Name    |  Type  | Required |                                         Description                                         |
-|-----------|--------|----------|---------------------------------------------------------------------------------------------|
-| kind      | string |          | Kind specifies the Kubernetes Resource type. At the moment only &#34;pod&#34; is supported. |
-| name      | string |          | Name is the resource name. It supports wildcards.                                           |
-| namespace | string |          | Namespace is the resource namespace. It supports wildcards.                                 |
+|   Name    |  Type  | Required |                                     Description                                     |
+|-----------|--------|----------|-------------------------------------------------------------------------------------|
+| kind      | string |          | Kind specifies the Kubernetes Resource type. At the moment only "pod" is supported. |
+| name      | string |          | Name is the resource name. It supports wildcards.                                   |
+| namespace | string |          | Namespace is the resource namespace. It supports wildcards.                         |
 
 ##### spec.deny.request
 
@@ -1432,14 +1433,14 @@ Thresholds is a list of thresholds, one of which must be met in order for review
 
 RequireSessionJoin specifies policies for required users to start a session.
 
-|   Name   |       Type       | Required |                                             Description                                             |
-|----------|------------------|----------|-----------------------------------------------------------------------------------------------------|
-| count    | number           |          | Count is the amount of people that need to be matched for this policy to be fulfilled.              |
-| filter   | string           |          | Filter is a predicate that determines what users count towards this policy.                         |
-| kinds    | array of strings |          | Kinds are the session kinds this policy applies to.                                                 |
-| modes    | array of strings |          | Modes is the list of modes that may be used to fulfill this policy.                                 |
-| name     | string           |          | Name is the name of the policy.                                                                     |
-| on_leave | string           |          | OnLeave is the behaviour that&#39;s used when the policy is no longer fulfilled for a live session. |
+|   Name   |       Type       | Required |                                           Description                                           |
+|----------|------------------|----------|-------------------------------------------------------------------------------------------------|
+| count    | number           |          | Count is the amount of people that need to be matched for this policy to be fulfilled.          |
+| filter   | string           |          | Filter is a predicate that determines what users count towards this policy.                     |
+| kinds    | array of strings |          | Kinds are the session kinds this policy applies to.                                             |
+| modes    | array of strings |          | Modes is the list of modes that may be used to fulfill this policy.                             |
+| name     | string           |          | Name is the name of the policy.                                                                 |
+| on_leave | string           |          | OnLeave is the behaviour that's used when the policy is no longer fulfilled for a live session. |
 
 ##### spec.deny.review_requests
 
@@ -1610,13 +1611,13 @@ resource "teleport_role" "example" {
 
 Metadata holds resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -1624,7 +1625,7 @@ Spec is an SAML connector specification.
 
 |          Name           |  Type  | Required |                                                                            Description                                                                            |
 |-------------------------|--------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| acs                     | string | *        | AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport&#39;s side).                                                   |
+| acs                     | string | *        | AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).                                                       |
 | allow_idp_initiated     | bool   |          | AllowIDPInitiated is a flag that indicates if the connector can be used for IdP-initiated logins.                                                                 |
 | assertion_key_pair      | object |          | EncryptionKeyPair is a key pair used for decrypting SAML assertions.                                                                                              |
 | attributes_to_roles     | object | *        | AttributesToRoles is a list of mappings of attribute statements to roles.                                                                                         |
@@ -1637,7 +1638,7 @@ Spec is an SAML connector specification.
 | provider                | string |          | Provider is the external identity provider.                                                                                                                       |
 | service_provider_issuer | string |          | ServiceProviderIssuer is the issuer of the service provider (Teleport).                                                                                           |
 | signing_key_pair        | object |          | SigningKeyPair is an x509 key pair used to sign AuthnRequest.                                                                                                     |
-| sso                     | string |          | SSO is the URL of the identity provider&#39;s SSO service.                                                                                                        |
+| sso                     | string |          | SSO is the URL of the identity provider's SSO service.                                                                                                            |
 
 #### spec.assertion_key_pair
 
@@ -1728,12 +1729,12 @@ resource "teleport_saml_connector" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -1777,13 +1778,13 @@ resource "teleport_session_recording_config" "example" {
 
 Metadata holds resource metadata.
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -1889,13 +1890,13 @@ resource "teleport_trusted_device" "TESTDEVICE1" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -1913,28 +1914,28 @@ Spec is a user specification
 
 GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity
 
-|     Name     |  Type  | Required |                                    Description                                    |
-|--------------|--------|----------|-----------------------------------------------------------------------------------|
-| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
-| username     | string |          | Username is username supplied by external identity provider                       |
+|     Name     |  Type  | Required |                                Description                                |
+|--------------|--------|----------|---------------------------------------------------------------------------|
+| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. 'google-example.com' |
+| username     | string |          | Username is username supplied by external identity provider               |
 
 #### spec.oidc_identities
 
 OIDCIdentities lists associated OpenID Connect identities that let user log in using externally verified identity
 
-|     Name     |  Type  | Required |                                    Description                                    |
-|--------------|--------|----------|-----------------------------------------------------------------------------------|
-| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
-| username     | string |          | Username is username supplied by external identity provider                       |
+|     Name     |  Type  | Required |                                Description                                |
+|--------------|--------|----------|---------------------------------------------------------------------------|
+| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. 'google-example.com' |
+| username     | string |          | Username is username supplied by external identity provider               |
 
 #### spec.saml_identities
 
 SAMLIdentities lists associated SAML identities that let user log in using externally verified identity
 
-|     Name     |  Type  | Required |                                    Description                                    |
-|--------------|--------|----------|-----------------------------------------------------------------------------------|
-| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
-| username     | string |          | Username is username supplied by external identity provider                       |
+|     Name     |  Type  | Required |                                Description                                |
+|--------------|--------|----------|---------------------------------------------------------------------------|
+| connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. 'google-example.com' |
+| username     | string |          | Username is username supplied by external identity provider               |
 
 Example:
 

--- a/terraform/reference.mdx
+++ b/terraform/reference.mdx
@@ -885,13 +885,13 @@ resource "teleport_oidc_connector" "example" {
 
 Metadata is resource metadata
 
-|    Name     |      Type      | Required |                                                  Description                                                   |
-|-------------|----------------|----------|----------------------------------------------------------------------------------------------------------------|
-| description | string         |          | Description is object description                                                                              |
-| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
-| labels      | map of strings |          | Labels is a set of labels                                                                                      |
-| name        | string         | *        | Name is an object name                                                                                         |
-| namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
+|    Name     |      Type      | Required |                                              Description                                               |
+|-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
+| description | string         |          | Description is object description                                                                      |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
+| labels      | map of strings |          | Labels is a set of labels                                                                              |
+| name        | string         | *        | Name is an object name                                                                                 |
+| namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |
 
 ### spec
 
@@ -915,10 +915,12 @@ Mappings is a list of matches that will map match conditions to labels.
 
 Match is a set of matching rules for this mapping. If any of these match, then the mapping will be applied.
 
-|   Name    |       Type       | Required |                    Description                    |
-|-----------|------------------|----------|---------------------------------------------------|
-| app_ids   | array of strings |          | AppIDs is a list of app IDs to match against.     |
-| group_ids | array of strings |          | GroupIDs is a list of group IDs to match against. |
+|        Name        |       Type       | Required |                             Description                             |
+|--------------------|------------------|----------|---------------------------------------------------------------------|
+| app_ids            | array of strings |          | AppIDs is a list of app IDs to match against.                       |
+| app_name_regexes   | array of strings |          | AppNameRegexes is a list of regexes to match against app names.     |
+| group_ids          | array of strings |          | GroupIDs is a list of group IDs to match against.                   |
+| group_name_regexes | array of strings |          | GroupNameRegexes is a list of regexes to match against group names. |
 
 Example:
 
@@ -1870,8 +1872,8 @@ Example:
 
 resource "teleport_trusted_device" "TESTDEVICE1" {
   spec = {
-    asset_tag     = "TESTDEVICE1"
-    os_type       = "macos"
+    asset_tag = "TESTDEVICE1"
+    os_type   = "macos"
   }
 }
 

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -3005,8 +3005,18 @@ func GenSchemaOktaImportRuleV1(ctx context.Context) (github_com_hashicorp_terraf
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
+								"app_name_regexes": {
+									Description: "AppNameRegexes is a list of regexes to match against app names.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
 								"group_ids": {
 									Description: "GroupIDs is a list of group IDs to match against.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
+								"group_name_regexes": {
+									Description: "GroupNameRegexes is a list of regexes to match against group names.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
@@ -29446,6 +29456,60 @@ func CopyOktaImportRuleV1FromTerraform(_ context.Context, tf github_com_hashicor
 																					}
 																				}
 																			}
+																			{
+																				a, ok := tf.Attrs["app_name_regexes"]
+																				if !ok {
+																					diags.Append(attrReadMissingDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes"})
+																				} else {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																					} else {
+																						obj.AppNameRegexes = make([]string, len(v.Elems))
+																						if !v.Null && !v.Unknown {
+																							for k, a := range v.Elems {
+																								v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																								if !ok {
+																									diags.Append(attrReadConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																								} else {
+																									var t string
+																									if !v.Null && !v.Unknown {
+																										t = string(v.Value)
+																									}
+																									obj.AppNameRegexes[k] = t
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
+																			{
+																				a, ok := tf.Attrs["group_name_regexes"]
+																				if !ok {
+																					diags.Append(attrReadMissingDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes"})
+																				} else {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																					} else {
+																						obj.GroupNameRegexes = make([]string, len(v.Elems))
+																						if !v.Null && !v.Unknown {
+																							for k, a := range v.Elems {
+																								v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																								if !ok {
+																									diags.Append(attrReadConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																								} else {
+																									var t string
+																									if !v.Null && !v.Unknown {
+																										t = string(v.Value)
+																									}
+																									obj.GroupNameRegexes[k] = t
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
 																		}
 																		obj.Match[k] = t
 																	}
@@ -29982,6 +30046,112 @@ func CopyOktaImportRuleV1ToTerraform(ctx context.Context, obj github_com_gravita
 																				}
 																				c.Unknown = false
 																				tf.Attrs["group_ids"] = c
+																			}
+																		}
+																	}
+																	{
+																		a, ok := tf.AttrTypes["app_name_regexes"]
+																		if !ok {
+																			diags.Append(attrWriteMissingDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes"})
+																		} else {
+																			o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																			if !ok {
+																				diags.Append(attrWriteConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																			} else {
+																				c, ok := tf.Attrs["app_name_regexes"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																				if !ok {
+																					c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																						ElemType: o.ElemType,
+																						Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AppNameRegexes)),
+																						Null:     true,
+																					}
+																				} else {
+																					if c.Elems == nil {
+																						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AppNameRegexes))
+																					}
+																				}
+																				if obj.AppNameRegexes != nil {
+																					t := o.ElemType
+																					if len(obj.AppNameRegexes) != len(c.Elems) {
+																						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AppNameRegexes))
+																					}
+																					for k, a := range obj.AppNameRegexes {
+																						v, ok := tf.Attrs["app_name_regexes"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																						if !ok {
+																							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																							if err != nil {
+																								diags.Append(attrWriteGeneralError{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes", err})
+																							}
+																							v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.AppNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																							}
+																							v.Null = string(a) == ""
+																						}
+																						v.Value = string(a)
+																						v.Unknown = false
+																						c.Elems[k] = v
+																					}
+																					if len(obj.AppNameRegexes) > 0 {
+																						c.Null = false
+																					}
+																				}
+																				c.Unknown = false
+																				tf.Attrs["app_name_regexes"] = c
+																			}
+																		}
+																	}
+																	{
+																		a, ok := tf.AttrTypes["group_name_regexes"]
+																		if !ok {
+																			diags.Append(attrWriteMissingDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes"})
+																		} else {
+																			o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																			if !ok {
+																				diags.Append(attrWriteConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																			} else {
+																				c, ok := tf.Attrs["group_name_regexes"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																				if !ok {
+																					c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																						ElemType: o.ElemType,
+																						Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.GroupNameRegexes)),
+																						Null:     true,
+																					}
+																				} else {
+																					if c.Elems == nil {
+																						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.GroupNameRegexes))
+																					}
+																				}
+																				if obj.GroupNameRegexes != nil {
+																					t := o.ElemType
+																					if len(obj.GroupNameRegexes) != len(c.Elems) {
+																						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.GroupNameRegexes))
+																					}
+																					for k, a := range obj.GroupNameRegexes {
+																						v, ok := tf.Attrs["group_name_regexes"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																						if !ok {
+																							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																							if err != nil {
+																								diags.Append(attrWriteGeneralError{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes", err})
+																							}
+																							v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"OktaImportRuleV1.Spec.Mappings.Match.GroupNameRegexes", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																							}
+																							v.Null = string(a) == ""
+																						}
+																						v.Value = string(a)
+																						v.Unknown = false
+																						c.Elems[k] = v
+																					}
+																					if len(obj.GroupNameRegexes) > 0 {
+																						c.Null = false
+																					}
+																				}
+																				c.Unknown = false
+																				tf.Attrs["group_name_regexes"] = c
 																			}
 																		}
 																	}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -225,6 +225,11 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
+								"subnets": {
+									Description: "Subnets is a list of subnets for the RDS instance.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
 							}),
 							Description: "RDS contains RDS specific metadata.",
 							Optional:    true,
@@ -3503,6 +3508,33 @@ func CopyDatabaseV3FromTerraform(_ context.Context, tf github_com_hashicorp_terr
 															}
 														}
 													}
+													{
+														a, ok := tf.Attrs["subnets"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"DatabaseV3.Spec.AWS.RDS.Subnets"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"DatabaseV3.Spec.AWS.RDS.Subnets", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+															} else {
+																obj.Subnets = make([]string, len(v.Elems))
+																if !v.Null && !v.Unknown {
+																	for k, a := range v.Elems {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"DatabaseV3.Spec.AWS.RDS.Subnets", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Subnets[k] = t
+																		}
+																	}
+																}
+															}
+														}
+													}
 												}
 											}
 										}
@@ -5005,6 +5037,59 @@ func CopyDatabaseV3ToTerraform(ctx context.Context, obj github_com_gravitational
 															v.Value = bool(obj.IAMAuth)
 															v.Unknown = false
 															tf.Attrs["iam_auth"] = v
+														}
+													}
+													{
+														a, ok := tf.AttrTypes["subnets"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"DatabaseV3.Spec.AWS.RDS.Subnets"})
+														} else {
+															o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+															if !ok {
+																diags.Append(attrWriteConversionFailureDiag{"DatabaseV3.Spec.AWS.RDS.Subnets", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+															} else {
+																c, ok := tf.Attrs["subnets"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																if !ok {
+																	c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																		ElemType: o.ElemType,
+																		Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Subnets)),
+																		Null:     true,
+																	}
+																} else {
+																	if c.Elems == nil {
+																		c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Subnets))
+																	}
+																}
+																if obj.Subnets != nil {
+																	t := o.ElemType
+																	if len(obj.Subnets) != len(c.Elems) {
+																		c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Subnets))
+																	}
+																	for k, a := range obj.Subnets {
+																		v, ok := tf.Attrs["subnets"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																			if err != nil {
+																				diags.Append(attrWriteGeneralError{"DatabaseV3.Spec.AWS.RDS.Subnets", err})
+																			}
+																			v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																			if !ok {
+																				diags.Append(attrWriteConversionFailureDiag{"DatabaseV3.Spec.AWS.RDS.Subnets", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																			}
+																			v.Null = string(a) == ""
+																		}
+																		v.Value = string(a)
+																		v.Unknown = false
+																		c.Elems[k] = v
+																	}
+																	if len(obj.Subnets) > 0 {
+																		c.Null = false
+																	}
+																}
+																c.Unknown = false
+																tf.Attrs["subnets"] = c
+															}
 														}
 													}
 												}


### PR DESCRIPTION
We released 13.0.3
This PR updates the reference docs for it.

It also changes the way we escape the fields description. It was using html escape previsouly, but then some words would trigger the cspell lint check we have in `Lint(Docs)` CI Step. Eg `doesn't` became `doesn&#39;t` and `doesn` isn't a valid word.