### PR TITLE
TF: Provision Token does not require `Metadata.Expires` fields

### DIFF
--- a/terraform/example/provision_token.tf.example
+++ b/terraform/example/provision_token.tf.example
@@ -15,3 +15,17 @@ resource "teleport_provision_token" "example" {
     roles = ["Node", "Auth"]
   }
 }
+
+resource "teleport_provision_token" "iam-token" {
+  metadata = {
+    name = "iam-token"
+  }
+  spec = {
+    roles       = ["Bot"]
+    bot_name    = "mybot"
+    join_method = "iam"
+    allow = [{
+      aws_account = "123456789012"
+    }]
+  }
+}

--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -280,7 +280,6 @@ required_fields:
     - "ProvisionTokenV2.Spec"
     - "ProvisionTokenV2.Spec.Options"
     - "ProvisionTokenV2.Spec.Roles"
-    - "ProvisionTokenV2.Metadata.Expires"
 
     # Role
     - "RoleV6.Metadata.Name"    

--- a/terraform/reference.mdx
+++ b/terraform/reference.mdx
@@ -982,7 +982,7 @@ Metadata is resource metadata
 |    Name     |      Type      | Required |                                              Description                                               |
 |-------------|----------------|----------|--------------------------------------------------------------------------------------------------------|
 | description | string         |          | Description is object description                                                                      |
-| expires     | RFC3339 time   | *        | Expires is a global expiry time header can be set on any resource in the system.                       |
+| expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                       |
 | labels      | map of strings |          | Labels is a set of labels                                                                              |
 | name        | string         |          | Name is an object name                                                                                 |
 | namespace   | string         |          | Namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4. |

--- a/terraform/reference.mdx
+++ b/terraform/reference.mdx
@@ -1155,6 +1155,20 @@ resource "teleport_provision_token" "example" {
   }
 }
 
+resource "teleport_provision_token" "iam-token" {
+  metadata = {
+    name = "iam-token"
+  }
+  spec = {
+    roles       = ["Bot"]
+    bot_name    = "mybot"
+    join_method = "iam"
+    allow = [{
+      aws_account = "123456789012"
+    }]
+  }
+}
+
 ```
 
 ## teleport_role

--- a/terraform/test/fixtures/provision_token_iam_create.tf
+++ b/terraform/test/fixtures/provision_token_iam_create.tf
@@ -1,0 +1,13 @@
+resource "teleport_provision_token" "iam-token" {
+  metadata = {
+    name = "iam-token"
+  }
+  spec = {
+    roles       = ["Bot"]
+    bot_name    = "mybot"
+    join_method = "iam"
+    allow = [{
+      aws_account = "123456789012"
+    }]
+  }
+}

--- a/terraform/test/fixtures/provision_token_no_expiry_0_create.tf
+++ b/terraform/test/fixtures/provision_token_no_expiry_0_create.tf
@@ -1,6 +1,6 @@
 resource "teleport_provision_token" "test" {
   metadata = {
-    name    = "test"
+    name = "test"
     labels = {
       example = "yes"
     }

--- a/terraform/test/fixtures/provision_token_no_expiry_0_create.tf
+++ b/terraform/test/fixtures/provision_token_no_expiry_0_create.tf
@@ -1,0 +1,11 @@
+resource "teleport_provision_token" "test" {
+  metadata = {
+    name    = "test"
+    labels = {
+      example = "yes"
+    }
+  }
+  spec = {
+    roles = ["Node", "Auth"]
+  }
+}

--- a/terraform/test/provision_token_test.go
+++ b/terraform/test/provision_token_test.go
@@ -222,3 +222,39 @@ func (s *TerraformSuite) TestProvisionTokenDoesNotLeakSensitiveData() {
 		},
 	})
 }
+
+func (s *TerraformSuite) TestProvisionTokenWithoutExpiration() {
+	checkRoleDestroyed := func(state *terraform.State) error {
+		_, err := s.client.GetToken(s.Context(), "test")
+		if trace.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	name := "teleport_provision_token.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkRoleDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("provision_token_no_expiry_0_create.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "token"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "metadata.labels.example", "yes"),
+					resource.TestCheckNoResourceAttr(name, "metadata.expiry"),
+					resource.TestCheckResourceAttr(name, "spec.roles.0", "Node"),
+					resource.TestCheckResourceAttr(name, "spec.roles.1", "Auth"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+				),
+			},
+			{
+				Config:   s.getFixture("provision_token_no_expiry_0_create.tf"),
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -621,7 +621,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 				},
 				"expires": {
 					Description: "Expires is a global expiry time header can be set on any resource in the system.",
-					Required:    true,
+					Optional:    true,
 					Type:        UseRFC3339Time(),
 					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{MustTimeBeInFuture()},
 				},


### PR DESCRIPTION
Provision Tokens can be created without an expiration date.

Expireless tokens are possible since https://github.com/gravitational/teleport/pull/21133
Fixes https://github.com/gravitational/teleport-plugins/issues/837