### PR TITLE
Patch install scripts

### DIFF
--- a/access/discord/install
+++ b/access/discord/install
@@ -14,7 +14,7 @@ DATADIR=/var/lib/teleport/plugins/discord
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd "$(dirname "$0")"
 mkdir -p "$BINDIR" "$DATADIR" || exit 1
-cp -f teleport-discord "$BINDIR/" || exit 1
+cp -f build/teleport-discord "$BINDIR/" || exit 1
 
 echo "Teleport Discord binaries have been copied to $BINDIR"
 echo "You can run teleport-discord configure > /etc/teleport-discord.toml to bootstrap your config file"

--- a/access/email/install
+++ b/access/email/install
@@ -14,7 +14,7 @@ DATADIR=/var/lib/teleport/plugins/email
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR || exit 1
-cp -f teleport-email $BINDIR/ || exit 1
+cp -f build/teleport-email $BINDIR/ || exit 1
 
 echo "Teleport Email binaries have been copied to $BINDIR"
 echo "You can run teleport-email configure > /etc/teleport-email.toml to bootstrap your config file"

--- a/access/jira/install
+++ b/access/jira/install
@@ -13,7 +13,7 @@ DATADIR=/var/lib/teleport/plugins/jira
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR
-cp -f teleport-jira $BINDIR/ || exit 1
+cp -f build/teleport-jira $BINDIR/ || exit 1
 
 echo "Teleport Jira Plugin binaries have been copied to $BINDIR"
 echo "You can run teleport-jira configure > /etc/teleport-jira.toml to bootstrap your config file."

--- a/access/mattermost/install
+++ b/access/mattermost/install
@@ -13,7 +13,7 @@ DATADIR=/var/lib/teleport/plugins/mattermost
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR
-cp -f teleport-mattermost $BINDIR/ || exit 1
+cp -f build/teleport-mattermost $BINDIR/ || exit 1
 
 echo "Teleport Mattermost plugin binaries have been copied to $BINDIR"
 echo "You can run teleport-mattermost configure > /etc/teleport-mattermost.toml to bootstrap your config file."

--- a/access/msteams/install
+++ b/access/msteams/install
@@ -14,7 +14,7 @@ DATADIR=/var/lib/teleport/plugins/msteams
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR || exit 1
-cp -f teleport-msteams $BINDIR/ || exit 1
+cp -f build/teleport-msteams $BINDIR/ || exit 1
 
 echo "Teleport MsTeams binaries have been copied to $BINDIR"
 echo "Please follow: https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-msteams/"

--- a/access/pagerduty/install
+++ b/access/pagerduty/install
@@ -13,7 +13,7 @@ DATADIR=/var/lib/teleport/plugins/pagerduty
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR
-cp -f teleport-pagerduty $BINDIR/ || exit 1
+cp -f build/teleport-pagerduty $BINDIR/ || exit 1
 
 echo "Teleport PagerDuty Plugin binaries have been copied to $BINDIR"
 echo "You can run teleport-pagerduty configure > /etc/teleport-pagerduty.toml to bootstrap your config file."

--- a/access/slack/install
+++ b/access/slack/install
@@ -14,7 +14,7 @@ DATADIR=/var/lib/teleport/plugins/slack
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
 cd $(dirname $0)
 mkdir -p $BINDIR $DATADIR || exit 1
-cp -f teleport-slack $BINDIR/ || exit 1
+cp -f build/teleport-slack $BINDIR/ || exit 1
 
 echo "Teleport Slack binaries have been copied to $BINDIR"
 echo "You can run teleport-slack configure > /etc/teleport-slack.toml to bootstrap your config file"


### PR DESCRIPTION
While testing [docs](https://github.com/gravitational/teleport/pull/26783) I found that the install scripts are broken, because the look for the binaries in the same directory instead of `./build`. I testing this for the Discord, email, and Jira plugins, and feel safe assuming the rest of the access plugins behave the same.