### PR TITLE
Ignore error when session doesn't return events.

### DIFF
--- a/event-handler/session_events_job.go
+++ b/event-handler/session_events_job.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/gravitational/teleport/integrations/lib"
@@ -233,7 +234,8 @@ Loop:
 
 	// We have finished ingestion and do not need session state anymore
 	err := j.app.State.RemoveSession(s.ID)
-	if err != nil {
+	// If the session had no events, the file won't exist, so we ignore the error
+	if err != nil && !os.IsNotExist(err) {
 		return false, trace.Wrap(err)
 	}
 

--- a/event-handler/session_events_job_test.go
+++ b/event-handler/session_events_job_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/peterbourgon/diskv/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConsumeSessionNoEventsFound tests that the consumeSession method returns without error
+// if no events are found.
+func TestConsumeSessionNoEventsFound(t *testing.T) {
+	sessionID := "test"
+	j := &SessionEventsJob{
+		app: &App{
+			Config: &StartCmdConfig{},
+			EventWatcher: &TeleportEventsWatcher{
+				client: &mockClient{},
+			},
+			State: &State{
+				dv: diskv.New(diskv.Options{
+					BasePath: t.TempDir(),
+				}),
+			},
+		},
+	}
+	_, err := j.consumeSession(context.Background(), session{ID: sessionID})
+	require.NoError(t, err)
+}
+
+type mockClient struct {
+	client.Client
+}
+
+// StreamSessionEvents overrides the client.Client method to return a closed channel
+// to ensure that the consumeSession method returns without error if no events are found.
+func (m *mockClient) StreamSessionEvents(ctx context.Context, sessionID string, startIndex int64) (chan events.AuditEvent, chan error) {
+	c := make(chan events.AuditEvent)
+	e := make(chan error)
+	close(c)
+	return c, e
+}


### PR DESCRIPTION
If the given session doesn't have any events, thee session index file wasn't created and cleaning results in error.

This PR checks if the error is `os.IsNotExist` and returns nil if it's the case so it can resume the normal operation.