### PR TITLE
Pin Golang Docker image to Debian 11

### DIFF
--- a/access/Dockerfile
+++ b/access/Dockerfile
@@ -1,7 +1,7 @@
 # Build the plugin binary
 ARG GO_VERSION
 
-FROM golang:${GO_VERSION} as builder
+FROM golang:${GO_VERSION}-bullseye as builder
 
 ARG ACCESS_PLUGIN
 ARG GITREF

--- a/event-handler/Dockerfile
+++ b/event-handler/Dockerfile
@@ -1,7 +1,7 @@
 # Build the plugin binary
 ARG GO_VERSION
 
-FROM golang:${GO_VERSION} as builder
+FROM golang:${GO_VERSION}-bullseye as builder
 
 ARG GITREF
 

--- a/event-handler/build.assets/Dockerfile
+++ b/event-handler/build.assets/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VER
-FROM golang:${GO_VER}
+FROM golang:${GO_VER}-bullseye
 
 ARG UID
 ARG GID


### PR DESCRIPTION
Currently, we're using the latest Docker Go image without specifying a version that defaults to the latest. Debian 12 was released recently, which upgraded our build environment. This PR pins down the OS version, which should solve the issue.

Distroless images are still not upgraded to use Debian 12, hence the downgrade for building images. We should upgrade everything once this happens.

Fixes https://github.com/gravitational/teleport/issues/28445