### PR TITLE
[PagerDuty] Restores pagerduty config loader

### DIFF
--- a/access/pagerduty/config.go
+++ b/access/pagerduty/config.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020-2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/gravitational/teleport/integrations/access/pagerduty"
+	"github.com/gravitational/teleport/integrations/lib"
+	"github.com/gravitational/trace"
+	"github.com/pelletier/go-toml"
+)
+
+func LoadConfig(filepath string) (*pagerduty.Config, error) {
+	t, err := toml.LoadFile(filepath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	conf := &pagerduty.Config{}
+	if err := t.Unmarshal(conf); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if strings.HasPrefix(conf.Pagerduty.APIKey, "/") {
+		conf.Pagerduty.APIKey, err = lib.ReadPassword(conf.Pagerduty.APIKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	if err := conf.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return conf, nil
+}

--- a/access/pagerduty/main.go
+++ b/access/pagerduty/main.go
@@ -69,7 +69,7 @@ func main() {
 }
 
 func run(configPath string, debug bool) error {
-	conf, err := pagerduty.LoadConfig(configPath)
+	conf, err := LoadConfig(configPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Restores the PagerDuty config file loader. This seems to have gone missing between the bulk of the PagerDuty code being vendored into the `teleport` repository and then backpoorted onto a feature branch.