### PR TITLE
[buddy] Add standard annotation support to Slack plugin

### DIFF
--- a/charts/access/slack/README.md
+++ b/charts/access/slack/README.md
@@ -193,4 +193,41 @@ The following values can be set for the Helm chart:
     <td><code>"INFO"</code></td>
     <td>no</td>
   </tr>
+
+  <tr>
+    <td><code>annotations.config</code></td>
+    <td>
+      Annotations to add to the configmap.
+    </td>
+    <td>map</td>
+    <td><code>{}</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>annotations.deployment</code></td>
+    <td>
+      Annotations to add to the deployment.
+    </td>
+    <td>map</td>
+    <td><code>{}</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>annotations.pod</code></td>
+    <td>
+      Annotations to add to every pod created by the deployment.
+    </td>
+    <td>map</td>
+    <td><code>{}</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
+    <td><code>annotations.secret</code></td>
+    <td>
+      Annotations to add to the secret.
+    </td>
+    <td>map</td>
+    <td><code>{}</code></td>
+    <td>no</td>
+  </tr>
 </table>

--- a/charts/access/slack/templates/configmap.yaml
+++ b/charts/access/slack/templates/configmap.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "slack.fullname" . }}
+  {{- with .Values.annotations.config }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "slack.labels" . | nindent 4 }}
 data:

--- a/charts/access/slack/templates/deployment.yaml
+++ b/charts/access/slack/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "slack.fullname" . }}
+  {{- with .Values.annotations.deployment }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "slack.labels" . | nindent 4 }}
 spec:
@@ -11,7 +15,7 @@ spec:
       {{- include "slack.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with or .Values.annotations.pod .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/access/slack/templates/secret.yaml
+++ b/charts/access/slack/templates/secret.yaml
@@ -4,6 +4,10 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "slack.fullname" . }}-secret
+  {{- with .Values.annotations.secret }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
    slackToken: {{ .Values.slack.token | b64enc }}
 {{- end }}

--- a/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -23,37 +23,37 @@ should match the snapshot:
             app.kubernetes.io/name: teleport-plugin-slack
         spec:
           containers:
-          - command:
-            - /usr/local/bin/teleport-plugin
-            - start
-            - --config
-            - /etc/teleport-slack.toml
-            image: gcr.io/overridden/repository:v98.76.54
-            imagePullPolicy: IfNotPresent
-            name: teleport-plugin-slack
-            resources: {}
-            securityContext: {}
-            volumeMounts:
-            - mountPath: /etc/teleport-slack.toml
-              name: config
-              subPath: teleport-slack.toml
-            - mountPath: /var/lib/teleport/plugins/slack/auth_id
-              name: auth-id
-              subPath: auth_id
-            - mountPath: /var/lib/teleport/plugins/slack/slack-token
-              name: password-file
-              subPath: slackToken
+            - command:
+                - /usr/local/bin/teleport-plugin
+                - start
+                - --config
+                - /etc/teleport-slack.toml
+              image: gcr.io/overridden/repository:v98.76.54
+              imagePullPolicy: IfNotPresent
+              name: teleport-plugin-slack
+              resources: {}
+              securityContext: {}
+              volumeMounts:
+                - mountPath: /etc/teleport-slack.toml
+                  name: config
+                  subPath: teleport-slack.toml
+                - mountPath: /var/lib/teleport/plugins/slack/auth_id
+                  name: auth-id
+                  subPath: auth_id
+                - mountPath: /var/lib/teleport/plugins/slack/slack-token
+                  name: password-file
+                  subPath: slackToken
           securityContext: {}
           volumes:
-          - configMap:
-              defaultMode: 384
-              name: RELEASE-NAME-teleport-plugin-slack
-            name: config
-          - name: auth-id
-            secret:
-              defaultMode: 384
-              secretName: ""
-          - name: password-file
-            secret:
-              defaultMode: 384
-              secretName: RELEASE-NAME-teleport-plugin-slack-secret
+            - configMap:
+                defaultMode: 384
+                name: RELEASE-NAME-teleport-plugin-slack
+              name: config
+            - name: auth-id
+              secret:
+                defaultMode: 384
+                secretName: ""
+            - name: password-file
+              secret:
+                defaultMode: 384
+                secretName: RELEASE-NAME-teleport-plugin-slack-secret

--- a/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -23,37 +23,37 @@ should match the snapshot:
             app.kubernetes.io/name: teleport-plugin-slack
         spec:
           containers:
-            - command:
-                - /usr/local/bin/teleport-plugin
-                - start
-                - --config
-                - /etc/teleport-slack.toml
-              image: gcr.io/overridden/repository:v98.76.54
-              imagePullPolicy: IfNotPresent
-              name: teleport-plugin-slack
-              resources: {}
-              securityContext: {}
-              volumeMounts:
-                - mountPath: /etc/teleport-slack.toml
-                  name: config
-                  subPath: teleport-slack.toml
-                - mountPath: /var/lib/teleport/plugins/slack/auth_id
-                  name: auth-id
-                  subPath: auth_id
-                - mountPath: /var/lib/teleport/plugins/slack/slack-token
-                  name: password-file
-                  subPath: slackToken
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-slack.toml
+            image: gcr.io/overridden/repository:v98.76.54
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-slack
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-slack.toml
+              name: config
+              subPath: teleport-slack.toml
+            - mountPath: /var/lib/teleport/plugins/slack/auth_id
+              name: auth-id
+              subPath: auth_id
+            - mountPath: /var/lib/teleport/plugins/slack/slack-token
+              name: password-file
+              subPath: slackToken
           securityContext: {}
           volumes:
-            - configMap:
-                defaultMode: 384
-                name: RELEASE-NAME-teleport-plugin-slack
-              name: config
-            - name: auth-id
-              secret:
-                defaultMode: 384
-                secretName: ""
-            - name: password-file
-              secret:
-                defaultMode: 384
-                secretName: RELEASE-NAME-teleport-plugin-slack-secret
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-slack
+            name: config
+          - name: auth-id
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-slack-secret

--- a/charts/access/slack/tests/configmap_test.yaml
+++ b/charts/access/slack/tests/configmap_test.yaml
@@ -1,4 +1,4 @@
-suite: Test deployment
+suite: Test configmap
 templates:
   - configmap.yaml
 tests:
@@ -19,3 +19,21 @@ tests:
         severity: DEBUG
     asserts:
       - matchSnapshot: {}
+
+  - it: should not contain annotations when not defined
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should contain annotations when defined
+    set:
+      annotations:
+        config:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB

--- a/charts/access/slack/tests/deployment_test.yaml
+++ b/charts/access/slack/tests/deployment_test.yaml
@@ -9,3 +9,61 @@ tests:
         tag: v98.76.54
     asserts:
       - matchSnapshot: {}
+
+  - it: should not contain deployment or pod annotations when not defined
+    asserts:
+      - isNull:
+          path: metadata.annotations
+      - isNull:
+          path: spec.template.metadata.annotations
+
+  - it: should contain deployment annotations when defined
+    set:
+      annotations:
+        deployment:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - isNull:
+          path: spec.template.metadata.annotations
+
+  - it: should contain pod annotations when defined
+    set:
+      annotations:
+        pod:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - isNull:
+          path: metadata.annotations
+
+  - it: should contain both annotations when defined
+    set:
+      annotations:
+        deployment:
+          keyA: valA
+          keyB: valB
+        pod:
+          keyA: valA'
+          keyC: valC
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            keyA: valA'
+            keyC: valC

--- a/charts/access/slack/tests/secret_test.yaml
+++ b/charts/access/slack/tests/secret_test.yaml
@@ -16,3 +16,21 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not contain annotations when not defined
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should contain annotations when defined
+    set:
+      annotations:
+        secret:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB

--- a/charts/access/slack/values.schema.json
+++ b/charts/access/slack/values.schema.json
@@ -16,7 +16,8 @@
         "teleport",
         "slack",
         "roleToRecipients",
-        "log"
+        "log",
+        "annotations"
     ],
     "properties": {
         "image": {
@@ -393,6 +394,38 @@
             "examples": [
                 "my-secret-volume"
             ]
+        },
+        "annotations": {
+            "$id": "#/properties/annotations",
+            "type": "object",
+            "required": [
+                "config",
+                "deployment",
+                "pod",
+                "secret"
+            ],
+            "properties": {
+                "config": {
+                    "$id": "#/properties/annotations/properties/config",
+                    "type": "object",
+                    "default": {}
+                },
+                "deployment": {
+                    "$id": "#/properties/annotations/properties/deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "pod": {
+                    "$id": "#/properties/annotations/properties/pod",
+                    "type": "object",
+                    "default": {}
+                },
+                "secret": {
+                    "$id": "#/properties/annotations/properties/secret",
+                    "type": "object",
+                    "default": {}
+                }
+            }
         }
     },
     "additionalProperties": true

--- a/charts/access/slack/values.yaml
+++ b/charts/access/slack/values.yaml
@@ -23,6 +23,18 @@ log:
 
 secretVolumeName: "password-file"
 
+# Kubernetes annotations to apply
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+annotations:
+  # Annotations for the ConfigMap
+  config: {}
+  # Annotations for the Deployment
+  deployment: {}
+  # Annotations for each Pod in the Deployment
+  pod: {}
+  # Annotations for the Secret
+  secret: {}
+
 #
 # Deployment
 #

--- a/charts/access/slack/values.yaml
+++ b/charts/access/slack/values.yaml
@@ -48,6 +48,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Deprecated way to set pod annotations. `annotations.pod` should be preferred.
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Buddies #869 
---

The `teleport-kube-agent` and `teleport-cluster` charts have a standard config pattern of

```
annotations:
  resourceType1:
    keyA: valueA
  resourceType2:
    keyB: valueB
```

etc. The Slack plugin chart currently doesn't support this, having a top level `podAnnotations` value (undocumented on
https://goteleport.com/docs/reference/helm-reference/teleport-plugin-slack/) only.

I need to be able to add annotations to the `ConfigMap` and `Deployment` so that our install of `stakater/reloader` picks up when the `roleToRecipients` map changes (because we've added a new role that goes to a non-default Slack channel) and restarts the container so that it fetches its new config.

This was a problem we ran into recently, where it took a bit of time to realise that Slack notifications for some Teleport roles were going to the wrong channel.

This PR brings the Slack plugin into line with the more recent versions of the core cluster and agent helm charts, and allows setting annotations on any of the created resources via a consistent block.

For backwards compatibility, the old `podAnnotations` value has been retained but the newer `annotations.pod` version takes priority.