### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for items not matched below
 
-* @klizhentas @russjones @r0mant @Joerger @tcsc @zmb3
+* @klizhentas @russjones @r0mant @Joerger @tcsc @zmb3 @camscale @fheinecke


### PR DESCRIPTION
Add Cam and Fred to codeowners so they can approve release PRs as well.

Ideally we would port our review bot here as well but I'm hoping that we'll get rid of this repo entirely once all plugins move to teleport so this should be ok for now.