### PR TITLE
fix: pass proto messages by pointer

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -43,7 +43,7 @@ $(BUILDDIR)/terraform-provider-teleport_%: terraform-provider-teleport-v$(VERSIO
 	mv $(BUILDDIR)/terraform-provider-teleport $@
 
 CUSTOM_IMPORTS_TMP_DIR ?= /tmp/protoc-gen-terraform/custom-imports
-PROTOC_GEN_TERRAFORM_VERSION ?= v1.4.2
+PROTOC_GEN_TERRAFORM_VERSION ?= v2.0.0
 PROTOC_GEN_TERRAFORM_EXISTS := $(shell protoc-gen-terraform version 2>&1 >/dev/null | grep 'protoc-gen-terraform $(PROTOC_GEN_TERRAFORM_VERSION)')
 
 .PHONY: gen-tfschema

--- a/terraform/gen/plural_data_source.go.tpl
+++ b/terraform/gen/plural_data_source.go.tpl
@@ -73,7 +73,7 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	{{else -}}
 	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
 	{{end -}}
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/gen/plural_resource.go.tpl
+++ b/terraform/gen/plural_resource.go.tpl
@@ -177,7 +177,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	{{- end}}
 
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &plan)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,7 +224,7 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	{{else -}}
 	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
 	{{end -}}
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -321,7 +321,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{if not .IsPlainStruct -}}
 	{{.VarName}} = {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
 	{{end -}}
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &plan)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -372,7 +372,7 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 		return
 	}
 
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/gen/singular_data_source.go.tpl
+++ b/terraform/gen/singular_data_source.go.tpl
@@ -65,7 +65,7 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	{{else -}}
 	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
 	{{end -}}
-	diags := {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags := {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/gen/singular_resource.go.tpl
+++ b/terraform/gen/singular_resource.go.tpl
@@ -109,7 +109,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		tries = tries + 1
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
 		if err != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 			return
 		}
 		if {{.VarName}}Before.GetMetadata().ID != {{.VarName}}I.GetMetadata().ID || {{.HasStaticID}} {
@@ -126,7 +126,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 
@@ -142,7 +142,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	{{- end}}
 
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &plan)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -168,12 +168,12 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 
 	{{.VarName}}I, err := r.p.Client.Get{{.Name}}(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 
 	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -250,12 +250,12 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 
 	{{.VarName}} = {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &plan)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -272,7 +272,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	err := r.p.Client.{{.DeleteMethod}}(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 
@@ -283,7 +283,7 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	{{.VarName}}I, err := r.p.Client.Get{{.Name}}(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 
@@ -297,7 +297,7 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 		return
 	}
 
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, *{{.VarName}}, &state)
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_app.go
+++ b/terraform/provider/data_source_teleport_app.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportApp) Read(ctx context.Context, req tfsdk.ReadDataSourc
 
     var state types.Object
 	app := appI.(*apitypes.AppV3)
-	diags = tfschema.CopyAppV3ToTerraform(ctx, *app, &state)
+	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_auth_preference.go
+++ b/terraform/provider/data_source_teleport_auth_preference.go
@@ -59,7 +59,7 @@ func (r dataSourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Re
 
     var state types.Object
 	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)
-	diags := tfschema.CopyAuthPreferenceV2ToTerraform(ctx, *authPreference, &state)
+	diags := tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_cluster_networking_config.go
+++ b/terraform/provider/data_source_teleport_cluster_networking_config.go
@@ -59,7 +59,7 @@ func (r dataSourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req
 
     var state types.Object
 	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
-	diags := tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, *clusterNetworkingConfig, &state)
+	diags := tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_database.go
+++ b/terraform/provider/data_source_teleport_database.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportDatabase) Read(ctx context.Context, req tfsdk.ReadData
 
     var state types.Object
 	database := databaseI.(*apitypes.DatabaseV3)
-	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, *database, &state)
+	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_device_trust.go
+++ b/terraform/provider/data_source_teleport_device_trust.go
@@ -66,7 +66,7 @@ func (r dataSourceTeleportDeviceV1) Read(ctx context.Context, req tfsdk.ReadData
 
     var state types.Object
 	trustedDevice := trustedDeviceI
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, *trustedDevice, &state)
+	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_github_connector.go
+++ b/terraform/provider/data_source_teleport_github_connector.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportGithubConnector) Read(ctx context.Context, req tfsdk.R
 
     var state types.Object
 	githubConnector := githubConnectorI.(*apitypes.GithubConnectorV3)
-	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, *githubConnector, &state)
+	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_login_rule.go
+++ b/terraform/provider/data_source_teleport_login_rule.go
@@ -66,7 +66,7 @@ func (r dataSourceTeleportLoginRule) Read(ctx context.Context, req tfsdk.ReadDat
 
     var state types.Object
 	loginRule := loginRuleI
-	diags = schemav1.CopyLoginRuleToTerraform(ctx, *loginRule, &state)
+	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_oidc_connector.go
+++ b/terraform/provider/data_source_teleport_oidc_connector.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportOIDCConnector) Read(ctx context.Context, req tfsdk.Rea
 
     var state types.Object
 	oidcConnector := oidcConnectorI.(*apitypes.OIDCConnectorV3)
-	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, *oidcConnector, &state)
+	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_okta_import_rule.go
+++ b/terraform/provider/data_source_teleport_okta_import_rule.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportOktaImportRule) Read(ctx context.Context, req tfsdk.Re
 
     var state types.Object
 	oktaImportRule := oktaImportRuleI.(*apitypes.OktaImportRuleV1)
-	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, *oktaImportRule, &state)
+	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_provision_token.go
+++ b/terraform/provider/data_source_teleport_provision_token.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportProvisionToken) Read(ctx context.Context, req tfsdk.Re
 
     var state types.Object
 	provisionToken := provisionTokenI.(*apitypes.ProvisionTokenV2)
-	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, *provisionToken, &state)
+	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_role.go
+++ b/terraform/provider/data_source_teleport_role.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportRole) Read(ctx context.Context, req tfsdk.ReadDataSour
 
     var state types.Object
 	role := roleI.(*apitypes.RoleV6)
-	diags = tfschema.CopyRoleV6ToTerraform(ctx, *role, &state)
+	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_saml_connector.go
+++ b/terraform/provider/data_source_teleport_saml_connector.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.Rea
 
     var state types.Object
 	samlConnector := samlConnectorI.(*apitypes.SAMLConnectorV2)
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, *samlConnector, &state)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_session_recording_config.go
+++ b/terraform/provider/data_source_teleport_session_recording_config.go
@@ -59,7 +59,7 @@ func (r dataSourceTeleportSessionRecordingConfig) Read(ctx context.Context, req 
 
     var state types.Object
 	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
-	diags := tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, *sessionRecordingConfig, &state)
+	diags := tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_trusted_cluster.go
+++ b/terraform/provider/data_source_teleport_trusted_cluster.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportTrustedCluster) Read(ctx context.Context, req tfsdk.Re
 
     var state types.Object
 	trustedCluster := trustedClusterI.(*apitypes.TrustedClusterV2)
-	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, *trustedCluster, &state)
+	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_user.go
+++ b/terraform/provider/data_source_teleport_user.go
@@ -67,7 +67,7 @@ func (r dataSourceTeleportUser) Read(ctx context.Context, req tfsdk.ReadDataSour
 
     var state types.Object
 	user := userI.(*apitypes.UserV2)
-	diags = tfschema.CopyUserV2ToTerraform(ctx, *user, &state)
+	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_app.go
+++ b/terraform/provider/resource_teleport_app.go
@@ -136,7 +136,7 @@ func (r resourceTeleportApp) Create(ctx context.Context, req tfsdk.CreateResourc
 		return
 	}
 
-	diags = tfschema.CopyAppV3ToTerraform(ctx, *app, &plan)
+	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportApp) Read(ctx context.Context, req tfsdk.ReadResourceReq
 	}
 
 	app := appI.(*apitypes.AppV3)
-	diags = tfschema.CopyAppV3ToTerraform(ctx, *app, &state)
+	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportApp) Update(ctx context.Context, req tfsdk.UpdateResourc
 	}
 
 	app = appI.(*apitypes.AppV3)
-	diags = tfschema.CopyAppV3ToTerraform(ctx, *app, &plan)
+	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportApp) ImportState(ctx context.Context, req tfsdk.ImportRe
 		return
 	}
 
-	diags = tfschema.CopyAppV3ToTerraform(ctx, *app, &state)
+	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_auth_preference.go
+++ b/terraform/provider/resource_teleport_auth_preference.go
@@ -100,7 +100,7 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		authPreferenceI, err = r.p.Client.GetAuthPreference(ctx)
 		if err != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 			return
 		}
 		if authPreferenceBefore.GetMetadata().ID != authPreferenceI.GetMetadata().ID || false {
@@ -117,7 +117,7 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
 
@@ -129,7 +129,7 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, *authPreference, &plan)
+	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -155,12 +155,12 @@ func (r resourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Read
 
 	authPreferenceI, err := r.p.Client.GetAuthPreference(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
 
 	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)
-	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, *authPreference, &state)
+	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -237,12 +237,12 @@ func (r resourceTeleportAuthPreference) Update(ctx context.Context, req tfsdk.Up
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
 
 	authPreference = authPreferenceI.(*apitypes.AuthPreferenceV2)
-	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, *authPreference, &plan)
+	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -259,7 +259,7 @@ func (r resourceTeleportAuthPreference) Update(ctx context.Context, req tfsdk.Up
 func (r resourceTeleportAuthPreference) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	err := r.p.Client.ResetAuthPreference(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (r resourceTeleportAuthPreference) Delete(ctx context.Context, req tfsdk.De
 func (r resourceTeleportAuthPreference) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	authPreferenceI, err := r.p.Client.GetAuthPreference(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AuthPreference", trace.Wrap(err), "cluster_auth_preference"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
 
@@ -284,7 +284,7 @@ func (r resourceTeleportAuthPreference) ImportState(ctx context.Context, req tfs
 		return
 	}
 
-	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, *authPreference, &state)
+	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -100,7 +100,7 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 		tries = tries + 1
 		clusterNetworkingConfigI, err = r.p.Client.GetClusterNetworkingConfig(ctx)
 		if err != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 			return
 		}
 		if clusterNetworkingConfigBefore.GetMetadata().ID != clusterNetworkingConfigI.GetMetadata().ID || false {
@@ -117,7 +117,7 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
 
@@ -129,7 +129,7 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 		return
 	}
 
-	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, *clusterNetworkingConfig, &plan)
+	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -155,12 +155,12 @@ func (r resourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req t
 
 	clusterNetworkingConfigI, err := r.p.Client.GetClusterNetworkingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
 
 	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
-	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, *clusterNetworkingConfig, &state)
+	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -237,12 +237,12 @@ func (r resourceTeleportClusterNetworkingConfig) Update(ctx context.Context, req
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
 
 	clusterNetworkingConfig = clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
-	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, *clusterNetworkingConfig, &plan)
+	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -259,7 +259,7 @@ func (r resourceTeleportClusterNetworkingConfig) Update(ctx context.Context, req
 func (r resourceTeleportClusterNetworkingConfig) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	err := r.p.Client.ResetClusterNetworkingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (r resourceTeleportClusterNetworkingConfig) Delete(ctx context.Context, req
 func (r resourceTeleportClusterNetworkingConfig) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	clusterNetworkingConfigI, err := r.p.Client.GetClusterNetworkingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
 
@@ -284,7 +284,7 @@ func (r resourceTeleportClusterNetworkingConfig) ImportState(ctx context.Context
 		return
 	}
 
-	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, *clusterNetworkingConfig, &state)
+	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_database.go
+++ b/terraform/provider/resource_teleport_database.go
@@ -136,7 +136,7 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		return
 	}
 
-	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, *database, &plan)
+	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportDatabase) Read(ctx context.Context, req tfsdk.ReadResour
 	}
 
 	database := databaseI.(*apitypes.DatabaseV3)
-	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, *database, &state)
+	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportDatabase) Update(ctx context.Context, req tfsdk.UpdateRe
 	}
 
 	database = databaseI.(*apitypes.DatabaseV3)
-	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, *database, &plan)
+	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportDatabase) ImportState(ctx context.Context, req tfsdk.Imp
 		return
 	}
 
-	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, *database, &state)
+	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_device_trust.go
+++ b/terraform/provider/resource_teleport_device_trust.go
@@ -135,7 +135,7 @@ func (r resourceTeleportDeviceV1) Create(ctx context.Context, req tfsdk.CreateRe
 	trustedDevice = trustedDeviceI
 	
 
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, *trustedDevice, &plan)
+	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,7 +178,7 @@ func (r resourceTeleportDeviceV1) Read(ctx context.Context, req tfsdk.ReadResour
 	}
 
 	trustedDevice := trustedDeviceI
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, *trustedDevice, &state)
+	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -255,7 +255,7 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 		}
 	}
 
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, *trustedDevice, &plan)
+	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -304,7 +304,7 @@ func (r resourceTeleportDeviceV1) ImportState(ctx context.Context, req tfsdk.Imp
 		return
 	}
 
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, *trustedDevice, &state)
+	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_github_connector.go
+++ b/terraform/provider/resource_teleport_github_connector.go
@@ -136,7 +136,7 @@ func (r resourceTeleportGithubConnector) Create(ctx context.Context, req tfsdk.C
 		return
 	}
 
-	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, *githubConnector, &plan)
+	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportGithubConnector) Read(ctx context.Context, req tfsdk.Rea
 	}
 
 	githubConnector := githubConnectorI.(*apitypes.GithubConnectorV3)
-	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, *githubConnector, &state)
+	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportGithubConnector) Update(ctx context.Context, req tfsdk.U
 	}
 
 	githubConnector = githubConnectorI.(*apitypes.GithubConnectorV3)
-	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, *githubConnector, &plan)
+	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportGithubConnector) ImportState(ctx context.Context, req tf
 		return
 	}
 
-	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, *githubConnector, &state)
+	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_login_rule.go
+++ b/terraform/provider/resource_teleport_login_rule.go
@@ -131,7 +131,7 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 	loginRule = loginRuleI
 	
 
-	diags = schemav1.CopyLoginRuleToTerraform(ctx, *loginRule, &plan)
+	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -174,7 +174,7 @@ func (r resourceTeleportLoginRule) Read(ctx context.Context, req tfsdk.ReadResou
 	}
 
 	loginRule := loginRuleI
-	diags = schemav1.CopyLoginRuleToTerraform(ctx, *loginRule, &state)
+	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -251,7 +251,7 @@ func (r resourceTeleportLoginRule) Update(ctx context.Context, req tfsdk.UpdateR
 		}
 	}
 
-	diags = schemav1.CopyLoginRuleToTerraform(ctx, *loginRule, &plan)
+	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -300,7 +300,7 @@ func (r resourceTeleportLoginRule) ImportState(ctx context.Context, req tfsdk.Im
 		return
 	}
 
-	diags = schemav1.CopyLoginRuleToTerraform(ctx, *loginRule, &state)
+	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_oidc_connector.go
+++ b/terraform/provider/resource_teleport_oidc_connector.go
@@ -136,7 +136,7 @@ func (r resourceTeleportOIDCConnector) Create(ctx context.Context, req tfsdk.Cre
 		return
 	}
 
-	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, *oidcConnector, &plan)
+	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportOIDCConnector) Read(ctx context.Context, req tfsdk.ReadR
 	}
 
 	oidcConnector := oidcConnectorI.(*apitypes.OIDCConnectorV3)
-	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, *oidcConnector, &state)
+	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportOIDCConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 
 	oidcConnector = oidcConnectorI.(*apitypes.OIDCConnectorV3)
-	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, *oidcConnector, &plan)
+	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportOIDCConnector) ImportState(ctx context.Context, req tfsd
 		return
 	}
 
-	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, *oidcConnector, &state)
+	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/terraform/provider/resource_teleport_okta_import_rule.go
@@ -136,7 +136,7 @@ func (r resourceTeleportOktaImportRule) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, *oktaImportRule, &plan)
+	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportOktaImportRule) Read(ctx context.Context, req tfsdk.Read
 	}
 
 	oktaImportRule := oktaImportRuleI.(*apitypes.OktaImportRuleV1)
-	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, *oktaImportRule, &state)
+	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportOktaImportRule) Update(ctx context.Context, req tfsdk.Up
 	}
 
 	oktaImportRule = oktaImportRuleI.(*apitypes.OktaImportRuleV1)
-	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, *oktaImportRule, &plan)
+	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportOktaImportRule) ImportState(ctx context.Context, req tfs
 		return
 	}
 
-	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, *oktaImportRule, &state)
+	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_provision_token.go
+++ b/terraform/provider/resource_teleport_provision_token.go
@@ -148,7 +148,7 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, *provisionToken, &plan)
+	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -191,7 +191,7 @@ func (r resourceTeleportProvisionToken) Read(ctx context.Context, req tfsdk.Read
 	}
 
 	provisionToken := provisionTokenI.(*apitypes.ProvisionTokenV2)
-	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, *provisionToken, &state)
+	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -272,7 +272,7 @@ func (r resourceTeleportProvisionToken) Update(ctx context.Context, req tfsdk.Up
 	}
 
 	provisionToken = provisionTokenI.(*apitypes.ProvisionTokenV2)
-	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, *provisionToken, &plan)
+	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -321,7 +321,7 @@ func (r resourceTeleportProvisionToken) ImportState(ctx context.Context, req tfs
 		return
 	}
 
-	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, *provisionToken, &state)
+	diags = tfschema.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_role.go
+++ b/terraform/provider/resource_teleport_role.go
@@ -136,7 +136,7 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		return
 	}
 
-	diags = tfschema.CopyRoleV6ToTerraform(ctx, *role, &plan)
+	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportRole) Read(ctx context.Context, req tfsdk.ReadResourceRe
 	}
 
 	role := roleI.(*apitypes.RoleV6)
-	diags = tfschema.CopyRoleV6ToTerraform(ctx, *role, &state)
+	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportRole) Update(ctx context.Context, req tfsdk.UpdateResour
 	}
 
 	role = roleI.(*apitypes.RoleV6)
-	diags = tfschema.CopyRoleV6ToTerraform(ctx, *role, &plan)
+	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportRole) ImportState(ctx context.Context, req tfsdk.ImportR
 		return
 	}
 
-	diags = tfschema.CopyRoleV6ToTerraform(ctx, *role, &state)
+	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_saml_connector.go
+++ b/terraform/provider/resource_teleport_saml_connector.go
@@ -136,7 +136,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		return
 	}
 
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, *samlConnector, &plan)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.ReadR
 	}
 
 	samlConnector := samlConnectorI.(*apitypes.SAMLConnectorV2)
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, *samlConnector, &state)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 
 	samlConnector = samlConnectorI.(*apitypes.SAMLConnectorV2)
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, *samlConnector, &plan)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportSAMLConnector) ImportState(ctx context.Context, req tfsd
 		return
 	}
 
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, *samlConnector, &state)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_session_recording_config.go
+++ b/terraform/provider/resource_teleport_session_recording_config.go
@@ -100,7 +100,7 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 		tries = tries + 1
 		sessionRecordingConfigI, err = r.p.Client.GetSessionRecordingConfig(ctx)
 		if err != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 			return
 		}
 		if sessionRecordingConfigBefore.GetMetadata().ID != sessionRecordingConfigI.GetMetadata().ID || false {
@@ -117,7 +117,7 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
 
@@ -129,7 +129,7 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 		return
 	}
 
-	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, *sessionRecordingConfig, &plan)
+	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -155,12 +155,12 @@ func (r resourceTeleportSessionRecordingConfig) Read(ctx context.Context, req tf
 
 	sessionRecordingConfigI, err := r.p.Client.GetSessionRecordingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
 
 	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
-	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, *sessionRecordingConfig, &state)
+	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -237,12 +237,12 @@ func (r resourceTeleportSessionRecordingConfig) Update(ctx context.Context, req 
 		}
 	}
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
 
 	sessionRecordingConfig = sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
-	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, *sessionRecordingConfig, &plan)
+	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -259,7 +259,7 @@ func (r resourceTeleportSessionRecordingConfig) Update(ctx context.Context, req 
 func (r resourceTeleportSessionRecordingConfig) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	err := r.p.Client.ResetSessionRecordingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (r resourceTeleportSessionRecordingConfig) Delete(ctx context.Context, req 
 func (r resourceTeleportSessionRecordingConfig) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	sessionRecordingConfigI, err := r.p.Client.GetSessionRecordingConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.Append(diagFromWrappedErr("Error updating SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))	
+		resp.Diagnostics.Append(diagFromWrappedErr("Error updating SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
 
@@ -284,7 +284,7 @@ func (r resourceTeleportSessionRecordingConfig) ImportState(ctx context.Context,
 		return
 	}
 
-	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, *sessionRecordingConfig, &state)
+	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/terraform/provider/resource_teleport_trusted_cluster.go
@@ -136,7 +136,7 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, *trustedCluster, &plan)
+	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportTrustedCluster) Read(ctx context.Context, req tfsdk.Read
 	}
 
 	trustedCluster := trustedClusterI.(*apitypes.TrustedClusterV2)
-	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, *trustedCluster, &state)
+	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportTrustedCluster) Update(ctx context.Context, req tfsdk.Up
 	}
 
 	trustedCluster = trustedClusterI.(*apitypes.TrustedClusterV2)
-	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, *trustedCluster, &plan)
+	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportTrustedCluster) ImportState(ctx context.Context, req tfs
 		return
 	}
 
-	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, *trustedCluster, &state)
+	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_user.go
+++ b/terraform/provider/resource_teleport_user.go
@@ -136,7 +136,7 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		return
 	}
 
-	diags = tfschema.CopyUserV2ToTerraform(ctx, *user, &plan)
+	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +179,7 @@ func (r resourceTeleportUser) Read(ctx context.Context, req tfsdk.ReadResourceRe
 	}
 
 	user := userI.(*apitypes.UserV2)
-	diags = tfschema.CopyUserV2ToTerraform(ctx, *user, &state)
+	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +260,7 @@ func (r resourceTeleportUser) Update(ctx context.Context, req tfsdk.UpdateResour
 	}
 
 	user = userI.(*apitypes.UserV2)
-	diags = tfschema.CopyUserV2ToTerraform(ctx, *user, &plan)
+	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r resourceTeleportUser) ImportState(ctx context.Context, req tfsdk.ImportR
 		return
 	}
 
-	diags = tfschema.CopyUserV2ToTerraform(ctx, *user, &state)
+	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/tfschema/devicetrust/v1/device_terraform.go
+++ b/terraform/tfschema/devicetrust/v1/device_terraform.go
@@ -561,7 +561,7 @@ func CopyDeviceV1FromTerraform(_ context.Context, tf github_com_hashicorp_terraf
 }
 
 // CopyDeviceV1ToTerraform copies contents of the source Terraform object into a target struct
-func CopyDeviceV1ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.DeviceV1, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyDeviceV1ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.DeviceV1, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false

--- a/terraform/tfschema/loginrule/v1/loginrule_terraform.go
+++ b/terraform/tfschema/loginrule/v1/loginrule_terraform.go
@@ -343,7 +343,7 @@ func CopyLoginRuleFromTerraform(_ context.Context, tf github_com_hashicorp_terra
 }
 
 // CopyLoginRuleToTerraform copies contents of the source Terraform object into a target struct
-func CopyLoginRuleToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_gen_proto_go_teleport_loginrule_v1.LoginRule, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyLoginRuleToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_gen_proto_go_teleport_loginrule_v1.LoginRule, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -4667,7 +4667,7 @@ func CopyDatabaseV3FromTerraform(_ context.Context, tf github_com_hashicorp_terr
 }
 
 // CopyDatabaseV3ToTerraform copies contents of the source Terraform object into a target struct
-func CopyDatabaseV3ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.DatabaseV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyDatabaseV3ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.DatabaseV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -7307,7 +7307,7 @@ func CopyAppV3FromTerraform(_ context.Context, tf github_com_hashicorp_terraform
 }
 
 // CopyAppV3ToTerraform copies contents of the source Terraform object into a target struct
-func CopyAppV3ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.AppV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyAppV3ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.AppV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -9269,7 +9269,7 @@ func CopyProvisionTokenV2FromTerraform(_ context.Context, tf github_com_hashicor
 }
 
 // CopyProvisionTokenV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopyProvisionTokenV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.ProvisionTokenV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyProvisionTokenV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.ProvisionTokenV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -11509,7 +11509,7 @@ func CopyClusterNetworkingConfigV2FromTerraform(_ context.Context, tf github_com
 }
 
 // CopyClusterNetworkingConfigV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopyClusterNetworkingConfigV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.ClusterNetworkingConfigV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyClusterNetworkingConfigV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.ClusterNetworkingConfigV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -12327,7 +12327,7 @@ func CopySessionRecordingConfigV2FromTerraform(_ context.Context, tf github_com_
 }
 
 // CopySessionRecordingConfigV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopySessionRecordingConfigV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.SessionRecordingConfigV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopySessionRecordingConfigV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.SessionRecordingConfigV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -13233,7 +13233,7 @@ func CopyAuthPreferenceV2FromTerraform(_ context.Context, tf github_com_hashicor
 }
 
 // CopyAuthPreferenceV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopyAuthPreferenceV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.AuthPreferenceV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyAuthPreferenceV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.AuthPreferenceV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -18156,7 +18156,7 @@ func CopyRoleV6FromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 }
 
 // CopyRoleV6ToTerraform copies contents of the source Terraform object into a target struct
-func CopyRoleV6ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.RoleV6, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyRoleV6ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.RoleV6, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -25219,7 +25219,7 @@ func CopyUserV2FromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 }
 
 // CopyUserV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopyUserV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.UserV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyUserV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.UserV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -26375,7 +26375,7 @@ func CopyOIDCConnectorV3FromTerraform(_ context.Context, tf github_com_hashicorp
 }
 
 // CopyOIDCConnectorV3ToTerraform copies contents of the source Terraform object into a target struct
-func CopyOIDCConnectorV3ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.OIDCConnectorV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyOIDCConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.OIDCConnectorV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -27701,7 +27701,7 @@ func CopySAMLConnectorV2FromTerraform(_ context.Context, tf github_com_hashicorp
 }
 
 // CopySAMLConnectorV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopySAMLConnectorV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.SAMLConnectorV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopySAMLConnectorV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.SAMLConnectorV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -29049,7 +29049,7 @@ func CopyGithubConnectorV3FromTerraform(_ context.Context, tf github_com_hashico
 }
 
 // CopyGithubConnectorV3ToTerraform copies contents of the source Terraform object into a target struct
-func CopyGithubConnectorV3ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.GithubConnectorV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyGithubConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.GithubConnectorV3, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -30227,7 +30227,7 @@ func CopyTrustedClusterV2FromTerraform(_ context.Context, tf github_com_hashicor
 }
 
 // CopyTrustedClusterV2ToTerraform copies contents of the source Terraform object into a target struct
-func CopyTrustedClusterV2ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.TrustedClusterV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyTrustedClusterV2ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.TrustedClusterV2, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -31176,7 +31176,7 @@ func CopyOktaImportRuleV1FromTerraform(_ context.Context, tf github_com_hashicor
 }
 
 // CopyOktaImportRuleV1ToTerraform copies contents of the source Terraform object into a target struct
-func CopyOktaImportRuleV1ToTerraform(ctx context.Context, obj github_com_gravitational_teleport_api_types.OktaImportRuleV1, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+func CopyOktaImportRuleV1ToTerraform(ctx context.Context, obj *github_com_gravitational_teleport_api_types.OktaImportRuleV1, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false


### PR DESCRIPTION
This commit updates the Terraform provider to use the latest version of protoc-gen-terraform which generates code to pass messages by pointer instead of by value.

Protobuf messages are in general not safe to pass by value since they may contain a mutex.

Depends on https://github.com/gravitational/protoc-gen-terraform/pull/33

Fixes https://github.com/gravitational/teleport-plugins/issues/845