### PR TITLE
charts: enable fail-fast feature flag on all plugin charts

### DIFF
--- a/charts/access/discord/templates/deployment.yaml
+++ b/charts/access/discord/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-discord.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-discord.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-discord

--- a/charts/access/email/templates/deployment.yaml
+++ b/charts/access/email/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-email.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           ports:
             - name: http
               containerPort: 80

--- a/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should be possible to override volume name (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-email:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
@@ -91,6 +94,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
@@ -147,6 +153,9 @@ should match the snapshot (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-email:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
@@ -210,6 +219,9 @@ should match the snapshot (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-email:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
@@ -273,6 +285,9 @@ should mount external secret (mailgun on):
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-email:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
@@ -336,6 +351,9 @@ should mount external secret (smtp on):
             - start
             - --config
             - /etc/teleport-email.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-email:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email

--- a/charts/access/jira/templates/deployment.yaml
+++ b/charts/access/jira/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-jira.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           ports:
             - name: http
               containerPort: 8443

--- a/charts/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-jira.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-jira

--- a/charts/access/mattermost/templates/deployment.yaml
+++ b/charts/access/mattermost/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-mattermost.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           ports:
             - name: http
               containerPort: 80

--- a/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-mattermost.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
@@ -91,6 +94,9 @@ should mount external secret:
             - start
             - --config
             - /etc/teleport-mattermost.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-mattermost:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
@@ -154,6 +160,9 @@ should override volume name:
             - start
             - --config
             - /etc/teleport-mattermost.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: public.ecr.aws/gravitational/teleport-plugin-mattermost:13.3.2
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost

--- a/charts/access/msteams/templates/deployment.yaml
+++ b/charts/access/msteams/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-msteams.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-msteams.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-msteams

--- a/charts/access/pagerduty/templates/deployment.yaml
+++ b/charts/access/pagerduty/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-pagerduty.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           ports:
             - name: http
               containerPort: 80

--- a/charts/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-pagerduty.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-pagerduty

--- a/charts/access/slack/templates/deployment.yaml
+++ b/charts/access/slack/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-slack.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-slack.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-slack

--- a/charts/event-handler/templates/deployment.yaml
+++ b/charts/event-handler/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - start
             - "--config"
             - "/etc/teleport-event-handler.toml"
+          env:
+            - name: "TELEPORT_PLUGIN_FAIL_FAST"
+              value: "true"
           ports:
             - name: http
               containerPort: 80

--- a/charts/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,9 @@ should match the snapshot:
             - start
             - --config
             - /etc/teleport-event-handler.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
             image: gcr.io/overridden/repository:v98.76.54
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-event-handler


### PR DESCRIPTION
Adds the env var that causes the plugin to exit when the connection breaks instead of retrying infinitely. Fixes https://github.com/gravitational/teleport-plugins/issues/871

The disruption is quite low as Kubernetes will properly attempt to retry to connection. Worst case scenario we cannot reconnect and go into crashloop, which is still better than being stuck as the user will have a clear warning about the pod being broken.