### PR TITLE
TF: add `oidc_connector.spec.max_age` field

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
       TERRAFORM_VERSION: 1.4.6-1
-      TELEPORT_VERSION: 13.0.3
+      TELEPORT_VERSION: 13.3.6
     commands:
       - echo Testing plugins against Teleport $TELEPORT_VERSION
       - apt update && apt install -y software-properties-common
@@ -86,7 +86,7 @@ steps:
 
   - name: Install Teleport
     environment:
-      TELEPORT_VERSION: 13.0.3
+      TELEPORT_VERSION: 13.3.6
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -1405,6 +1405,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 96e52d64db77e31da4a612b5e0838c171a50ac0762143dfd159946871865811a
+hmac: fef88289161f5ab1a334635da813cd0e8af827fa2554ec494326baf1f3f46caf
 
 ...

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 13.0.3
+          version: 13.3.6
           enterprise: true
 
       - name: make test-terraform

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 13.0.3
+          version: 13.3.6
           enterprise: true
 
       - name: Run unit tests

--- a/event-handler/event_handler_test.go
+++ b/event-handler/event_handler_test.go
@@ -183,6 +183,12 @@ func (s *EventHandlerSuite) TestEvents() {
 		evt, err := s.fakeFluentd.GetMessage(s.Context())
 		require.NoError(t, err)
 
+		// Ignore unrelated events
+		if strings.Contains(evt, `"event":"role.created"`) || strings.Contains(evt, `"event":"user.create"`) {
+			i--
+			continue
+		}
+
 		require.Contains(t, evt, `"event":"instance.join"`)
 
 		if strings.Contains(evt, `"role":"Proxy"`) {

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -43,7 +43,7 @@ $(BUILDDIR)/terraform-provider-teleport_%: terraform-provider-teleport-v$(VERSIO
 	mv $(BUILDDIR)/terraform-provider-teleport $@
 
 CUSTOM_IMPORTS_TMP_DIR ?= /tmp/protoc-gen-terraform/custom-imports
-PROTOC_GEN_TERRAFORM_VERSION ?= v2.0.0
+PROTOC_GEN_TERRAFORM_VERSION ?= v2.0.1
 PROTOC_GEN_TERRAFORM_EXISTS := $(shell protoc-gen-terraform version 2>&1 >/dev/null | grep 'protoc-gen-terraform $(PROTOC_GEN_TERRAFORM_VERSION)')
 
 .PHONY: gen-tfschema

--- a/terraform/reference.mdx
+++ b/terraform/reference.mdx
@@ -858,6 +858,7 @@ Spec is an OIDC connector specification.
 | google_service_account     | string           |          | GoogleServiceAccount is a string containing google service account credentials.                                                               |
 | google_service_account_uri | string           |          | GoogleServiceAccountURI is a path to a google service account uri.                                                                            |
 | issuer_url                 | string           |          | IssuerURL is the endpoint of the provider, e.g. https://accounts.google.com.                                                                  |
+| max_age                    | duration         |          |                                                                                                                                               |
 | prompt                     | string           |          | Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility. |
 | provider                   | string           |          | Provider is the external identity provider.                                                                                                   |
 | redirect_url               | array of strings |          |                                                                                                                                               |

--- a/terraform/test/fixtures/oidc_connector_1_update.tf
+++ b/terraform/test/fixtures/oidc_connector_1_update.tf
@@ -17,5 +17,6 @@ resource "teleport_oidc_connector" "test" {
     }]
 
     redirect_url = ["https://example.com/redirect"]
+    max_age      = "5m0s"
   }
 }

--- a/terraform/test/oidc_connector_test.go
+++ b/terraform/test/oidc_connector_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package test
 
 import (
+	"time"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/trace"
@@ -63,6 +65,7 @@ func (s *TerraformSuite) TestOIDCConnector() {
 					resource.TestCheckResourceAttr(name, "spec.client_id", "client"),
 					resource.TestCheckResourceAttr(name, "spec.claims_to_roles.0.claim", "test"),
 					resource.TestCheckResourceAttr(name, "spec.claims_to_roles.0.roles.0", "teleport"),
+					resource.TestCheckResourceAttr(name, "spec.max_age", "5m0s"),
 				),
 			},
 			{
@@ -94,6 +97,9 @@ func (s *TerraformSuite) TestImportOIDCConnector() {
 			RedirectURLs: wrappers.Strings{
 				"https://example.com/redirect",
 			},
+			MaxAge: &types.MaxAge{
+				Value: types.Duration(5 * time.Minute),
+			},
 		},
 	}
 
@@ -116,6 +122,7 @@ func (s *TerraformSuite) TestImportOIDCConnector() {
 					require.Equal(s.T(), state[0].Attributes["spec.client_id"], "Iv1.3386eee92ff932a4")
 					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.claim"], "test")
 					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.roles.0"], "terraform")
+					require.Equal(s.T(), state[0].Attributes["spec.max_age"], "5m0s")
 
 					return nil
 				},

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -2599,6 +2599,11 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
+				"max_age": {
+					Description: "",
+					Optional:    true,
+					Type:        DurationType{},
+				},
 				"prompt": {
 					Description: "Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.",
 					Optional:    true,
@@ -26584,6 +26589,26 @@ func CopyOIDCConnectorV3FromTerraform(_ context.Context, tf github_com_hashicorp
 							}
 						}
 					}
+					{
+						a, ok := tf.Attrs["max_age"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"OIDCConnectorSpecV3.Value"})
+						} else {
+							v, ok := a.(DurationValue)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"OIDCConnectorSpecV3.Value", "DurationValue"})
+							} else {
+								var t github_com_gravitational_teleport_api_types.Duration
+								if !v.Null && !v.Unknown {
+									t = github_com_gravitational_teleport_api_types.Duration(v.Value)
+								}
+								if obj.MaxAge == nil {
+									obj.MaxAge = &github_com_gravitational_teleport_api_types.MaxAge{}
+								}
+								obj.Value = t
+							}
+						}
+					}
 				}
 			}
 		}
@@ -27339,6 +27364,31 @@ func CopyOIDCConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravita
 							v.Value = string(obj.UsernameClaim)
 							v.Unknown = false
 							tf.Attrs["username_claim"] = v
+						}
+					}
+					{
+						t, ok := tf.AttrTypes["max_age"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"OIDCConnectorSpecV3.Value"})
+						} else {
+							v, ok := tf.Attrs["max_age"].(DurationValue)
+							if !ok {
+								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+								if err != nil {
+									diags.Append(attrWriteGeneralError{"OIDCConnectorSpecV3.Value", err})
+								}
+								v, ok = i.(DurationValue)
+								if !ok {
+									diags.Append(attrWriteConversionFailureDiag{"OIDCConnectorSpecV3.Value", "DurationValue"})
+								}
+								v.Null = false
+							}
+							if obj.MaxAge == nil {
+								obj.MaxAge = &github_com_gravitational_teleport_api_types.MaxAge{}
+							}
+							v.Value = time.Duration(obj.Value)
+							v.Unknown = false
+							tf.Attrs["max_age"] = v
 						}
 					}
 				}


### PR DESCRIPTION
The generator now supports the usage of nullable/embedded fields. So the max_age can be added back to the oidc_connector fields.

Depends on https://github.com/gravitational/protoc-gen-terraform/pull/34