### PR TITLE
Don't use the same CN for all mTLS certs

### DIFF
--- a/event-handler/mtls_certs.go
+++ b/event-handler/mtls_certs.go
@@ -58,37 +58,47 @@ func GenerateMTLSCerts(cn string, dnsNames []string, ips []string, ttl time.Dura
 	notBefore := time.Now()
 	notAfter := notBefore.Add(ttl)
 
-	entity := pkix.Name{
+	entityCA := pkix.Name{
+                Country:    []string{"US"},
+                CommonName: "Teleport Event Handler mTLS CA",
+        }
+
+	entityClient := pkix.Name{
+                Country:    []string{"US"},
+                CommonName: "Teleport Event Handler mTLS Client",
+        }
+
+	entityServer := pkix.Name{
 		Country:    []string{"US"},
 		CommonName: cn,
 	}
 
 	c := &MTLSCerts{
 		caCert: x509.Certificate{ // caCert is a fluentd CA certificate
-			Subject:               entity,
+			Subject:               entityCA,
 			NotBefore:             notBefore,
 			NotAfter:              notAfter,
 			IsCA:                  true,
 			MaxPathLenZero:        true,
 			KeyUsage:              x509.KeyUsageCRLSign | x509.KeyUsageCertSign,
 			BasicConstraintsValid: true,
-			Issuer:                entity,
+			Issuer:                entityCA,
 		},
 		clientCert: x509.Certificate{ // clientCert is a fluentd client certificate
-			Subject:     entity,
+			Subject:     entityClient,
 			NotBefore:   notBefore,
 			NotAfter:    notAfter,
 			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			KeyUsage:    x509.KeyUsageDigitalSignature,
-			Issuer:      entity,
+			Issuer:      entityCA,
 		},
 		serverCert: x509.Certificate{ // Server CSR
-			Subject:     entity,
+			Subject:     entityServer,
 			NotBefore:   notBefore,
 			NotAfter:    notAfter,
 			KeyUsage:    x509.KeyUsageDigitalSignature,
 			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-			Issuer:      entity,
+			Issuer:      entityCA,
 		},
 	}
 

--- a/event-handler/mtls_certs.go
+++ b/event-handler/mtls_certs.go
@@ -59,14 +59,14 @@ func GenerateMTLSCerts(cn string, dnsNames []string, ips []string, ttl time.Dura
 	notAfter := notBefore.Add(ttl)
 
 	entityCA := pkix.Name{
-                Country:    []string{"US"},
-                CommonName: "Teleport Event Handler mTLS CA",
-        }
+		Country:    []string{"US"},
+		CommonName: "Teleport Event Handler mTLS CA",
+	}
 
 	entityClient := pkix.Name{
-                Country:    []string{"US"},
-                CommonName: "Teleport Event Handler mTLS Client",
-        }
+		Country:    []string{"US"},
+		CommonName: "Teleport Event Handler mTLS Client",
+	}
 
 	entityServer := pkix.Name{
 		Country:    []string{"US"},

--- a/event-handler/mtls_certs_test.go
+++ b/event-handler/mtls_certs_test.go
@@ -45,7 +45,7 @@ func TestGenerateClientCertFile(t *testing.T) {
 	require.NotEqual(t, certs.caCert.Subject.CommonName, certs.serverCert.Subject.CommonName, "CA and server certs should be different")
 
 	// Server cert should have SAN
-	require.NotNil(t, certs.serverCert.DNSNames)
+	require.NotEmpty(t, certs.serverCert.DNSNames)
 	require.Equal(t, "localhost", certs.serverCert.DNSNames[0])
 
 	// Write the cert to the tempdir

--- a/event-handler/mtls_certs_test.go
+++ b/event-handler/mtls_certs_test.go
@@ -46,7 +46,7 @@ func TestGenerateClientCertFile(t *testing.T) {
 
 	// Server cert should have SAN
 	require.NotNil(t, certs.serverCert.DNSNames)
-	require.Equal(t, certs.serverCert.DNSNames[0], "localhost")
+	require.Equal(t, "localhost", certs.serverCert.DNSNames[0])
 
 	// Write the cert to the tempdir
 	err = certs.ClientCert.WriteFile(path.Join(td, cp), path.Join(td, kp), ".")

--- a/event-handler/mtls_certs_test.go
+++ b/event-handler/mtls_certs_test.go
@@ -40,6 +40,14 @@ func TestGenerateClientCertFile(t *testing.T) {
 	require.NotNil(t, certs.clientCert.Issuer)
 	require.NotNil(t, certs.serverCert.Issuer)
 
+	// make sure certs are different
+	require.NotEqual(t, certs.caCert.Subject.CommonName, certs.clientCert.Subject.CommonName, "CA and client certs should be different")
+	require.NotEqual(t, certs.caCert.Subject.CommonName, certs.serverCert.Subject.CommonName, "CA and server certs should be different")
+
+	// Server cert should have SAN
+	require.NotNil(t, certs.serverCert.DNSNames)
+	require.Equal(t, certs.serverCert.DNSNames[0], "localhost")
+
 	// Write the cert to the tempdir
 	err = certs.ClientCert.WriteFile(path.Join(td, cp), path.Join(td, kp), ".")
 	require.NoError(t, err)


### PR DESCRIPTION
Use a unique Common Name for each certificate type when generating
the event handler mTLS certificates, instead of reusing the same
Common Name for all.

Fixes #747