### PR TITLE
TF: fix unset `oidc_connector.spec.max_age`

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -43,7 +43,7 @@ $(BUILDDIR)/terraform-provider-teleport_%: terraform-provider-teleport-v$(VERSIO
 	mv $(BUILDDIR)/terraform-provider-teleport $@
 
 CUSTOM_IMPORTS_TMP_DIR ?= /tmp/protoc-gen-terraform/custom-imports
-PROTOC_GEN_TERRAFORM_VERSION ?= v2.0.1
+PROTOC_GEN_TERRAFORM_VERSION ?= v2.0.2
 PROTOC_GEN_TERRAFORM_EXISTS := $(shell protoc-gen-terraform version 2>&1 >/dev/null | grep 'protoc-gen-terraform $(PROTOC_GEN_TERRAFORM_VERSION)')
 
 .PHONY: gen-tfschema

--- a/terraform/test/fixtures/oidc_connector_without_max_age.tf
+++ b/terraform/test/fixtures/oidc_connector_without_max_age.tf
@@ -1,0 +1,18 @@
+resource "teleport_oidc_connector" "test_max_age" {
+  metadata = {
+    name    = "test_max_age"
+    expires = "2032-10-12T07:20:50Z"
+  }
+
+  spec = {
+    client_id     = "client"
+    client_secret = "value"
+
+    claims_to_roles = [{
+      claim = "test"
+      roles = ["teleport"]
+    }]
+
+    redirect_url = ["https://example.com/redirect"]
+  }
+}

--- a/terraform/test/oidc_connector_test.go
+++ b/terraform/test/oidc_connector_test.go
@@ -168,3 +168,55 @@ func (s *TerraformSuite) TestOIDCConnectorWithoutMaxAge() {
 		},
 	})
 }
+
+func (s *TerraformSuite) TestImportOIDCConnectorWithoutMaxAge() {
+	r := "teleport_oidc_connector"
+	id := "test_import"
+	name := r + "." + id
+
+	oidcConnector := &types.OIDCConnectorV3{
+		Metadata: types.Metadata{
+			Name: id,
+		},
+		Spec: types.OIDCConnectorSpecV3{
+			ClientID:     "Iv1.3386eee92ff932a4",
+			ClientSecret: "secret",
+			ClaimsToRoles: []types.ClaimMapping{
+				{
+					Claim: "test",
+					Roles: []string{"terraform"},
+				},
+			},
+			RedirectURLs: wrappers.Strings{
+				"https://example.com/redirect",
+			},
+		},
+	}
+
+	err := oidcConnector.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	err = s.client.UpsertOIDCConnector(s.Context(), oidcConnector)
+	require.NoError(s.T(), err)
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:        s.terraformConfig + "\n" + `resource "` + r + `" "` + id + `" { }`,
+				ResourceName:  name,
+				ImportState:   true,
+				ImportStateId: id,
+				ImportStateCheck: func(state []*terraform.InstanceState) error {
+					require.Equal(s.T(), state[0].Attributes["kind"], "oidc")
+					require.Equal(s.T(), state[0].Attributes["spec.client_id"], "Iv1.3386eee92ff932a4")
+					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.claim"], "test")
+					require.Equal(s.T(), state[0].Attributes["spec.claims_to_roles.0.roles.0"], "terraform")
+					require.NotContains(s.T(), state[0].Attributes, "spec.max_age")
+
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -27386,9 +27386,10 @@ func CopyOIDCConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravita
 								v.Null = false
 							}
 							if obj.MaxAge == nil {
-								obj.MaxAge = &github_com_gravitational_teleport_api_types.MaxAge{}
+								v.Null = true
+							} else {
+								v.Value = time.Duration(obj.Value)
 							}
-							v.Value = time.Duration(obj.Value)
 							v.Unknown = false
 							tf.Attrs["max_age"] = v
 						}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -26602,10 +26602,12 @@ func CopyOIDCConnectorV3FromTerraform(_ context.Context, tf github_com_hashicorp
 								if !v.Null && !v.Unknown {
 									t = github_com_gravitational_teleport_api_types.Duration(v.Value)
 								}
-								if obj.MaxAge == nil {
-									obj.MaxAge = &github_com_gravitational_teleport_api_types.MaxAge{}
+								if !v.Null && !v.Unknown {
+									if obj.MaxAge == nil {
+										obj.MaxAge = &github_com_gravitational_teleport_api_types.MaxAge{}
+									}
+									obj.Value = t
 								}
-								obj.Value = t
 							}
 						}
 					}


### PR DESCRIPTION
We were initializing the value even when it was not set, resulting in `0s` (the default value for time.Duration).

This PR fixes and only sends the `max_age` to the API is it was set in Terraform file.