### PR TITLE
`event-handler`: Remove `namespace` configuration

### DIFF
--- a/charts/event-handler/README.md
+++ b/charts/event-handler/README.md
@@ -101,7 +101,6 @@ eventHandler:
   storagePath: "/var/lib/teleport/plugins/event-handler/storage"
   timeout: "10s"
   batch: 20
-  namespace: "default"
 
 fluentd:
   url: "https://fluentd.fluentd.svc.cluster.local/events.log"
@@ -170,13 +169,6 @@ The following values can be set for the Helm chart:
   <tr>
     <td><code>eventHandler.batch</code></td>
     <td>Maximum number of events fetched from Teleport in one request</td>
-    <td>string</td>
-    <td><code>20</code></td>
-    <td>no</td>
-  </tr>
-  <tr>
-    <td><code>eventHandler.namespace</code></td>
-    <td>Namespace where the events are received from</td>
     <td>string</td>
     <td><code>20</code></td>
     <td>no</td>

--- a/charts/event-handler/templates/configmap.yaml
+++ b/charts/event-handler/templates/configmap.yaml
@@ -9,7 +9,6 @@ data:
     storage = {{ .Values.eventHandler.storagePath | toJson }}
     timeout = {{ .Values.eventHandler.timeout | toJson }}
     batch = {{ .Values.eventHandler.batch }}
-    namespace = {{ .Values.eventHandler.namespace | toJson }}
 
     [teleport]
     addr = "{{ .Values.teleport.address }}"

--- a/charts/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -6,7 +6,6 @@ should match the snapshot:
         storage = "/var/lib/teleport/plugins/event-handler/storage"
         timeout = "10s"
         batch = 20
-        namespace = "default"
 
         [teleport]
         addr = "teleport.example.com:1234"

--- a/charts/event-handler/values.schema.json
+++ b/charts/event-handler/values.schema.json
@@ -307,21 +307,18 @@
             "default": {
                 "storagePath": "/var/lib/teleport/plugins/event-handler/storage",
                 "timeout": "10s",
-                "batch": 20,
-                "namespace": "default"
+                "batch": 20
             },
             "examples": [
                 {
                     "storagePath": "/var/lib/teleport/plugins/event-handler/storage",
                     "timeout": "10s",
-                    "batch": 20,
-                    "namespace": "default"
+                    "batch": 20
                 }
             ],
             "required": [
                 "storagePath",
-                "timeout",
-                "namespace"
+                "timeout"
             ],
             "properties": {
                 "storagePath": {
@@ -342,11 +339,6 @@
                     "$id": "#/properties/eventHandler/properties/batch",
                     "type": "number",
                     "default": 20
-                },
-                "namespace": {
-                    "$id": "#/properties/eventHandler/properties/namespace",
-                    "type": "string",
-                    "default": "default"
                 }
             },
             "additionalProperties": true

--- a/charts/event-handler/values.yaml
+++ b/charts/event-handler/values.yaml
@@ -14,7 +14,6 @@ eventHandler:
   storagePath: "/var/lib/teleport/plugins/event-handler/storage"
   timeout: "10s"
   batch: 20
-  namespace: "default"
 
 fluentd:
   url: ""

--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -212,7 +212,6 @@ The generated `teleport-event-handler.toml` would contain the following plugin c
 storage = "./storage" # Plugin will save it's state here
 timeout = "10s"
 batch = 20
-namespace = "default"
 
 [fluentd]
 cert = "client.crt"
@@ -293,7 +292,6 @@ You may specify configuration options via command line arguments, environment va
 | fluentd-key         | Fluentd TLS key file                                | FDFWD_FLUENTD_KEY         |
 | storage             | Storage directory                                   | FDFWD_STORAGE             |
 | batch               | Fetch batch size                                    | FDFWD_BATCH               |
-| namespace           | Events namespace                                    | FDFWD_NAMESPACE           |
 | types               | Comma-separated list of event types to forward      | FDFWD_TYPES               |
 | skip-session-types  | Comma-separated list of session event types to skip | FDFWD_SKIP_SESSION_TYPES  |
 | start-time          | Minimum event time (RFC3339 format)                 | FDFWD_START_TIME          |

--- a/event-handler/cli.go
+++ b/event-handler/cli.go
@@ -112,9 +112,6 @@ type IngestConfig struct {
 	// BatchSize is a fetch batch size
 	BatchSize int `help:"Fetch batch size" default:"20" env:"FDFWD_BATCH" name:"batch"`
 
-	// Namespace is events namespace
-	Namespace string `help:"Events namespace" default:"default" env:"FDFWD_NAMESPACE"`
-
 	// Types are event types to log
 	Types []string `help:"Comma-separated list of event types to forward" env:"FDFWD_TYPES"`
 
@@ -234,7 +231,6 @@ func (c *StartCmdConfig) Dump(ctx context.Context) {
 
 	// Log configuration variables
 	log.WithField("batch", c.BatchSize).Info("Using batch size")
-	log.WithField("namespace", c.Namespace).Info("Using namespace")
 	log.WithField("types", c.Types).Info("Using type filter")
 	log.WithField("types", c.SkipSessionTypes).Info("Skipping session events of type")
 	log.WithField("value", c.StartTime).Info("Using start time")

--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -214,7 +214,7 @@ func (t *TeleportEventsWatcher) getEvents(ctx context.Context) ([]*auditlogpb.Ev
 		ctx,
 		t.startTime,
 		time.Now().UTC(),
-		t.config.Namespace,
+		"default",
 		t.config.Types,
 		t.config.BatchSize,
 		types.EventOrderAscending,

--- a/event-handler/tpl/teleport-event-handler.toml.tpl
+++ b/event-handler/tpl/teleport-event-handler.toml.tpl
@@ -1,7 +1,6 @@
 storage = "./storage"
 timeout = "10s"
 batch = 20
-namespace = "default"
 
 [forward.fluentd]
 ca = "{{index .CaCertPath}}"


### PR DESCRIPTION
The event-handler plugin still exposes Teleport namespace as a configuration option in the config file.

This appears to be required in the RPC Client to Teleport, but is always set to "default" and doesn't really seem like a fully developed feature inside of Teleport.

This option should probably just be hard coded to "default" inside the plugin and not exposed as an option to end users.

Closes #904 