### PR TITLE
CI: update terraform, teleport and linter versions used in pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ workspace:
 
 steps:
   - name: Run linter
-    image: golangci/golangci-lint:v1.51.2
+    image: golangci/golangci-lint:v1.54.2
     commands:
       - make lint
 
@@ -29,8 +29,8 @@ steps:
       RUNNER_TEMP: /tmp
       TELEPORT_ENTERPRISE_LICENSE:
         from_secret: TELEPORT_ENTERPRISE_LICENSE
-      TERRAFORM_VERSION: 1.4.6-1
-      TELEPORT_VERSION: 13.3.6
+      TERRAFORM_VERSION: 1.5.6-1
+      TELEPORT_VERSION: 13.3.8
     commands:
       - echo Testing plugins against Teleport $TELEPORT_VERSION
       - apt update && apt install -y gnupg software-properties-common
@@ -72,8 +72,8 @@ steps:
     environment:
       GO_VERSION: go1.20.8
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
-      TERRAFORM_VERSION: 1.4.6
-      TERRAFORM_ARCHIVE: terraform_1.4.6_darwin_amd64.zip
+      TERRAFORM_VERSION: 1.5.6
+      TERRAFORM_ARCHIVE: terraform_1.5.6_darwin_amd64.zip
     commands:
       - set -u
       - mkdir -p $TOOLCHAIN_DIR
@@ -86,7 +86,7 @@ steps:
 
   - name: Install Teleport
     environment:
-      TELEPORT_VERSION: 13.3.6
+      TELEPORT_VERSION: 13.3.8
       TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}/toolchains
     commands:
       - set -u
@@ -1405,6 +1405,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 58400da35f98ba776332fd8b7b21c0b01b72bba9b75626b480689785fa1cb567
+hmac: c17310f28e521b2e143130a48fa7b820de102c97bc00564e46212a220e095f1c
 
 ...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.54.2
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -27,16 +27,16 @@ jobs:
         with:
           go-version: '1.20.8'
 
-      - name: Setup Terraform 1.4.6
+      - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: '1.4.6'
+          terraform_version: '1.5.6'
           terraform_wrapper: false
 
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 13.3.6
+          version: 13.3.8
           enterprise: true
 
       - name: make test-terraform

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 13.3.6
+          version: 13.3.8
           enterprise: true
 
       - name: Run unit tests
@@ -63,7 +63,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 13.1.0
+          version: 13.3.8
           enterprise: true
 
       - name: Run unit tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,4 @@
 issues:
-  exclude-rules:
-    - linters:
-      - gosimple
-      text: "S1002: should omit comparison to bool constant"
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0
@@ -22,22 +18,31 @@ linters:
     - revive
     - staticcheck
     - unconvert
-    # Re-add the `unused` linter when this issue is fixed and released in the golangci-lint
-    # https://github.com/dominikh/go-tools/issues/1361
-    # - unused
+    - unused
 
 linters-settings:
   depguard:
-    list-type: denylist
-    include-go-root: true # check against stdlib
-    packages-with-error-message:
-      - io/ioutil: 'use "io" or "os" packages instead'
-      - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
-      - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
-      - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
-      - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
-      - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
-      - go.uber.org/atomic: 'use "sync/atomic" instead'
+    rules:
+      main:
+        deny:
+          - pkg: io/ioutil
+            desc: 'use "io" or "os" packages instead'
+          - pkg: github.com/golang/protobuf
+            desc: 'use "google.golang.org/protobuf"'
+          - pkg: github.com/hashicorp/go-uuid
+            desc: 'use "github.com/google/uuid" instead'
+          - pkg: github.com/pborman/uuid
+            desc: 'use "github.com/google/uuid" instead'
+          - pkg: github.com/siddontang/go-log/log
+            desc: 'use "github.com/sirupsen/logrus" instead'
+          - pkg: github.com/siddontang/go/log
+            desc: 'use "github.com/sirupsen/logrus" instead'
+          - pkg: github.com/tj/assert
+            desc: 'use "github.com/stretchr/testify/assert" instead'
+          - pkg: go.uber.org/atomic
+            desc: 'use "sync/atomic" instead'
+          - pkg: golang.design
+            desc: 'experimental project, not to be confused with official Go packages'
   misspell:
     locale: US
   gci:
@@ -51,11 +56,15 @@ linters-settings:
     allow-unused: true # Enabled because of conditional builds / build tags.
     require-explanation: true
     require-specific: true
+  revive:
+    rules:
+    - name: unused-parameter
+      disabled: true
 output:
   uniq-by-line: false
 
 run:
-  go: '1.19'
+  go: '1.20'
   skip-dirs:
     - (^|/)node_modules/
     - ^api/gen/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport-plugins
 
-go 1.19
+go 1.20
 
 require (
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -94,13 +94,13 @@ release: build
 endif
 	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
 
-TERRAFORM_EXISTS := $(shell terraform -version 2>/dev/null | grep 'Terraform v1.4')
+TERRAFORM_EXISTS := $(shell terraform -version 2>/dev/null | grep 'Terraform v1.5')
 CURRENT_ULIMIT := $(shell ulimit -n)
 
 .PHONY: test
 test: install
 ifndef TERRAFORM_EXISTS
-	@echo "Terraform v1.4+ is not installed (tfenv install 1.4.6 && tfenv use 1.4.6)."
+	@echo "Terraform v1.4+ is not installed (tfenv install 1.5.6 && tfenv use 1.5.6)."
 	terraform -version
 	@exit -1
 endif

--- a/terraform/test/cluster_networking_config_test.go
+++ b/terraform/test/cluster_networking_config_test.go
@@ -50,7 +50,6 @@ func (s *TerraformSuite) TestClusterNetworkingConfig() {
 					resource.TestCheckResourceAttr(name, "kind", "cluster_networking_config"),
 					resource.TestCheckResourceAttr(name, "metadata.labels.example", "no"),
 					resource.TestCheckResourceAttr(name, "spec.client_idle_timeout", "1h"),
-					resource.TestCheckResourceAttr(name, "spec.tunnel_strategy.proxy_peering.agent_connection_count", "5"),
 				),
 			},
 			{

--- a/terraform/test/fixtures/networking_config_1_update.tf
+++ b/terraform/test/fixtures/networking_config_1_update.tf
@@ -8,10 +8,5 @@ resource "teleport_cluster_networking_config" "test" {
 
   spec = {
     client_idle_timeout = "1h"
-    tunnel_strategy = {
-      proxy_peering = {
-        agent_connection_count = 5
-      }
-    }
   }
 }


### PR DESCRIPTION
It looks like our darwin builder has a cloud license, and some network settings can't be changed.
Remove that test case.

![image](https://github.com/gravitational/teleport-plugins/assets/689271/0efce0ff-30e5-44fd-b9ed-42ae60951997)
