### PR TITLE
Update access plugins image to latest base distroless image

### DIFF
--- a/access/Dockerfile
+++ b/access/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base@sha256:03dcbf61f859d0ae4c69c6242c9e5c3d7e1a42e5d3b69eb235e81a5810dd768e
+FROM gcr.io/distroless/base@sha256:46c5b9bd3e3efff512e28350766b54355fce6337a0b44ba3f822ab918eca4520
 ARG ACCESS_PLUGIN
 COPY --from=builder /workspace/access/${ACCESS_PLUGIN}/build/teleport-${ACCESS_PLUGIN} /usr/local/bin/teleport-plugin
 


### PR DESCRIPTION
The current image contains several critical vulnerabilities for OpenSSL, libc and libssl.

Trivy output on current image:

```
public.ecr.aws/gravitational/teleport-plugin-slack:13.3.8 (debian 11.2)

Total: 48 (UNKNOWN: 0, LOW: 12, MEDIUM: 18, HIGH: 11, CRITICAL: 7)

┌───────────┬──────────────────┬──────────┬───────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│  Library  │  Vulnerability   │ Severity │ Installed Version │  Fixed Version   │                            Title                             │
├───────────┼──────────────────┼──────────┼───────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ libc6     │ CVE-2021-33574   │ CRITICAL │ 2.31-13+deb11u2   │ 2.31-13+deb11u3  │ mq_notify does not handle separately allocated thread        │
│           │                  │          │                   │                  │ attributes                                                   │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2021-33574                   │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-23218   │          │                   │                  │ glibc: Stack-based buffer overflow in svcunix_create via     │
│           │                  │          │                   │                  │ long pathnames                                               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-23218                   │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-23219   │          │                   │                  │ glibc: Stack-based buffer overflow in sunrpc clnt_create via │
│           │                  │          │                   │                  │ a long pathname                                              │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-23219                   │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2021-3999    │ HIGH     │                   │ 2.31-13+deb11u4  │ Off-by-one buffer overflow/underflow in getcwd()             │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2021-3999                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-4806    │ MEDIUM   │                   │                  │ potential use-after-free in getaddrinfo()                    │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-4806                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-4813    │          │                   │                  │ potential use-after-free in gaih_inet()                      │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-4813                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2010-4756    │ LOW      │                   │                  │ glibc: glob implementation can cause excessive CPU and       │
│           │                  │          │                   │                  │ memory consumption due to...                                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-4756                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2018-20796   │          │                   │                  │ glibc: uncontrolled recursion in function                    │
│           │                  │          │                   │                  │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2018-20796                   │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010022 │          │                   │                  │ glibc: stack guard protection bypass                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010022                 │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010023 │          │                   │                  │ glibc: running ldd on malicious ELF leads to code execution  │
│           │                  │          │                   │                  │ because of...                                                │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010023                 │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010024 │          │                   │                  │ glibc: ASLR bypass using cache of thread stack and heap      │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010024                 │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010025 │          │                   │                  │ glibc: information disclosure of heap addresses of           │
│           │                  │          │                   │                  │ pthread_created thread                                       │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010025                 │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2019-9192    │          │                   │                  │ glibc: uncontrolled recursion in function                    │
│           │                  │          │                   │                  │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-9192                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2021-43396   │          │                   │ 2.31-13+deb11u3  │ glibc: conversion from ISO-2022-JP-3 with iconv may emit     │
│           │                  │          │                   │                  │ spurious NUL character on...                                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2021-43396                   │
├───────────┼──────────────────┼──────────┼───────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2022-1292    │ CRITICAL │ 1.1.1k-1+deb11u1  │ 1.1.1n-0+deb11u2 │ c_rehash script allows command injection                     │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-1292                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2068    │          │                   │ 1.1.1n-0+deb11u3 │ the c_rehash script allows command injection                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2068                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-0778    │ HIGH     │                   │ 1.1.1k-1+deb11u2 │ Infinite loop in BN_mod_sqrt() reachable when parsing        │
│           │                  │          │                   │                  │ certificates                                                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-0778                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4450    │          │                   │ 1.1.1n-0+deb11u4 │ double free after calling PEM_read_bio_ex                    │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0215    │          │                   │                  │ use-after-free following BIO_new_NDEF                        │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0286    │          │                   │                  │ X.400 address type confusion in X.509 GeneralName            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0464    │          │                   │ 1.1.1n-0+deb11u5 │ Denial of service by excessive resource usage in verifying   │
│           │                  │          │                   │                  │ X509 policy constraints...                                   │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0464                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2021-4160    │ MEDIUM   │                   │ 1.1.1k-1+deb11u2 │ openssl: Carry propagation bug in the MIPS32 and MIPS64      │
│           │                  │          │                   │                  │ squaring procedure                                           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2021-4160                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2097    │          │                   │ 1.1.1n-0+deb11u4 │ AES OCB fails to encrypt some bytes                          │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2097                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4304    │          │                   │                  │ timing attack in RSA Decryption implementation               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0465    │          │                   │ 1.1.1n-0+deb11u5 │ Invalid certificate policies in leaf certificates are        │
│           │                  │          │                   │                  │ silently ignored                                             │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0465                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0466    │          │                   │                  │ Certificate policy check not enabled                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0466                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-2650    │          │                   │                  │ Possible DoS translating ASN.1 object identifiers            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-3446    │          │                   │                  │ Excessive time spent checking DH keys and parameters         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3446                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-3817    │          │                   │                  │ Excessive time spent checking DH q parameter value           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3817                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2007-6755    │ LOW      │                   │                  │ Dual_EC_DRBG: weak pseudo random number generator            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2007-6755                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │                  │ openssl: RSA authentication weakness                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-0928                    │
├───────────┼──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│ openssl   │ CVE-2022-1292    │ CRITICAL │                   │ 1.1.1n-0+deb11u2 │ c_rehash script allows command injection                     │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-1292                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2068    │          │                   │ 1.1.1n-0+deb11u3 │ the c_rehash script allows command injection                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2068                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-0778    │ HIGH     │                   │ 1.1.1k-1+deb11u2 │ Infinite loop in BN_mod_sqrt() reachable when parsing        │
│           │                  │          │                   │                  │ certificates                                                 │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-0778                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4450    │          │                   │ 1.1.1n-0+deb11u4 │ double free after calling PEM_read_bio_ex                    │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0215    │          │                   │                  │ use-after-free following BIO_new_NDEF                        │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0286    │          │                   │                  │ X.400 address type confusion in X.509 GeneralName            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0464    │          │                   │ 1.1.1n-0+deb11u5 │ Denial of service by excessive resource usage in verifying   │
│           │                  │          │                   │                  │ X509 policy constraints...                                   │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0464                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2021-4160    │ MEDIUM   │                   │ 1.1.1k-1+deb11u2 │ openssl: Carry propagation bug in the MIPS32 and MIPS64      │
│           │                  │          │                   │                  │ squaring procedure                                           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2021-4160                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2097    │          │                   │ 1.1.1n-0+deb11u4 │ AES OCB fails to encrypt some bytes                          │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2097                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4304    │          │                   │                  │ timing attack in RSA Decryption implementation               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0465    │          │                   │ 1.1.1n-0+deb11u5 │ Invalid certificate policies in leaf certificates are        │
│           │                  │          │                   │                  │ silently ignored                                             │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0465                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0466    │          │                   │                  │ Certificate policy check not enabled                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0466                    │
│           ├──────────────────┤          │                   │                  ├──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-2650    │          │                   │                  │ Possible DoS translating ASN.1 object identifiers            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-3446    │          │                   │                  │ Excessive time spent checking DH keys and parameters         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3446                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2023-3817    │          │                   │                  │ Excessive time spent checking DH q parameter value           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3817                    │
│           ├──────────────────┼──────────┤                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2007-6755    │ LOW      │                   │                  │ Dual_EC_DRBG: weak pseudo random number generator            │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2007-6755                    │
│           ├──────────────────┤          │                   ├──────────────────┼──────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │                  │ openssl: RSA authentication weakness                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-0928                    │
└───────────┴──────────────────┴──────────┴───────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
```