### PR TITLE
ci: Build darwin tag builds on linux

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -512,13 +512,6 @@ kind: pipeline
 type: exec
 name: tag-build-terraform-darwin
 
-concurrency:
-  limit: 1
-
-platform:
-  os: darwin
-  arch: amd64
-
 trigger:
   event:
     - tag
@@ -547,9 +540,10 @@ steps:
       - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
       - mkdir -p build/
       - go version
-      - make ARCH=amd64 release/terraform
-      - make ARCH=arm64 release/terraform
-      - make ARCH=universal release/terraform
+      - go install github.com/konoui/lipo@latest
+      - make OS=darwin ARCH=amd64 release/terraform
+      - make OS=darwin ARCH=arm64 release/terraform
+      - make OS=darwin ARCH=universal release/terraform
       - find terraform/ -iname "*.tar.gz" -print -exec cp {} build/ \;
       - cd build
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
@@ -749,13 +743,6 @@ kind: pipeline
 type: exec
 name: tag-build-event-handler-darwin
 
-concurrency:
-  limit: 1
-
-platform:
-  os: darwin
-  arch: amd64
-
 trigger:
   event:
     - tag
@@ -783,7 +770,7 @@ steps:
     commands:
       - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
       - mkdir -p build/
-      - make release/event-handler
+      - make OS=darwin ARCH=amd64 release/event-handler
       - find event-handler/ -iname "*.tar.gz" -print -exec cp {} build/ \;
       - cd build
       - for FILE in *.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done
@@ -1406,6 +1393,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 425a71127807e20a715648d0ab87f362c204dcc7dbc986771815dd3082697641
+hmac: 1827b705eb7b214e3ad85b2b5a1dc7ba6ee5f9f5ad0fbf5beb843f718d7c78ad
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -509,7 +509,7 @@ volumes:
 
 ---
 kind: pipeline
-type: exec
+type: kubernetes
 name: tag-build-terraform-darwin
 
 trigger:
@@ -740,7 +740,7 @@ volumes:
 
 ---
 kind: pipeline
-type: exec
+type: kubernetes
 name: tag-build-event-handler-darwin
 
 trigger:
@@ -1393,6 +1393,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: 1827b705eb7b214e3ad85b2b5a1dc7ba6ee5f9f5ad0fbf5beb843f718d7c78ad
+hmac: c3961774798e0204a21e77a2ef051da7b6224c8435a48b676c81ae206335335a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -520,24 +520,9 @@ trigger:
       - refs/tags/terraform-provider-teleport-v*
 
 steps:
-  - name: Install Go Toolchain
-    environment:
-      GO_VERSION: go1.21.1
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-    commands:
-      - set -u
-      - mkdir -p $TOOLCHAIN_DIR
-      - curl --no-progress-meter -O https://dl.google.com/go/$GO_VERSION.darwin-amd64.tar.gz
-      - tar -C  $TOOLCHAIN_DIR -xzf $GO_VERSION.darwin-amd64.tar.gz
-      - rm -rf $GO_VERSION.darwin-amd64.tar.gz
-
   - name: Build artifacts
-    environment:
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-      GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains/go
-      GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains/go/cache
+    image: golang:1.21.1
     commands:
-      - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
       - mkdir -p build/
       - go version
       - go install github.com/konoui/lipo@latest
@@ -550,6 +535,10 @@ steps:
       - ls -l .
 
   - name: Assume AWS Role
+    image: amazon/aws-cli
+    volumes:
+    - name: awsconfig
+      path: /root/.aws
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -557,10 +546,8 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_ROLE:
         from_secret: AWS_ROLE
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
     - aws sts get-caller-identity
-    - export AWS_SHARED_CREDENTIALS_FILE="$TOOLCHAIN_DIR/credentials"
     - |-
         printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
           $(aws sts assume-role \
@@ -568,32 +555,26 @@ steps:
             --role-session-name $(echo "drone-${DRONE_REPO}/${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
             --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
             --output text) \
-            > "$AWS_SHARED_CREDENTIALS_FILE"
+            > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
     - aws sts get-caller-identity
 
   - name: Upload to S3
+    image: amazon/aws-cli
+    volumes:
+    - name: awsconfig
+      path: /root/.aws
     environment:
       AWS_S3_BUCKET:
         from_secret: AWS_S3_BUCKET
       AWS_REGION: us-west-2
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
-      - export AWS_SHARED_CREDENTIALS_FILE="$TOOLCHAIN_DIR/credentials"
       - cd build
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
 
-  - name: Clean up toolchains (post)
-    environment:
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-    when:
-      status:
-      - success
-      - failure
-    commands:
-      - set -u
-      - chmod -R u+rw $TOOLCHAIN_DIR
-      - rm -rf $TOOLCHAIN_DIR
+volumes:
+  - name: awsconfig
+    temp: {}
 
 ---
 kind: pipeline
@@ -751,24 +732,9 @@ trigger:
       - refs/tags/teleport-event-handler-v*
 
 steps:
-  - name: Install Go Toolchain
-    environment:
-      GO_VERSION: go1.21.1
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-    commands:
-      - set -u
-      - mkdir -p $TOOLCHAIN_DIR
-      - curl --no-progress-meter -O https://dl.google.com/go/$GO_VERSION.darwin-amd64.tar.gz
-      - tar -C  $TOOLCHAIN_DIR -xzf $GO_VERSION.darwin-amd64.tar.gz
-      - rm -rf $GO_VERSION.darwin-amd64.tar.gz
-
   - name: Build artifacts
-    environment:
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-      GOPATH: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains/go
-      GOCACHE: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains/go/cache
+    image: golang:1.21.1
     commands:
-      - export PATH=$TOOLCHAIN_DIR/go/bin:$PATH
       - mkdir -p build/
       - make OS=darwin ARCH=amd64 release/event-handler
       - find event-handler/ -iname "*.tar.gz" -print -exec cp {} build/ \;
@@ -777,6 +743,10 @@ steps:
       - ls -l .
 
   - name: Assume AWS Role
+    image: amazon/aws-cli
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
@@ -784,10 +754,8 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_ROLE:
         from_secret: AWS_ROLE
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
     - aws sts get-caller-identity
-    - export AWS_SHARED_CREDENTIALS_FILE="$TOOLCHAIN_DIR/credentials"
     - |-
         printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s" \
           $(aws sts assume-role \
@@ -795,33 +763,26 @@ steps:
             --role-session-name $(echo "drone-${DRONE_REPO}/${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
             --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
             --output text) \
-            > "$AWS_SHARED_CREDENTIALS_FILE"
+            > /root/.aws/credentials
     - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
     - aws sts get-caller-identity
 
   - name: Upload to S3
+    image: amazon/aws-cli
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
     environment:
       AWS_S3_BUCKET:
         from_secret: AWS_S3_BUCKET
       AWS_REGION: us-west-2
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
     commands:
-      - export AWS_SHARED_CREDENTIALS_FILE="$TOOLCHAIN_DIR/credentials"
       - cd build
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport-plugins/tag/${DRONE_TAG}/
 
-  - name: Clean up toolchains (post)
-    environment:
-      TOOLCHAIN_DIR: /tmp/teleport-plugins/${DRONE_BUILD_NUMBER}-${DRONE_BUILD_CREATED}-${DRONE_STAGE_NAME}/toolchains
-    when:
-      status:
-      - success
-      - failure
-    commands:
-      - set -u
-      - chmod -R u+rw $TOOLCHAIN_DIR
-      - rm -rf $TOOLCHAIN_DIR
-
+volumes:
+  - name: awsconfig
+    temp: {}
 ---
 kind: pipeline
 type: kubernetes
@@ -1393,6 +1354,6 @@ steps:
         from_secret: PRODUCTION_TERRAFORM_REGISTRY_SIGNING_KEY
 ---
 kind: signature
-hmac: c3961774798e0204a21e77a2ef051da7b6224c8435a48b676c81ae206335335a
+hmac: a7975ebf8fec0ac0df356da35309c6c1ae076b5e51226f86b96dfa9ac2ad4936
 
 ...


### PR DESCRIPTION
Build the tag builds of the terraform provider and event-handler for
darwin on linux. These are pure Go programs so can easily be
cross-compiled using GOOS/GOARCH. The "tricky" part is the universal
binary, solved by using https://github.com/konoui/lipo - a Go version of
lipo (the tool that constructs universal binaries) that can run on
Linux.