### PR TITLE
Stop publishing remaining plugins to quay.io (and remove all references to)

### DIFF
--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -19,7 +19,6 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 DOCKER_NAME = teleport-plugin-email
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=email --build-arg GITREF=$(GITREF)
 
 .PHONY: $(BINARY)
@@ -62,13 +61,7 @@ docker-push:
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -19,7 +19,6 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 DOCKER_NAME = teleport-plugin-jira
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=jira --build-arg GITREF=$(GITREF)
 
 .PHONY: $(BINARY)
@@ -62,13 +61,7 @@ docker-push:
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -19,7 +19,6 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 DOCKER_NAME = teleport-plugin-mattermost
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=mattermost --build-arg GITREF=$(GITREF)
 
 .PHONY: $(BINARY)
@@ -62,13 +61,7 @@ docker-push:
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:

--- a/access/msteams/README.md
+++ b/access/msteams/README.md
@@ -29,15 +29,15 @@ $ ./install
 
 ### Docker Image
 ```bash
-$ docker pull quay.io/gravitational/teleport-plugin-msteams:9.0.2
+$ docker pull public.ecr.aws/gravitational/teleport-plugin-msteams:9.0.2
 ```
 
 ```bash
-$ docker run quay.io/gravitational/teleport-plugin-msteams:9.0.2 version
+$ docker run public.ecr.aws/gravitational/teleport-plugin-msteams:9.0.2 version
 teleport-msteams v9.0.2 git:teleport-msteams-v9.0.2-0-g9e149895 go1.17.8
 ```
 
-For a list of available tags, visit [https://quay.io/](https://quay.io/repository/gravitational/teleport-plugin-msteams?tab=tags)
+For a list of available tags, visit [https://gallery.ecr.aws/](https://gallery.ecr.aws/gravitational/teleport-plugin-msteams)
 
 ### Building from source
 
@@ -168,7 +168,7 @@ $ teleport-msteams start -c ~/msteams/teleport-msteams.toml
 or with docker:
 
 ```bash
-$ docker run -v <path/to/config>:~/msteams/teleport-msteams.toml quay.io/gravitational/teleport-plugin-msteams:9.0.2 start
+$ docker run -v <path/to/config>:~/msteams/teleport-msteams.toml public.ecr.aws/gravitational/teleport-plugin-msteams:9.0.2 start
 ```
 
 ## Usage

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -19,7 +19,6 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 DOCKER_NAME = teleport-plugin-pagerduty
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=pagerduty --build-arg GITREF=$(GITREF)
 
 .PHONY: $(BINARY)
@@ -62,13 +61,7 @@ docker-push:
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -19,7 +19,6 @@ RELEASE_MESSAGE = "Building with GOOS=$(OS) GOARCH=$(ARCH)."
 DOCKER_NAME = teleport-plugin-slack
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg ACCESS_PLUGIN=slack --build-arg GITREF=$(GITREF)
 
 .PHONY: $(BINARY)
@@ -62,13 +61,7 @@ docker-push: ## Push docker image with the plugin.
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,11 +7,11 @@ SRCDIR ?= /go/src/github.com/gravitational/teleport-plugins
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 
 # Teleport Enterprise Binary release name. Can be any teleport
-# enterprise version, but has to be available on get.gravitational.com
-RELEASE ?= teleport-ent-v6.0.2-linux-amd64-bin
+# enterprise version, but has to be available on cdn.teleport.dev
+RELEASE ?= teleport-ent-v14.0.0-linux-amd64-bin
 
 RUNTIME ?= go1.21.1
-BBOX ?= quay.io/gravitational/teleport-buildbox:$(RUNTIME)
+BBOX ?= public.ecr.aws/gravitational/teleport-buildbox:$(RUNTIME)
 
 # Teleport CLI and plugins CLI flags to pass to them on start
 # This is used in insecure-up and debug to pass

--- a/docker/plugins/Dockerfile
+++ b/docker/plugins/Dockerfile
@@ -1,6 +1,6 @@
 # Defines Teleport Slack image, based on Teleport OSS image.
-ARG RUNTIME="go1.16.2"
-ARG BBOX="quay.io/gravitational/teleport-buildbox"
+ARG RUNTIME="go1.21.1"
+ARG BBOX="public.ecr.aws/gravitational/teleport-buildbox"
 FROM $BBOX:$RUNTIME
 
 RUN apt-get update

--- a/docker/teleport/Dockerfile
+++ b/docker/teleport/Dockerfile
@@ -1,10 +1,10 @@
 # This image builds a Docker image with Teleport Enterprise.
 FROM teleport:latest
 
-ARG RELEASE="teleport-ent-v6.0.0-alpha.2-linux-amd64-bin"
+ARG RELEASE="teleport-ent-v14.0.0-linux-amd64-bin"
 
 # Install Teleport
 RUN (cd /teleport;\
-      curl -L https://get.gravitational.com/$RELEASE.tar.gz | tar -xz ;\
+      curl -L https://cdn.teleport.dev/$RELEASE.tar.gz | tar -xz ;\
       ./teleport-ent/install)
 

--- a/event-handler/Makefile
+++ b/event-handler/Makefile
@@ -28,7 +28,6 @@ IDENTITY_FILE=example/keys/identity
 DOCKER_NAME=teleport-plugin-event-handler
 DOCKER_IMAGE = 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_IMAGE_ECR_PUBLIC = public.ecr.aws/gravitational/$(DOCKER_NAME):$(VERSION)
-DOCKER_IMAGE_QUAY = quay.io/gravitational/$(DOCKER_NAME):$(VERSION)
 DOCKER_BUILD_ARGS = --build-arg GO_VERSION=${GO_VERSION} --build-arg GITREF=$(GITREF)
 
 RELEASE_NAME = teleport-event-handler
@@ -66,13 +65,7 @@ docker-push:
 	docker push ${DOCKER_IMAGE}
 
 .PHONY: docker-promote
-docker-promote: docker-promote-quay docker-promote-ecr-public
-
-.PHONY: docker-promote-quay
-docker-promote-quay:
-	docker pull ${DOCKER_IMAGE} && \
-	docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_QUAY} && \
-	docker push ${DOCKER_IMAGE_QUAY}
+docker-promote: docker-promote-ecr-public
 
 .PHONY: docker-promote-ecr-public
 docker-promote-ecr-public:


### PR DESCRIPTION
Several old plugins were still being published to quay.io, even though we deprecated that quite a while ago. Stop publishing, and remove all references to quay.io throughout the teleport-plugins repository.