### PR TITLE
Update base docker images to use Debian 12 distroless `static` image

### DIFF
--- a/access/Dockerfile
+++ b/access/Dockerfile
@@ -1,7 +1,8 @@
 # Build the plugin binary
 ARG GO_VERSION
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
-FROM golang:${GO_VERSION}-bullseye as builder
+FROM golang:${GO_VERSION}-bookworm as builder
 
 ARG ACCESS_PLUGIN
 ARG GITREF
@@ -22,7 +23,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base@sha256:03dcbf61f859d0ae4c69c6242c9e5c3d7e1a42e5d3b69eb235e81a5810dd768e
+FROM $BASE_IMAGE
 ARG ACCESS_PLUGIN
 COPY --from=builder /workspace/access/${ACCESS_PLUGIN}/build/teleport-${ACCESS_PLUGIN} /usr/local/bin/teleport-plugin
 

--- a/event-handler/Dockerfile
+++ b/event-handler/Dockerfile
@@ -1,7 +1,8 @@
 # Build the plugin binary
 ARG GO_VERSION
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
-FROM golang:${GO_VERSION}-bullseye as builder
+FROM golang:${GO_VERSION}-bookworm as builder
 
 ARG GITREF
 
@@ -21,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base@sha256:03dcbf61f859d0ae4c69c6242c9e5c3d7e1a42e5d3b69eb235e81a5810dd768e
+FROM $BASE_IMAGE
 
 COPY --from=builder /workspace/event-handler/build/teleport-event-handler /usr/local/bin/teleport-event-handler
 

--- a/event-handler/build.assets/Dockerfile
+++ b/event-handler/build.assets/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VER
-FROM golang:${GO_VER}-bullseye
+FROM golang:${GO_VER}-bookworm
 
 ARG UID
 ARG GID


### PR DESCRIPTION
Instead of chasing ever-changing commit hashes, just use the apppropriate tag for the distroless image. This aligns things to how `teleport` is handled (https://github.com/gravitational/teleport/pull/31620).

Additionally, standardize on Debian 12 for everything (instead of a mix of 11 and 12). Also, use `static` over `base`. This means no `glibc` or `libssl`, which should be fine for these plugins.

Alternative to #924 and #915.