### PR TITLE
Compile plugins as static (`CGO_ENABLED=0`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,9 @@ access-msteams:
 access-pagerduty:
 	$(MAKE) -C access/pagerduty
 
-.PHONY: access-example
-access-example:
-	go build -o build/access-example ./access/example
-
 .PHONY: access-email
 access-email:
-	go build -o build/access-email ./access/email
+	$(MAKE) -C access/email
 
 # Build specific access plugin with docker
 .PHONY: docker-build-access-%
@@ -288,6 +284,7 @@ update-goversion:
 	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/pagerduty/Makefile
 	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' access/email/Makefile
 	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' event-handler/Makefile
+	$(SED) '2s/.*/GO_VERSION=$(GOVERSION)/' event-handler/build.assets/Makefile
 	$(SED) 's/^RUNTIME ?= go.*/RUNTIME ?= go$(GOVERSION)/' docker/Makefile
 	$(SED) 's/Setup Go .*/Setup Go $(GOVERSION)/g' .github/workflows/unit-tests.yaml
 	$(SED) 's/Setup Go .*/Setup Go $(GOVERSION)/g' .github/workflows/terraform-tests.yaml

--- a/README.md
+++ b/README.md
@@ -12,15 +12,6 @@ which can be used for writing plugins. More info can be found in
 [access/README.md](./access/README.md), including instructions on how to
 properly provision necessary certificates.
 
-### API Example
-
-The [access/example](./access/example) plugin automatically approves access
-requests based on a user whitelist. This is a good place to start if you are
-trying to understand how to use the [`access`](./access) API.
-
-Use `make access-example` to build the plugin and
-`./build/access-example configure` to print out a sample configuration file.
-
 ### Slack
 
 [See setup instructions on Teleport's website](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-slack/)

--- a/access/discord/Makefile
+++ b/access/discord/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*discord*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/email/Makefile
+++ b/access/email/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*email*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/jira/Makefile
+++ b/access/jira/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*jira*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/mattermost/Makefile
+++ b/access/mattermost/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*mattermost*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/msteams/Makefile
+++ b/access/msteams/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*msteams*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/pagerduty/Makefile
+++ b/access/pagerduty/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*pagerduty*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/access/slack/Makefile
+++ b/access/slack/Makefile
@@ -7,7 +7,7 @@ GITTAG=v$(VERSION)
 GITREF ?= $(shell git describe --dirty --long --tags --match '*slack*')
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags "-w -s -X main.Gitref=$(GITREF) -X main.Version=$(VERSION)"
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/event-handler/build.assets/Dockerfile
+++ b/event-handler/build.assets/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VER
-FROM golang:${GO_VER}-bookworm
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-bookworm
 
 ARG UID
 ARG GID

--- a/event-handler/build.assets/Makefile
+++ b/event-handler/build.assets/Makefile
@@ -2,7 +2,7 @@ LOCALDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 TOP ?= $(abspath $(LOCALDIR)/../..)
 SRCDIR=/go/src/github.com/gravitational/teleport-plugins/event-handler
 VERSION=0.0.1
-CGOFLAG ?= CGO_ENABLED=1
+CGOFLAG ?= CGO_ENABLED=0
 BUILDDIR=$(TOP)/build
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
@@ -19,10 +19,10 @@ DOCKERFLAGS := --rm \
 
 BUILDFORHOST := -e OS=$(OS) \
 	-e ARCH=$(ARCH) \
-	-e CGOFLAG="CGO_ENABLED=0"
+	-e CGOFLAG=$(CGOFLAG)
 
 DOCKERPULLFLAGS ?= --pull
-GO_VER = 1.18
+GO_VERSION = 1.21.1
 
 NOROOT=-u $$(id -u):$$(id -g)
 BINDIR=/usr/local/bin
@@ -30,7 +30,7 @@ BINDIR=/usr/local/bin
 .PHONY: buildbox
 buildbox:
 	docker build \
-		--build-arg GO_VER=$(GO_VER) \
+		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg UID=$(shell id -u) \
 		--build-arg GID=$(shell id -g) \
 		--build-arg ARCH=$(ARCH) \


### PR DESCRIPTION
The change to distroless static in #928 broke plugin binaries, as the distroless image doesn't have glibc. However, there's no reason for the plugins to need glibc, so just change them to all `CGO_ENABLED=0`.

Additionally, some minor fixes:
* Change one place where `GO_VERSION` wasn't properly set/updated.
* Correct build process for `access/email`.
* Remove reference to previously removed `access/example`.

Fixes #935.