### PR TITLE
Relax mandatory FluentD's key and cert

### DIFF
--- a/event-handler/cli.go
+++ b/event-handler/cli.go
@@ -38,10 +38,10 @@ type FluentdConfig struct {
 	FluentdSessionURL string `help:"fluentd session url" required:"true" env:"FDFWD_FLUENTD_SESSION_URL"`
 
 	// FluentdCert is a path to fluentd cert
-	FluentdCert string `help:"fluentd TLS certificate file" required:"true" type:"existingfile" env:"FDWRD_FLUENTD_CERT"`
+	FluentdCert string `help:"fluentd TLS certificate file" type:"existingfile" env:"FDWRD_FLUENTD_CERT"`
 
 	// FluentdKey is a path to fluentd key
-	FluentdKey string `help:"fluentd TLS key file" required:"true" type:"existingfile" env:"FDWRD_FLUENTD_KEY"`
+	FluentdKey string `help:"fluentd TLS key file" type:"existingfile" env:"FDWRD_FLUENTD_KEY"`
 
 	// FluentdCA is a path to fluentd CA
 	FluentdCA string `help:"fluentd TLS CA file" type:"existingfile" env:"FDWRD_FLUENTD_CA"`


### PR DESCRIPTION
There are cases where the upstream service uses other CA certificates and shares it with other components. When this happens, it's not possible to configure fluentd to use mTLS.

This commit relaxes the mandatory cert-key usage for fluentD.