### PR TITLE
terraform: add custom type to access list notification start field

### DIFF
--- a/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/terraform/protoc-gen-terraform-accesslist.yaml
@@ -71,3 +71,4 @@ custom_types:
   "AccessList.header.metadata.expires": Timestamp
   "AccessList.spec.audit.next_audit_date": Timestamp
   "AccessList.spec.audit.frequency": Duration
+  "AccessList.spec.audit.notifications.start": Duration


### PR DESCRIPTION
Add a custom type for `AccessList.spec.audit.notifications.start` as
`Duration` so we can generate correct code for the Notifications
message.

This field was added in PR gravitational/teleport#33373.

Link: https://github.com/gravitational/teleport/pull/33373