### PR TITLE
fix leaking go-routines in event-handler watcher

### DIFF
--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -281,7 +281,7 @@ func (t *TeleportEventsWatcher) Events(ctx context.Context) (chan *TeleportEvent
 				err := t.fetch(ctx)
 				if err != nil {
 					e <- trace.Wrap(err)
-					continue
+					break
 				}
 
 				// If there is still nothing new on current page, sleep


### PR DESCRIPTION
## Description
We had a misconfiguration that broke the communication between the `event-handler` and `teleport`, which in our case lead to the memory to quickly grow to unreasonable values.

Upon further inspection, we believe that this was due to the fact that the `Events` call is creating a go-routine that is not terminating when the last event on a page was processed and calling `fetch` returns an error. Since in our case the error returned to the `EventsJob` was considered a connetion problem, this means that `Events` would be called yet again, leading to go-routines that would not exit until the connetion issue was fixed being continuously spawned.

This PR attempts to fix that

## Additional Info
Memory:
![image](https://github.com/gravitational/teleport-plugins/assets/7035110/658a9490-581d-4063-aa34-477a51872d87)


Logs:
```
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
2023-10-12T21:35:46+01:00       Stack Trace:
2023-10-12T21:35:46+01:00       Original Error: *trace.TraceErr breaker is tripped
2023-10-12T21:35:46+01:00       ERROR REPORT:
2023-10-12T21:35:46+01:00       ERRO   Failed to connect to Teleport Auth server. Reconnecting... error:[
2023-10-12T21:35:46+01:00       ERRO   Error ingesting Audit Log err:breaker is tripped event-handler/events_job.go:96
2023-10-12T21:35:46+01:00       User Message: breaker is tripped] event-handler/events_job.go:69
2023-10-12T21:35:46+01:00               /usr/local/go/src/runtime/asm_amd64.s:1598 runtime.goexit
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:281 main.(*TeleportEventsWatcher).Events.func1
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:141 main.(*TeleportEventsWatcher).fetch
2023-10-12T21:35:46+01:00               /workspace/event-handler/teleport_events_watcher.go:213 main.(*TeleportEventsWatcher).getEvents
2023-10-12T21:35:46+01:00               /go/pkg/mod/github.com/gravitational/teleport/api@v0.0.0-20230825181643-42843879008e/client/client.go:2227 github.com/gravitational/teleport/api/client.(*Client).SearchUnstructuredEvents
```