### PR TITLE
Terraform Provider: organize imports of generated code

### DIFF
--- a/terraform/gen/main.go
+++ b/terraform/gen/main.go
@@ -373,6 +373,7 @@ var (
 		Kind:                  "device",
 		ID:                    "trustedDevice.Metadata.Name",
 		HasStaticID:           true,
+		SchemaPackage:         "schemav1",
 		SchemaPackagePath:     "github.com/gravitational/teleport-plugins/terraform/tfschema/devicetrust/v1",
 		IsPlainStruct:         true,
 		UUIDMetadataName:      true,
@@ -477,7 +478,24 @@ func generate(p payload, tpl, outFile string) {
 		log.Fatal(err)
 	}
 
-	t, err := template.ParseFiles(path.Join("gen", tpl))
+	funcs := template.FuncMap{
+		"schemaImport": func(p payload) string {
+			if p.SchemaPackage == "tfschema" {
+				return `"` + p.SchemaPackagePath + `"`
+			}
+
+			return p.SchemaPackage + ` "` + p.SchemaPackagePath + `"`
+		},
+		"protoImport": func(p payload) string {
+			if p.ConvertPackagePath != "" {
+				return "convert" + ` "` + p.ConvertPackagePath + `"`
+			}
+
+			return p.ProtoPackage + ` "` + p.ProtoPackagePath + `"`
+		},
+	}
+
+	t, err := template.New(p.Name).Funcs(funcs).ParseFiles(path.Join("gen", tpl))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/terraform/gen/plural_data_source.go.tpl
+++ b/terraform/gen/plural_data_source.go.tpl
@@ -20,20 +20,16 @@ package provider
 import (
 	"context"
 
+	{{ if not .IsPlainStruct }}
+    {{- protoImport . }}
+    {{ end }}
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	{{.SchemaPackage}} "{{.SchemaPackagePath}}"
-	{{if not .IsPlainStruct -}}
-	{{- if .ConvertPackagePath}}
-	convert "{{.ConvertPackagePath}}"
-	{{ else }}
-	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
-	{{- end}}
-	{{end -}}
-	"github.com/gravitational/trace"
+	{{ schemaImport . }}
 )
 
 // dataSourceTeleport{{.Name}}Type is the data source metadata type

--- a/terraform/gen/plural_resource.go.tpl
+++ b/terraform/gen/plural_resource.go.tpl
@@ -19,31 +19,30 @@ package provider
 
 import (
 	"context"
+{{- if .RandomMetadataName }}
+    "crypto/rand"
+    "encoding/hex"
+{{- end }}
 	"fmt"
-{{- if .RandomMetadataName}}
-	"crypto/rand"
-	"encoding/hex"
-{{- end}}
-{{- if .UUIDMetadataName}}
-	"github.com/google/uuid"
-{{- end}}
-{{- range $i, $a := .ExtraImports}}
+{{- range $i, $a := .ExtraImports }}
 	"{{$a}}"
-{{- end}}
-
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
+{{- end }}
+{{ if .UUIDMetadataName }}
+	"github.com/google/uuid"
+{{- end }}
 	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
-	{{.SchemaPackage}} "{{.SchemaPackagePath}}"
-{{- if .ConvertPackagePath}}
-	convert "{{.ConvertPackagePath}}"
-{{- end}}
+	{{ if .ConvertPackagePath -}}
+    convert "{{.ConvertPackagePath}}"
+    {{- end}}
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	{{ schemaImport . }}
 )
 
 // resourceTeleport{{.Name}}Type is the resource metadata type

--- a/terraform/gen/singular_data_source.go.tpl
+++ b/terraform/gen/singular_data_source.go.tpl
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	{{ if not .IsPlainStruct }}
+    {{- protoImport . }}
+    {{- end }}
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	{{.SchemaPackage}} "{{.SchemaPackagePath}}"
-	{{if not .IsPlainStruct -}}
-	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
-	{{end -}}
-	"github.com/gravitational/trace"
+	{{ schemaImport . }}
 )
 
 // dataSourceTeleport{{.Name}}Type is the data source metadata type

--- a/terraform/gen/singular_resource.go.tpl
+++ b/terraform/gen/singular_resource.go.tpl
@@ -24,15 +24,15 @@ import (
 	 "math"
 {{- end}}
 
+	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
+	"github.com/gravitational/teleport/integrations/lib/backoff"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
-	{{.SchemaPackage}} "{{.SchemaPackagePath}}"
-	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	{{ schemaImport . }}
 )
 
 // resourceTeleport{{.Name}}Type is the resource metadata type

--- a/terraform/provider/data_source_teleport_access_list.go
+++ b/terraform/provider/data_source_teleport_access_list.go
@@ -20,16 +20,15 @@ package provider
 import (
 	"context"
 
+	convert "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/accesslist/v1"
-	
-	convert "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
-	
-	"github.com/gravitational/trace"
 )
 
 // dataSourceTeleportAccessListType is the data source metadata type

--- a/terraform/provider/data_source_teleport_app.go
+++ b/terraform/provider/data_source_teleport_app.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportAppType is the data source metadata type

--- a/terraform/provider/data_source_teleport_auth_preference.go
+++ b/terraform/provider/data_source_teleport_auth_preference.go
@@ -20,13 +20,13 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportAuthPreferenceType is the data source metadata type

--- a/terraform/provider/data_source_teleport_cluster_maintenance_config.go
+++ b/terraform/provider/data_source_teleport_cluster_maintenance_config.go
@@ -20,13 +20,13 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportClusterMaintenanceConfigType is the data source metadata type

--- a/terraform/provider/data_source_teleport_cluster_networking_config.go
+++ b/terraform/provider/data_source_teleport_cluster_networking_config.go
@@ -20,13 +20,13 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportClusterNetworkingConfigType is the data source metadata type

--- a/terraform/provider/data_source_teleport_database.go
+++ b/terraform/provider/data_source_teleport_database.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportDatabaseType is the data source metadata type

--- a/terraform/provider/data_source_teleport_device_trust.go
+++ b/terraform/provider/data_source_teleport_device_trust.go
@@ -20,13 +20,14 @@ package provider
 import (
 	"context"
 
+	
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema/devicetrust/v1"
-	"github.com/gravitational/trace"
+	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/devicetrust/v1"
 )
 
 // dataSourceTeleportDeviceV1Type is the data source metadata type
@@ -39,7 +40,7 @@ type dataSourceTeleportDeviceV1 struct {
 
 // GetSchema returns the data source schema
 func (r dataSourceTeleportDeviceV1Type) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
-	return tfschema.GenSchemaDeviceV1(ctx)
+	return schemav1.GenSchemaDeviceV1(ctx)
 }
 
 // NewDataSource creates the empty data source
@@ -67,7 +68,7 @@ func (r dataSourceTeleportDeviceV1) Read(ctx context.Context, req tfsdk.ReadData
     var state types.Object
 	trustedDevice := trustedDeviceI
 	
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
+	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/data_source_teleport_github_connector.go
+++ b/terraform/provider/data_source_teleport_github_connector.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportGithubConnectorType is the data source metadata type

--- a/terraform/provider/data_source_teleport_login_rule.go
+++ b/terraform/provider/data_source_teleport_login_rule.go
@@ -20,13 +20,14 @@ package provider
 import (
 	"context"
 
+	
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/loginrule/v1"
-	"github.com/gravitational/trace"
 )
 
 // dataSourceTeleportLoginRuleType is the data source metadata type

--- a/terraform/provider/data_source_teleport_oidc_connector.go
+++ b/terraform/provider/data_source_teleport_oidc_connector.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportOIDCConnectorType is the data source metadata type

--- a/terraform/provider/data_source_teleport_okta_import_rule.go
+++ b/terraform/provider/data_source_teleport_okta_import_rule.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportOktaImportRuleType is the data source metadata type

--- a/terraform/provider/data_source_teleport_provision_token.go
+++ b/terraform/provider/data_source_teleport_provision_token.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportProvisionTokenType is the data source metadata type

--- a/terraform/provider/data_source_teleport_role.go
+++ b/terraform/provider/data_source_teleport_role.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportRoleType is the data source metadata type

--- a/terraform/provider/data_source_teleport_saml_connector.go
+++ b/terraform/provider/data_source_teleport_saml_connector.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportSAMLConnectorType is the data source metadata type

--- a/terraform/provider/data_source_teleport_session_recording_config.go
+++ b/terraform/provider/data_source_teleport_session_recording_config.go
@@ -20,13 +20,13 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportSessionRecordingConfigType is the data source metadata type

--- a/terraform/provider/data_source_teleport_trusted_cluster.go
+++ b/terraform/provider/data_source_teleport_trusted_cluster.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportTrustedClusterType is the data source metadata type

--- a/terraform/provider/data_source_teleport_user.go
+++ b/terraform/provider/data_source_teleport_user.go
@@ -20,15 +20,15 @@ package provider
 import (
 	"context"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+    
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	
-	apitypes "github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // dataSourceTeleportUserType is the data source metadata type

--- a/terraform/provider/resource_teleport_access_list.go
+++ b/terraform/provider/resource_teleport_access_list.go
@@ -21,17 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	accesslist "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
-	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/accesslist/v1"
 	convert "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/accesslist/v1"
 )
 
 // resourceTeleportAccessListType is the resource metadata type

--- a/terraform/provider/resource_teleport_app.go
+++ b/terraform/provider/resource_teleport_app.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportAppType is the resource metadata type

--- a/terraform/provider/resource_teleport_auth_preference.go
+++ b/terraform/provider/resource_teleport_auth_preference.go
@@ -21,15 +21,15 @@ import (
 	"context"
 	"fmt"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/backoff"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportAuthPreferenceType is the resource metadata type

--- a/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 	 "math"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/backoff"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportClusterMaintenanceConfigType is the resource metadata type

--- a/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -21,15 +21,15 @@ import (
 	"context"
 	"fmt"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/backoff"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportClusterNetworkingConfigType is the resource metadata type

--- a/terraform/provider/resource_teleport_database.go
+++ b/terraform/provider/resource_teleport_database.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportDatabaseType is the resource metadata type

--- a/terraform/provider/resource_teleport_device_trust.go
+++ b/terraform/provider/resource_teleport_device_trust.go
@@ -20,18 +20,19 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/uuid"
-
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema/devicetrust/v1"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/devicetrust/v1"
 )
 
 // resourceTeleportDeviceV1Type is the resource metadata type
@@ -44,7 +45,7 @@ type resourceTeleportDeviceV1 struct {
 
 // GetSchema returns the resource schema
 func (r resourceTeleportDeviceV1Type) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
-	return tfschema.GenSchemaDeviceV1(ctx)
+	return schemav1.GenSchemaDeviceV1(ctx)
 }
 
 // NewResource creates the empty resource
@@ -69,7 +70,7 @@ func (r resourceTeleportDeviceV1) Create(ctx context.Context, req tfsdk.CreateRe
 	}
 
 	trustedDevice := &apitypes.DeviceV1{}
-	diags = tfschema.CopyDeviceV1FromTerraform(ctx, plan, trustedDevice)
+	diags = schemav1.CopyDeviceV1FromTerraform(ctx, plan, trustedDevice)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -134,7 +135,7 @@ func (r resourceTeleportDeviceV1) Create(ctx context.Context, req tfsdk.CreateRe
 	
 	trustedDevice = trustedDeviceResource
 
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
+	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -176,7 +177,7 @@ func (r resourceTeleportDeviceV1) Read(ctx context.Context, req tfsdk.ReadResour
 		return
 	}
 	trustedDevice := trustedDeviceI
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
+	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -204,7 +205,7 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 	}
 
 	trustedDevice := &apitypes.DeviceV1{}
-	diags = tfschema.CopyDeviceV1FromTerraform(ctx, plan, trustedDevice)
+	diags = schemav1.CopyDeviceV1FromTerraform(ctx, plan, trustedDevice)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -254,7 +255,7 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 
 	trustedDeviceResource = trustedDeviceI
 	
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
+	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -304,7 +305,7 @@ func (r resourceTeleportDeviceV1) ImportState(ctx context.Context, req tfsdk.Imp
 		return
 	}
 
-	diags = tfschema.CopyDeviceV1ToTerraform(ctx, trustedDeviceResource, &state)
+	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDeviceResource, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/terraform/provider/resource_teleport_github_connector.go
+++ b/terraform/provider/resource_teleport_github_connector.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportGithubConnectorType is the resource metadata type

--- a/terraform/provider/resource_teleport_login_rule.go
+++ b/terraform/provider/resource_teleport_login_rule.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	loginrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
-	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/loginrule/v1"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	schemav1 "github.com/gravitational/teleport-plugins/terraform/tfschema/loginrule/v1"
 )
 
 // resourceTeleportLoginRuleType is the resource metadata type

--- a/terraform/provider/resource_teleport_oidc_connector.go
+++ b/terraform/provider/resource_teleport_oidc_connector.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportOIDCConnectorType is the resource metadata type

--- a/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/terraform/provider/resource_teleport_okta_import_rule.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportOktaImportRuleType is the resource metadata type

--- a/terraform/provider/resource_teleport_provision_token.go
+++ b/terraform/provider/resource_teleport_provision_token.go
@@ -19,21 +19,22 @@ package provider
 
 import (
 	"context"
+    "crypto/rand"
+    "encoding/hex"
 	"fmt"
-	"crypto/rand"
-	"encoding/hex"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportProvisionTokenType is the resource metadata type

--- a/terraform/provider/resource_teleport_role.go
+++ b/terraform/provider/resource_teleport_role.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportRoleType is the resource metadata type

--- a/terraform/provider/resource_teleport_saml_connector.go
+++ b/terraform/provider/resource_teleport_saml_connector.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportSAMLConnectorType is the resource metadata type

--- a/terraform/provider/resource_teleport_session_recording_config.go
+++ b/terraform/provider/resource_teleport_session_recording_config.go
@@ -21,15 +21,15 @@ import (
 	"context"
 	"fmt"
 
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/backoff"
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
-	"github.com/gravitational/teleport/integrations/lib/backoff"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportSessionRecordingConfigType is the resource metadata type

--- a/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/terraform/provider/resource_teleport_trusted_cluster.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportTrustedClusterType is the resource metadata type

--- a/terraform/provider/resource_teleport_user.go
+++ b/terraform/provider/resource_teleport_user.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	apitypes "github.com/gravitational/teleport/api/types"
-	tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
+	
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport-plugins/terraform/tfschema"
 )
 
 // resourceTeleportUserType is the resource metadata type


### PR DESCRIPTION
Updates code generation to sort and group imports in the same manner as dictated by the gci. This also removes the redundant `tfschema` import alias for packages which do not have custom schema.