### PR TITLE
Terraform: Correctly handle null/unknown conversion to apitypes.BoolOption

### DIFF
--- a/terraform/tfschema/custom_types.go
+++ b/terraform/tfschema/custom_types.go
@@ -60,8 +60,11 @@ func CopyFromBoolOption(diags diag.Diagnostics, tf attr.Value, o **apitypes.Bool
 		diags.AddError("Error reading from Terraform object", fmt.Sprintf("Can not convert %T to types.Bool", tf))
 		return
 	}
-	value := apitypes.BoolOption{Value: v.Value}
-	*o = &value
+	if !v.Null && !v.Unknown {
+		value := apitypes.BoolOption{Value: v.Value}
+		*o = &value
+		return
+	}
 }
 
 func CopyToBoolOption(diags diag.Diagnostics, o *apitypes.BoolOption, t attr.Type, v attr.Value) attr.Value {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/35947
Closes https://github.com/gravitational/teleport/issues/42432
Closes https://github.com/gravitational/teleport/issues/42429

It looks like if the Terraform value was null, it previously ended up sending `false` rather than null to the Teleport API. This leads to things erroneously being set to false and triggering warnings like:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to module.auth.teleport_provision_token.token,
│ provider
│ "module.auth.provider[\"terraform.releases.teleport.dev/gravitational/teleport\"]"
│ produced an unexpected new value: .spec.gitlab.allow[0].ref_protected: was
│ null, but now cty.False.
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

I tested this change with:
```hcl
resource "teleport_provision_token" "token" {
  metadata = {
    name        = "gitlab-test-terraform"
    description = ""
  }

  spec = {
    roles       = ["Bot"]
    join_method = "gitlab"
    bot_name    = "gitlab-bot"
    gitlab = {
      domain = "bug.report"
      allow = [
        {
          project_path = "my-repo"
        }
      ]
    }
  }
}
```

Followed by:
```hcl
resource "teleport_provision_token" "token" {
  metadata = {
    name        = "gitlab-test-terraform"
    description = ""
  }

  spec = {
    roles       = ["Bot"]
    join_method = "gitlab"
    bot_name    = "gitlab-bot"
    gitlab = {
      domain = "bug.report"
      allow = [
        {
          environment_protected = true
          ref_protected = false
          project_path = "my-repo"
        }
      ]
    }
  }
}
```

I figure that this is potentially a breaking fix ? Surely some folks have run into this with other BoolOptions on other resources and deploying this fix will lead to values being changed when upgrading to this version ? I'd appreciate someone who understands this chiming in here.