### PR TITLE
tf: propagate the next-audit-date from the existing resource

### DIFF
--- a/terraform/example/access_list.tf.example
+++ b/terraform/example/access_list.tf.example
@@ -30,7 +30,10 @@ resource "teleport_access_list" "crane-operation" {
     }
     title = "Crane operation"
     audit = {
-      frequency = "3600h"  // 150 days
+      recurrence = {
+        frequency = 3 # audit every 3 months
+        day_of_month = 15 # audit happen 15's day of the month. Possible values are 1, 15, and 31.
+      }
     }
   }
 }

--- a/terraform/gen/main.go
+++ b/terraform/gen/main.go
@@ -108,7 +108,7 @@ type payload struct {
 	ConvertPackagePath string
 	// PropagatedFields is a list of fields that must be copied from the
 	// existing resource when we're updating it. For example:
-	// "Spec.Audit.NextAuditDate"
+	// "Spec.Audit.NextAuditDate" in AccessList resource
 	PropagatedFields []string
 }
 

--- a/terraform/gen/main.go
+++ b/terraform/gen/main.go
@@ -106,6 +106,10 @@ type payload struct {
 	WithNonce bool
 	// ConvertPackagePath is the path of the package doing the conversion between protobuf and the go types.
 	ConvertPackagePath string
+	// PropagatedFields is a list of fields that must be copied from the
+	// existing resource when we're updating it. For example:
+	// "Spec.Audit.NextAuditDate"
+	PropagatedFields []string
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -416,6 +420,7 @@ var (
 		TerraformResourceType:  "teleport_access_list",
 		ConvertPackagePath:     "github.com/gravitational/teleport/api/types/accesslist/convert/v1",
 		HasCheckAndSetDefaults: true,
+		PropagatedFields:       []string{"Spec.Audit.NextAuditDate"},
 	}
 )
 

--- a/terraform/gen/plural_resource.go.tpl
+++ b/terraform/gen/plural_resource.go.tpl
@@ -305,6 +305,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
 		return
 	}
+	{{- $VarName := .VarName }}
+	{{- range $field := .PropagatedFields }}
+	{{ $VarName }}Resource.{{ $field }} = {{ $VarName }}Before.{{ $field }}
+	{{- end }}
 
 	{{if eq .UpsertMethodArity 2}}_, {{end}}err = r.p.Client.{{.UpdateMethod}}(ctx, {{.VarName}}Resource)
 	if err != nil {

--- a/terraform/gen/singular_resource.go.tpl
+++ b/terraform/gen/singular_resource.go.tpl
@@ -229,6 +229,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+	{{- $VarName := .VarName }}
+	{{- range $field := .PropagatedFields }}
+	{{ $VarName }}.{{ $field }} = {{ $VarName }}Before.{{ $field }}
+	{{- end }}
 
 	{{- if .WithNonce}}
 	{{.VarName}} = {{.VarName}}.WithNonce(math.MaxUint64).(*{{.ProtoPackage}}.{{.TypeName}})

--- a/terraform/provider/resource_teleport_access_list.go
+++ b/terraform/provider/resource_teleport_access_list.go
@@ -231,6 +231,7 @@ func (r resourceTeleportAccessList) Update(ctx context.Context, req tfsdk.Update
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", err, "access_list"))
 		return
 	}
+	accessListResource.Spec.Audit.NextAuditDate = accessListBefore.Spec.Audit.NextAuditDate
 
 	_, err = r.p.Client.AccessListClient().UpsertAccessList(ctx, accessListResource)
 	if err != nil {

--- a/terraform/test/fixtures/access_list_0_create.tf
+++ b/terraform/test/fixtures/access_list_0_create.tf
@@ -27,7 +27,7 @@ resource "teleport_access_list" "test" {
     title = "Hello"
     audit = {
       recurrence = {
-        frequency = 6
+        frequency = 3
       }
     }
   }

--- a/terraform/test/fixtures/access_list_1_update.tf
+++ b/terraform/test/fixtures/access_list_1_update.tf
@@ -30,7 +30,12 @@ resource "teleport_access_list" "test" {
     }
     title = "Hello"
     audit = {
-      frequency = "7200h"
+      recurrence = {
+        frequency = 3
+        // changing day of the month should not change the next audit date
+        // it should take effect after the next review
+        day_of_month = 15
+      }
     }
   }
 }

--- a/terraform/test/fixtures/access_list_2_expiring.tf
+++ b/terraform/test/fixtures/access_list_2_expiring.tf
@@ -32,7 +32,7 @@ resource "teleport_access_list" "test" {
     title = "Hello"
     audit = {
       recurrence = {
-        frequency = 3
+        frequency    = 3
         day_of_month = 15
       }
     }

--- a/terraform/test/fixtures/access_list_2_expiring.tf
+++ b/terraform/test/fixtures/access_list_2_expiring.tf
@@ -31,7 +31,10 @@ resource "teleport_access_list" "test" {
     }
     title = "Hello"
     audit = {
-      frequency = "7200h"
+      recurrence = {
+        frequency = 3
+        day_of_month = 15
+      }
     }
   }
 }

--- a/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -24,6 +24,8 @@ import (
 	math "math"
 
 	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/golang/protobuf/ptypes/duration"
+	_ "github.com/golang/protobuf/ptypes/timestamp"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	_ "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_header_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -34,8 +36,6 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
-	_ "google.golang.org/protobuf/types/known/durationpb"
-	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/terraform/tfschema/devicetrust/v1/device_terraform.go
+++ b/terraform/tfschema/devicetrust/v1/device_terraform.go
@@ -26,6 +26,7 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/golang/protobuf/ptypes/timestamp"
 	github_com_gravitational_teleport_plugins_terraform_tfschema "github.com/gravitational/teleport-plugins/terraform/tfschema"
 	github_com_gravitational_teleport_api_types "github.com/gravitational/teleport/api/types"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
@@ -33,7 +34,6 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
-	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -26,6 +26,7 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/golang/protobuf/ptypes/timestamp"
 	github_com_gravitational_teleport_api_constants "github.com/gravitational/teleport/api/constants"
 	_ "github.com/gravitational/teleport/api/gen/proto/go/attestation/v1"
 	github_com_gravitational_teleport_api_types "github.com/gravitational/teleport/api/types"
@@ -34,7 +35,6 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
-	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Ensure that Terraform honours the accesslist Next Audit Date if it already exists.

After this PR, Terraform will not manage the NextAuditDate anymore (except on first creation), I will document it in the IaC guide. This is the same behaviour as the Teleport Operator.