### PR TITLE
terraform provider does not load `~/.tsh` creds by default

### DIFF
--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -300,7 +300,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	}
 
 	if profileDir != "" || len(creds) == 0 {
-		log.WithField("dir", profileDir).WithField("name", profileName).Debug("Using profile as the default auth method")
+		log.WithFields(log.Fields{
+			"dir":  profileDir,
+			"name": profileName,
+		}).Debug("Using profile as the default auth method")
 		creds = append(creds, client.LoadProfile(profileDir, profileName))
 	}
 

--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -299,8 +299,10 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		creds = append(creds, client.LoadIdentityFileFromString(string(decoded)))
 	}
 
-	log.WithField("dir", profileDir).WithField("name", profileName).Debug("Using profile as the default auth method")
-	creds = append(creds, client.LoadProfile(profileDir, profileName))
+	if profileDir != "" {
+		log.WithField("dir", profileDir).WithField("name", profileName).Debug("Using profile as the default auth method")
+		creds = append(creds, client.LoadProfile(profileDir, profileName))
+	}
 
 	dialTimeoutDuration, err := time.ParseDuration(dialTimeoutDurationStr)
 	if err != nil {

--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -299,7 +299,7 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		creds = append(creds, client.LoadIdentityFileFromString(string(decoded)))
 	}
 
-	if profileDir != "" {
+	if profileDir != "" || len(creds) == 0 {
 		log.WithField("dir", profileDir).WithField("name", profileName).Debug("Using profile as the default auth method")
 		creds = append(creds, client.LoadProfile(profileDir, profileName))
 	}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-plugins/issues/1010