### PR TITLE
fix markdown code block in tf reference

### DIFF
--- a/terraform/gen/referencedocs.go.tpl
+++ b/terraform/gen/referencedocs.go.tpl
@@ -95,7 +95,7 @@ To mitigate this, you should explicitly set the resource version.
   For example, before upgrading from v12 to v13, edit every unversionned role
   to pin the `v5` version:
 
-  ```terraform
+  ```hcl
   resource "teleport_role" "test" {
     version = "v5"
     metadata = {

--- a/terraform/gen/referencedocs.go.tpl
+++ b/terraform/gen/referencedocs.go.tpl
@@ -88,9 +88,9 @@ To mitigate this, you should explicitly set the resource version.
 
   The default role version is the highest supported:
 
-  * v12 default role version is `v5`
-  * v13 default role version is `v6`
-  * v14 default role version is `v7`
+  - v12 default role version is `v5`
+  - v13 default role version is `v6`
+  - v14 default role version is `v7`
 
   For example, before upgrading from v12 to v13, edit every unversioned role
   to pin the `v5` version:

--- a/terraform/gen/referencedocs.go.tpl
+++ b/terraform/gen/referencedocs.go.tpl
@@ -70,7 +70,7 @@ provider "teleport" {
 
 ## Provider resource versioning
 
-Since Teleport 15, you MUST set the version on each resource, and version cannot
+Since Teleport 15, you must set the version on each resource, and version cannot
 be changed in-place. Terraform will delete the resource and create a new one if
 a version change is required.
 
@@ -80,7 +80,7 @@ However, version upgrades don't re-apply the resource defaults. This could lead
 to different results if you create a new resource or upgrade an existing one.
 To mitigate this, you should explicitly set the resource version.
 
-<Adminition type="danger">
+<Adminition type="warning">
   Upgrading the Terraform Provider to a new version with `teleport_role`
   resources without a specified version can change the role behavior and access
   rules. You must set the role version before upgrading to ensure the role

--- a/terraform/gen/referencedocs.go.tpl
+++ b/terraform/gen/referencedocs.go.tpl
@@ -80,7 +80,7 @@ However, version upgrades don't re-apply the resource defaults. This could lead
 to different results if you create a new resource or upgrade an existing one.
 To mitigate this, you should explicitly set the resource version.
 
-<Adminition type="warning">
+<Admonition type="warning">
   Upgrading the Terraform Provider to a new version with `teleport_role`
   resources without a specified version can change the role behavior and access
   rules. You must set the role version before upgrading to ensure the role
@@ -92,7 +92,7 @@ To mitigate this, you should explicitly set the resource version.
   * v13 default role version is `v6`
   * v14 default role version is `v7`
 
-  For example, before upgrading from v12 to v13, edit every unversionned role
+  For example, before upgrading from v12 to v13, edit every unversioned role
   to pin the `v5` version:
 
   ```hcl
@@ -104,7 +104,7 @@ To mitigate this, you should explicitly set the resource version.
     // ...
   }
   ```
-</Adminition>
+</Admonition>
 
 {{range $_, $resource := .resourcesDoc}}
 ## {{$resource.Name}}


### PR DESCRIPTION
small PR to backport fixes I did to the markdown reference in the main teleport repo