### PR TITLE
bump teleport provider min version

### DIFF
--- a/terraform/provider/provider.go
+++ b/terraform/provider/provider.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	// minServerVersion is the minimal teleport version the plugin supports.
-	minServerVersion = "6.1.0-beta.1"
+	minServerVersion = "15.0.0-0"
 )
 
 type RetryConfig struct {


### PR DESCRIPTION
Teleport provider must not connect to old Teleport version as they won't support newer RPCs.

Fixes https://github.com/gravitational/teleport-plugins/issues/1016