### PR TITLE
CI: Update teleport version to 15.2.0

### DIFF
--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -30,13 +30,13 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: '1.5.6'
+          terraform_version: '1.7.5'
           terraform_wrapper: false
 
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 15.0.0-alpha.5
+          version: 15.2.0
           enterprise: true
 
       - name: make test-terraform

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 15.0.0-alpha.5
+          version: 15.2.0
           enterprise: true
 
       - name: Run unit tests

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/peterbourgon/diskv/v3 v3.0.1
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.14.4
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 	golang.org/x/net v0.21.0
@@ -287,7 +287,7 @@ require (
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -364,8 +364,8 @@ replace (
 	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.1.1
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
-	github.com/gravitational/teleport => github.com/gravitational/teleport v0.0.0-20240327020503-fc3b2b31dec6 // ref: tags/v15.1.10
-	github.com/gravitational/teleport/api => github.com/gravitational/teleport/api v0.0.0-20240327020503-fc3b2b31dec6 // ref: tags/v15.1.10
+	github.com/gravitational/teleport => github.com/gravitational/teleport v0.0.0-20240329210410-bb8bd77625f4 // ref: tags/v15.2.0
+	github.com/gravitational/teleport/api => github.com/gravitational/teleport/api v0.0.0-20240329210410-bb8bd77625f4 // ref: tags/v15.2.0
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -609,10 +609,10 @@ github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf h1:MQ4e8X
 github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gravitational/roundtrip v1.0.2 h1:eOCY0NEKKaB0ksJmvhO6lPMFz1pIIef+vyPBTBROQ5c=
 github.com/gravitational/roundtrip v1.0.2/go.mod h1:fuI1booM2hLRA/B/m5MRAPOU6mBZNYcNycono2UuTw0=
-github.com/gravitational/teleport v0.0.0-20240327020503-fc3b2b31dec6 h1:3nHYZlcljAYrvQVbBYTjtltJQDn7y3cF2/khrw2XM9I=
-github.com/gravitational/teleport v0.0.0-20240327020503-fc3b2b31dec6/go.mod h1:jzLyYVmL2JU/8fJUJmhyzqYeCQgmz6Ypq8mP2BgC4fU=
-github.com/gravitational/teleport/api v0.0.0-20240327020503-fc3b2b31dec6 h1:p3oWqebbUx0nx+tEzfswKqkIbH3XVL5dFUJhdmRgIoo=
-github.com/gravitational/teleport/api v0.0.0-20240327020503-fc3b2b31dec6/go.mod h1:TbJnZvy5Q8Ye692yRVQzW5KfnkFRlh3qMd922HAtQ8Q=
+github.com/gravitational/teleport v0.0.0-20240329210410-bb8bd77625f4 h1:g4UswicmiUseh/1mdtTXnSMj1YtoYR+aLvKJNKm4HAk=
+github.com/gravitational/teleport v0.0.0-20240329210410-bb8bd77625f4/go.mod h1:JoZGqhngHo100AlR67nhDRSQhcmrI7XhCLdqDKtTa/4=
+github.com/gravitational/teleport/api v0.0.0-20240329210410-bb8bd77625f4 h1:FGwnoGbq9JDilDU0YHdsUBepOCas4DG2THnbrsMMpmc=
+github.com/gravitational/teleport/api v0.0.0-20240329210410-bb8bd77625f4/go.mod h1:TbJnZvy5Q8Ye692yRVQzW5KfnkFRlh3qMd922HAtQ8Q=
 github.com/gravitational/trace v1.3.1 h1:jwZEuRtCYpLhUtqHo+JH+lu2qM0LB98UagqHtvdKuLI=
 github.com/gravitational/trace v1.3.1/go.mod h1:E61mn73aro7Zg9gZheZaeUsK6gjUMbCLazY76xuYAVA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
@@ -1098,8 +1098,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -1110,8 +1111,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -103,7 +103,7 @@ release: build
 endif
 	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
 
-TERRAFORM_EXISTS := $(shell terraform -version 2>/dev/null | grep 'Terraform v1.5')
+TERRAFORM_EXISTS := $(shell terraform -version 2>/dev/null | grep 'Terraform v1.')
 CURRENT_ULIMIT := $(shell ulimit -n)
 
 .PHONY: test

--- a/terraform/gen/main.go
+++ b/terraform/gen/main.go
@@ -115,6 +115,8 @@ type payload struct {
 	// This is required for some special resources (ServerV2) that support multiple kinds.
 	// For those resources, we must set the kind, and don't want to have the user do it.
 	ForceSetKind string
+	// GetCanReturnNil is used to check for nil returned value when doing a Get<Resource>.
+	GetCanReturnNil bool
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -189,6 +191,7 @@ var (
 		HasStaticID:            true,
 		TerraformResourceType:  "teleport_cluster_maintenance_config",
 		WithNonce:              true,
+		GetCanReturnNil:        true,
 		HasCheckAndSetDefaults: true,
 	}
 
@@ -365,7 +368,7 @@ var (
 		DeleteMethod:          "DeleteLoginRule",
 		ID:                    "loginRule.Metadata.Name",
 		Kind:                  "login_rule",
-		HasStaticID:           false,
+		HasStaticID:           true,
 		ProtoPackage:          "loginrulev1",
 		ProtoPackagePath:      "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1",
 		SchemaPackage:         "schemav1",

--- a/terraform/gen/singular_resource.go.tpl
+++ b/terraform/gen/singular_resource.go.tpl
@@ -93,9 +93,13 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		return
 	}
 
+	{{- if .GetCanReturnNil }}
+
 	if {{.VarName}}Before == nil {
 		{{.VarName}}Before = &{{.ProtoPackage}}.{{.TypeName}}{}
 	}
+
+	{{- end}}
 
 	{{- if .WithNonce}}
 	{{.VarName}} = {{.VarName}}.WithNonce(math.MaxUint64).(*{{.ProtoPackage}}.{{.TypeName}})
@@ -123,16 +127,16 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 			return
 		}
-		if {{.VarName}}Before.GetMetadata().ID != {{.VarName}}I.GetMetadata().ID || {{.HasStaticID}} {
+		if {{.VarName}}Before.GetMetadata().Revision != {{.VarName}}I.GetMetadata().Revision || {{.HasStaticID}} {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(bErr), "{{.Kind}}"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {
 			diagMessage := fmt.Sprintf("Error reading {{.Name}} (tried %d times) - state outdated, please import resource", tries)
-			resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "{{.Kind}}"))
+			resp.Diagnostics.AddError(diagMessage, "{{.Kind}}")
 			return
 		}
 	}
@@ -255,11 +259,11 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 			return
 		}
-		if {{.VarName}}Before.GetMetadata().ID != {{.VarName}}I.GetMetadata().ID || {{.HasStaticID}} {
+		if {{.VarName}}Before.GetMetadata().Revision != {{.VarName}}I.GetMetadata().Revision || {{.HasStaticID}} {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(bErr), "{{.Kind}}"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {

--- a/terraform/provider/resource_teleport_access_list.go
+++ b/terraform/provider/resource_teleport_access_list.go
@@ -116,13 +116,12 @@ func (r resourceTeleportAccessList) Create(ctx context.Context, req tfsdk.Create
 		accessListI, err = r.p.Client.AccessListClient().GetAccessList(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(err), "access_list"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(bErr), "access_list"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading AccessList (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "access_list"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "access_list")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportAccessList) Update(ctx context.Context, req tfsdk.Update
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", err, "access_list"))
 			return
 		}
-		if accessListBefore.GetMetadata().ID != accessListI.GetMetadata().ID || false {
+		if accessListBefore.GetMetadata().Revision != accessListI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_app.go
+++ b/terraform/provider/resource_teleport_app.go
@@ -115,13 +115,12 @@ func (r resourceTeleportApp) Create(ctx context.Context, req tfsdk.CreateResourc
 		appI, err = r.p.Client.GetApp(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(err), "app"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(bErr), "app"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading App (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "app"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "app")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportApp) Update(ctx context.Context, req tfsdk.UpdateResourc
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", err, "app"))
 			return
 		}
-		if appBefore.GetMetadata().ID != appI.GetMetadata().ID || false {
+		if appBefore.GetMetadata().Revision != appI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_auth_preference.go
+++ b/terraform/provider/resource_teleport_auth_preference.go
@@ -86,10 +86,6 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 		return
 	}
 
-	if authPreferenceBefore == nil {
-		authPreferenceBefore = &apitypes.AuthPreferenceV2{}
-	}
-
 	err = r.p.Client.SetAuthPreference(ctx, authPreference)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
@@ -107,16 +103,16 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 			return
 		}
-		if authPreferenceBefore.GetMetadata().ID != authPreferenceI.GetMetadata().ID || false {
+		if authPreferenceBefore.GetMetadata().Revision != authPreferenceI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(bErr), "cluster_auth_preference"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {
 			diagMessage := fmt.Sprintf("Error reading AuthPreference (tried %d times) - state outdated, please import resource", tries)
-			resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "cluster_auth_preference"))
+			resp.Diagnostics.AddError(diagMessage, "cluster_auth_preference")
 			return
 		}
 	}
@@ -227,11 +223,11 @@ func (r resourceTeleportAuthPreference) Update(ctx context.Context, req tfsdk.Up
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 			return
 		}
-		if authPreferenceBefore.GetMetadata().ID != authPreferenceI.GetMetadata().ID || false {
+		if authPreferenceBefore.GetMetadata().Revision != authPreferenceI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(bErr), "cluster_auth_preference"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {

--- a/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -109,16 +109,16 @@ func (r resourceTeleportClusterMaintenanceConfig) Create(ctx context.Context, re
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
 			return
 		}
-		if clusterMaintenanceConfigBefore.GetMetadata().ID != clusterMaintenanceConfigI.GetMetadata().ID || true {
+		if clusterMaintenanceConfigBefore.GetMetadata().Revision != clusterMaintenanceConfigI.GetMetadata().Revision || true {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(bErr), "cluster_maintenance_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {
 			diagMessage := fmt.Sprintf("Error reading ClusterMaintenanceConfig (tried %d times) - state outdated, please import resource", tries)
-			resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "cluster_maintenance_config"))
+			resp.Diagnostics.AddError(diagMessage, "cluster_maintenance_config")
 			return
 		}
 	}
@@ -230,11 +230,11 @@ func (r resourceTeleportClusterMaintenanceConfig) Update(ctx context.Context, re
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
 			return
 		}
-		if clusterMaintenanceConfigBefore.GetMetadata().ID != clusterMaintenanceConfigI.GetMetadata().ID || true {
+		if clusterMaintenanceConfigBefore.GetMetadata().Revision != clusterMaintenanceConfigI.GetMetadata().Revision || true {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(bErr), "cluster_maintenance_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {

--- a/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -86,10 +86,6 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 		return
 	}
 
-	if clusterNetworkingConfigBefore == nil {
-		clusterNetworkingConfigBefore = &apitypes.ClusterNetworkingConfigV2{}
-	}
-
 	err = r.p.Client.SetClusterNetworkingConfig(ctx, clusterNetworkingConfig)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
@@ -107,16 +103,16 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 			return
 		}
-		if clusterNetworkingConfigBefore.GetMetadata().ID != clusterNetworkingConfigI.GetMetadata().ID || false {
+		if clusterNetworkingConfigBefore.GetMetadata().Revision != clusterNetworkingConfigI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(bErr), "cluster_networking_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {
 			diagMessage := fmt.Sprintf("Error reading ClusterNetworkingConfig (tried %d times) - state outdated, please import resource", tries)
-			resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "cluster_networking_config"))
+			resp.Diagnostics.AddError(diagMessage, "cluster_networking_config")
 			return
 		}
 	}
@@ -227,11 +223,11 @@ func (r resourceTeleportClusterNetworkingConfig) Update(ctx context.Context, req
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 			return
 		}
-		if clusterNetworkingConfigBefore.GetMetadata().ID != clusterNetworkingConfigI.GetMetadata().ID || false {
+		if clusterNetworkingConfigBefore.GetMetadata().Revision != clusterNetworkingConfigI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(bErr), "cluster_networking_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {

--- a/terraform/provider/resource_teleport_database.go
+++ b/terraform/provider/resource_teleport_database.go
@@ -115,13 +115,12 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		databaseI, err = r.p.Client.GetDatabase(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(err), "db"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(bErr), "db"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Database (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "db"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "db")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportDatabase) Update(ctx context.Context, req tfsdk.UpdateRe
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", err, "db"))
 			return
 		}
-		if databaseBefore.GetMetadata().ID != databaseI.GetMetadata().ID || false {
+		if databaseBefore.GetMetadata().Revision != databaseI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_device_trust.go
+++ b/terraform/provider/resource_teleport_device_trust.go
@@ -112,13 +112,12 @@ func (r resourceTeleportDeviceV1) Create(ctx context.Context, req tfsdk.CreateRe
 		trustedDeviceI, err = r.p.Client.GetDeviceResource(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(err), "device"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(bErr), "device"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading DeviceV1 (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "device"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "device")
 			}
 			continue
 		}
@@ -237,7 +236,7 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", err, "device"))
 			return
 		}
-		if trustedDeviceBefore.GetMetadata().ID != trustedDeviceI.GetMetadata().ID || true {
+		if trustedDeviceBefore.GetMetadata().Revision != trustedDeviceI.GetMetadata().Revision || true {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_github_connector.go
+++ b/terraform/provider/resource_teleport_github_connector.go
@@ -115,13 +115,12 @@ func (r resourceTeleportGithubConnector) Create(ctx context.Context, req tfsdk.C
 		githubConnectorI, err = r.p.Client.GetGithubConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(err), "github"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(bErr), "github"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading GithubConnector (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "github"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "github")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportGithubConnector) Update(ctx context.Context, req tfsdk.U
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", err, "github"))
 			return
 		}
-		if githubConnectorBefore.GetMetadata().ID != githubConnectorI.GetMetadata().ID || true {
+		if githubConnectorBefore.GetMetadata().Revision != githubConnectorI.GetMetadata().Revision || true {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_login_rule.go
+++ b/terraform/provider/resource_teleport_login_rule.go
@@ -108,13 +108,12 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 		loginRuleI, err = r.p.Client.GetLoginRule(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(err), "login_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(bErr), "login_rule"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading LoginRule (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "login_rule"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "login_rule")
 			}
 			continue
 		}
@@ -233,7 +232,7 @@ func (r resourceTeleportLoginRule) Update(ctx context.Context, req tfsdk.UpdateR
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", err, "login_rule"))
 			return
 		}
-		if loginRuleBefore.GetMetadata().ID != loginRuleI.GetMetadata().ID || false {
+		if loginRuleBefore.GetMetadata().Revision != loginRuleI.GetMetadata().Revision || true {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_oidc_connector.go
+++ b/terraform/provider/resource_teleport_oidc_connector.go
@@ -115,13 +115,12 @@ func (r resourceTeleportOIDCConnector) Create(ctx context.Context, req tfsdk.Cre
 		oidcConnectorI, err = r.p.Client.GetOIDCConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(err), "oidc"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(bErr), "oidc"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading OIDCConnector (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "oidc"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "oidc")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportOIDCConnector) Update(ctx context.Context, req tfsdk.Upd
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", err, "oidc"))
 			return
 		}
-		if oidcConnectorBefore.GetMetadata().ID != oidcConnectorI.GetMetadata().ID || true {
+		if oidcConnectorBefore.GetMetadata().Revision != oidcConnectorI.GetMetadata().Revision || true {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/terraform/provider/resource_teleport_okta_import_rule.go
@@ -115,13 +115,12 @@ func (r resourceTeleportOktaImportRule) Create(ctx context.Context, req tfsdk.Cr
 		oktaImportRuleI, err = r.p.Client.OktaClient().GetOktaImportRule(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(err), "okta_import_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(bErr), "okta_import_rule"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading OktaImportRule (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "okta_import_rule"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "okta_import_rule")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportOktaImportRule) Update(ctx context.Context, req tfsdk.Up
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", err, "okta_import_rule"))
 			return
 		}
-		if oktaImportRuleBefore.GetMetadata().ID != oktaImportRuleI.GetMetadata().ID || false {
+		if oktaImportRuleBefore.GetMetadata().Revision != oktaImportRuleI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_provision_token.go
+++ b/terraform/provider/resource_teleport_provision_token.go
@@ -127,13 +127,12 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		provisionTokenI, err = r.p.Client.GetToken(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(err), "token"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(bErr), "token"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading ProvisionToken (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "token"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "token")
 			}
 			continue
 		}
@@ -261,7 +260,7 @@ func (r resourceTeleportProvisionToken) Update(ctx context.Context, req tfsdk.Up
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", err, "token"))
 			return
 		}
-		if provisionTokenBefore.GetMetadata().ID != provisionTokenI.GetMetadata().ID || false {
+		if provisionTokenBefore.GetMetadata().Revision != provisionTokenI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_role.go
+++ b/terraform/provider/resource_teleport_role.go
@@ -115,13 +115,12 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		roleI, err = r.p.Client.GetRole(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(err), "role"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(bErr), "role"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Role (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "role"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "role")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportRole) Update(ctx context.Context, req tfsdk.UpdateResour
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", err, "role"))
 			return
 		}
-		if roleBefore.GetMetadata().ID != roleI.GetMetadata().ID || false {
+		if roleBefore.GetMetadata().Revision != roleI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_saml_connector.go
+++ b/terraform/provider/resource_teleport_saml_connector.go
@@ -115,13 +115,12 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(bErr), "saml"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading SAMLConnector (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "saml"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "saml")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", err, "saml"))
 			return
 		}
-		if samlConnectorBefore.GetMetadata().ID != samlConnectorI.GetMetadata().ID || true {
+		if samlConnectorBefore.GetMetadata().Revision != samlConnectorI.GetMetadata().Revision || true {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_server.go
+++ b/terraform/provider/resource_teleport_server.go
@@ -117,13 +117,12 @@ func (r resourceTeleportServer) Create(ctx context.Context, req tfsdk.CreateReso
 		serverI, err = r.p.Client.GetNode(ctx, defaults.Namespace, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(err), "node"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(bErr), "node"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Server (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "node"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "node")
 			}
 			continue
 		}
@@ -251,7 +250,7 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", err, "node"))
 			return
 		}
-		if serverBefore.GetMetadata().ID != serverI.GetMetadata().ID || false {
+		if serverBefore.GetMetadata().Revision != serverI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_session_recording_config.go
+++ b/terraform/provider/resource_teleport_session_recording_config.go
@@ -86,10 +86,6 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 		return
 	}
 
-	if sessionRecordingConfigBefore == nil {
-		sessionRecordingConfigBefore = &apitypes.SessionRecordingConfigV2{}
-	}
-
 	err = r.p.Client.SetSessionRecordingConfig(ctx, sessionRecordingConfig)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
@@ -107,16 +103,16 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 			return
 		}
-		if sessionRecordingConfigBefore.GetMetadata().ID != sessionRecordingConfigI.GetMetadata().ID || false {
+		if sessionRecordingConfigBefore.GetMetadata().Revision != sessionRecordingConfigI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(bErr), "session_recording_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {
 			diagMessage := fmt.Sprintf("Error reading SessionRecordingConfig (tried %d times) - state outdated, please import resource", tries)
-			resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "session_recording_config"))
+			resp.Diagnostics.AddError(diagMessage, "session_recording_config")
 			return
 		}
 	}
@@ -227,11 +223,11 @@ func (r resourceTeleportSessionRecordingConfig) Update(ctx context.Context, req 
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 			return
 		}
-		if sessionRecordingConfigBefore.GetMetadata().ID != sessionRecordingConfigI.GetMetadata().ID || false {
+		if sessionRecordingConfigBefore.GetMetadata().Revision != sessionRecordingConfigI.GetMetadata().Revision || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {
-			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(bErr), "session_recording_config"))
 			return
 		}
 		if tries >= r.p.RetryConfig.MaxTries {

--- a/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/terraform/provider/resource_teleport_trusted_cluster.go
@@ -115,13 +115,12 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		trustedClusterI, err = r.p.Client.GetTrustedCluster(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(err), "trusted_cluster"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(bErr), "trusted_cluster"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading TrustedCluster (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "trusted_cluster"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "trusted_cluster")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportTrustedCluster) Update(ctx context.Context, req tfsdk.Up
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", err, "trusted_cluster"))
 			return
 		}
-		if trustedClusterBefore.GetMetadata().ID != trustedClusterI.GetMetadata().ID || false {
+		if trustedClusterBefore.GetMetadata().Revision != trustedClusterI.GetMetadata().Revision || false {
 			break
 		}
 

--- a/terraform/provider/resource_teleport_user.go
+++ b/terraform/provider/resource_teleport_user.go
@@ -115,13 +115,12 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		userI, err = r.p.Client.GetUser(ctx, id, false)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(err), "user"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(bErr), "user"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading User (tried %d times) - state outdated, please import resource", tries)
-				resp.Diagnostics.Append(diagFromWrappedErr(diagMessage, trace.Wrap(err), "user"))
-				return
+				resp.Diagnostics.AddError(diagMessage, "user")
 			}
 			continue
 		}
@@ -249,7 +248,7 @@ func (r resourceTeleportUser) Update(ctx context.Context, req tfsdk.UpdateResour
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", err, "user"))
 			return
 		}
-		if userBefore.GetMetadata().ID != userI.GetMetadata().ID || false {
+		if userBefore.GetMetadata().Revision != userI.GetMetadata().Revision || false {
 			break
 		}
 


### PR DESCRIPTION
Updates Teleport binary used in tests to 15.2.0

This new version of teleport has the following relevant changes:

### Teleport process logging uses `log/slog`
For terraform tests we start a teleport binary and parse its output to understand when the Auth/Proxy service started and what ports are they listening on.
We used a regex for that, but teleport migrated to `log/slog` and the regex no longer works.
Migration PR: https://github.com/gravitational/teleport/pull/38551
We had to fix the regex for integration tests in teleport: https://github.com/gravitational/teleport/pull/39315
Terraform Tests also use that library, so after the regex changed, we must upgrade Teleport CI version to get the new log format.

### Teleport API: `GetClusterNetworkingConfig` and `GetSessionRecordingConfig` never return a nil

When developing the `ClusterMaitenanceConfig` we had to include a nil check, because if it was never configured, `GetClusterMaintenanceConfig` would return a nil object.
This nil check was added to all SingleResource resources.

For `ClusterNetworkingConfig` and `SessionRecordingConfig`, the `Get` operation never returns a nil resource and `staticcheck` linter was yelling about it.
So, we had to create a new flag to ensure we only nil-checked the resources that can actually return a nil value.

### Teleport Resource Metadata
It is no longer recommended to use the `<Resource>.Metadata.ID` to check for cached responses.
We are now using the revision field.

During this change we also detected a miss-usage of an `error` variable and fixed that (could lead to a panic).

LoginRules didn't have the `Revision` field, so we added it here: https://github.com/gravitational/teleport.e/pull/3821

Unfortunately, that PR didn't merge in time for 15.2.0.
However, that's ok because LoginRules are not cached.
So, instead of waiting for a new release (15.2.1), we just removed the cache check.
