### PR TITLE
Relax Terraform provider version re-creation condition

### DIFF
--- a/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/terraform/protoc-gen-terraform-accesslist.yaml
@@ -59,15 +59,6 @@ plan_modifiers:
     Metadata.name:
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
-    # Version MUST NOT change. Due to the way Terraform imports back the resource
-    # in its state (the provider relies on `USeStateForUnknown`) and the fact
-    # Teleport mixes the injected defaults with the original resource, defaults
-    # are set only on resource creation. Upgrading an existing resource will
-    # create a hybrid: a resource with the new version but old defaults.
-    AccessList.header.version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the
 # linter gets mad if we use raw structs instead of pointers).

--- a/terraform/protoc-gen-terraform-devicetrust.yaml
+++ b/terraform/protoc-gen-terraform-devicetrust.yaml
@@ -60,14 +60,6 @@ plan_modifiers:
     # Force to recreate resource if asset tag changes
     "DeviceV1.spec.asset_tag":
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    # Version MUST NOT change. Due to the way Terraform imports back the resource
-    # in its state (the provider relies on `USeStateForUnknown`) and the fact
-    # Teleport mixes the injected defaults with the original resource, defaults
-    # are set only on resource creation. Upgrading an existing resource will
-    # create a hybrid: a resource with the new version but old defaults.
-    DeviceV1.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 
 time_type:

--- a/terraform/protoc-gen-terraform-loginrule.yaml
+++ b/terraform/protoc-gen-terraform-loginrule.yaml
@@ -46,14 +46,6 @@ plan_modifiers:
     # Force to recreate resource if it's name changes
     Metadata.Name:
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    # Version MUST NOT change. Due to the way Terraform imports back the resource
-    # in its state (the provider relies on `USeStateForUnknown`) and the fact
-    # Teleport mixes the injected defaults with the original resource, defaults
-    # are set only on resource creation. Upgrading an existing resource will
-    # create a hybrid: a resource with the new version but old defaults.
-    LoginRule.version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 validators:
   Metadata.Expires:

--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -290,7 +290,7 @@ required_fields:
     - "ProvisionTokenV2.Spec.Roles"
     - "ProvisionTokenV2.Version"
 
-  # Role
+    # Role
     - "RoleV6.Metadata.Name"
     - "RoleV6.Version"
 
@@ -340,51 +340,6 @@ plan_modifiers:
     ProvisionTokenV2.Metadata.Name:
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-
-    # Version MUST NOT change. Due to the way Terraform imports back the resource
-    # in its state (the provider relies on `USeStateForUnknown`) and the fact
-    # Teleport mixes the injected defaults with the original resource, defaults
-    # are set only on resource creation. Upgrading an existing resource will
-    # create a hybrid: a resource with the new version but old defaults.
-    AppV3.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    DatabaseV3.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    GithubConnectorV3.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    OIDCConnectorV3.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    OktaImportRuleV1.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    ProvisionTokenV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    RoleV6.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    SAMLConnectorV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    TrustedClusterV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    UserV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    SessionRecordingConfigV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    ClusterMaintenanceConfigV1.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
-    AuthPreferenceV2.Version:
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
-      - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 validators:
   # Expires must be in the future

--- a/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -94,10 +94,9 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"version": {
-					Description:   "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-					Required:      true,
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					Description: "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
+					Required:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "header is the header for the resource.",

--- a/terraform/tfschema/devicetrust/v1/device_terraform.go
+++ b/terraform/tfschema/devicetrust/v1/device_terraform.go
@@ -127,10 +127,9 @@ func GenSchemaDeviceV1(ctx context.Context) (github_com_hashicorp_terraform_plug
 			Optional:    true,
 		},
 		"version": {
-			Description:   "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description: "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 	}}, nil
 }

--- a/terraform/tfschema/loginrule/v1/loginrule_terraform.go
+++ b/terraform/tfschema/loginrule/v1/loginrule_terraform.go
@@ -113,10 +113,9 @@ func GenSchemaLoginRule(ctx context.Context) (github_com_hashicorp_terraform_plu
 			Optional:    true,
 		},
 		"version": {
-			Description:   "Version is the resource version.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description: "Version is the resource version.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 	}}, nil
 }

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -507,11 +507,10 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v3`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v3`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
 		},
 	}}, nil
 }
@@ -674,11 +673,10 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are:`v3`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
+			Description: "Version is the resource version. It must be specified. Supported values are:`v3`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
 		},
 	}}, nil
 }
@@ -1093,11 +1091,10 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are:`v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Description: "Version is the resource version. It must be specified. Supported values are:`v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
 		},
 	}}, nil
 }
@@ -1332,11 +1329,10 @@ func GenSchemaSessionRecordingConfigV2(ctx context.Context) (github_com_hashicor
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are:`v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Description: "Version is the resource version. It must be specified. Supported values are:`v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
 		},
 	}}, nil
 }
@@ -1565,11 +1561,10 @@ func GenSchemaAuthPreferenceV2(ctx context.Context) (github_com_hashicorp_terraf
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
 		},
 	}}, nil
 }
@@ -2614,11 +2609,10 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v3`, `v4`, `v5`, `v6`, `v7`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 7)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v3`, `v4`, `v5`, `v6`, `v7`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 7)},
 		},
 	}}, nil
 }
@@ -2751,11 +2745,10 @@ func GenSchemaUserV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
 		},
 	}}, nil
 }
@@ -2923,11 +2916,10 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v3`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v3`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
 		},
 	}}, nil
 }
@@ -3132,11 +3124,10 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(2, 2)},
 		},
 	}}, nil
 }
@@ -3293,11 +3284,10 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v3`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
+			Description: "Version is the resource version. It must be specified. Supported values are: `v3`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(3, 3)},
 		},
 	}}, nil
 }
@@ -3413,10 +3403,9 @@ func GenSchemaTrustedClusterV2(ctx context.Context) (github_com_hashicorp_terraf
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the resource version. It must be specified. Supported values are: `v2`.",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description: "Version is the resource version. It must be specified. Supported values are: `v2`.",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 	}}, nil
 }
@@ -3503,11 +3492,10 @@ func GenSchemaClusterMaintenanceConfigV1(ctx context.Context) (github_com_hashic
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(1, 1)},
+			Description: "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(1, 1)},
 		},
 	}}, nil
 }
@@ -3623,11 +3611,10 @@ func GenSchemaOktaImportRuleV1(ctx context.Context) (github_com_hashicorp_terraf
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description:   "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown(), github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
-			Required:      true,
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(1, 1)},
+			Description: "Version is the API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by \"v\". For example: `v1`",
+			Required:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{UseVersionBetween(1, 1)},
 		},
 	}}, nil
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/39638

This PR keeps the mandatory version attribute but does not trigger re-creation when it changes like the v14 provider was doing. We might enable re-creation back in a future version.

Relaxing the re-creation is safe on any non-computed field. So basically every resource but the role with kubernetes_resource set.

This change is required because it's blocking people from upgrading to v15. I will investigate other fixes for the roles with Kubernetes resources attrs.