### PR TITLE
Ensure kube_resources always have the correct defaults, even after version change

### DIFF
--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -340,6 +340,8 @@ plan_modifiers:
     ProvisionTokenV2.Metadata.Name:
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
       - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
+    RoleV6.Spec.Allow.KubernetesResources:
+      - "DefaultRoleKubeResources()"
 
 validators:
   # Expires must be in the future

--- a/terraform/tfschema/role_plan_modifier.go
+++ b/terraform/tfschema/role_plan_modifier.go
@@ -1,0 +1,91 @@
+package tfschema
+
+import (
+	"context"
+	"fmt"
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	DefaultRoleKubeModifierErrSummary  = "DefaultRoleKubeResources modifier failed"
+	DefaultRoleKubeModifierDescription = `This modifier re-render the role.spec.allow.kubernetes_resources from the user provided config instead of using the state.
+The state contains server-generated defaults (in fact they are generated in the pre-apply plan).
+However, those defaults become outdated if the version changes.
+One way to deal with version change is to force-recreate, but this is too destructive.
+The workaround we found was to use this plan modifier.`
+)
+
+func DefaultRoleKubeResources() tfsdk.AttributePlanModifier {
+	return DefaultRoleKubeResourceModifier{}
+}
+
+type DefaultRoleKubeResourceModifier struct {
+}
+
+func (d DefaultRoleKubeResourceModifier) Description(ctx context.Context) string {
+	return DefaultRoleKubeModifierDescription
+}
+
+func (d DefaultRoleKubeResourceModifier) MarkdownDescription(ctx context.Context) string {
+	return DefaultRoleKubeModifierDescription
+}
+
+func (d DefaultRoleKubeResourceModifier) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+	var config tftypes.Object
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to get config.")
+		return
+	}
+
+	role := &apitypes.RoleV6{}
+	diags = CopyRoleV6FromTerraform(ctx, config, role)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to create a role from the config.")
+		return
+	}
+
+	err := role.CheckAndSetDefaults()
+	if err != nil {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, fmt.Sprintf("Failed to set the role defaults: %s", err))
+		return
+	}
+
+	diags = CopyRoleV6ToTerraform(ctx, role, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to convert back the role into a TF Object.")
+		return
+	}
+
+	specRaw, ok := config.Attrs["spec"]
+	if !ok {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to get 'spec' from TF object.")
+		return
+	}
+	spec, ok := specRaw.(tftypes.Object)
+	if !ok {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to cast 'spec' as a TF object.")
+		return
+	}
+	allowRaw, ok := spec.Attrs["allow"]
+	if !ok {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to get 'spec' from TF object.")
+		return
+	}
+	allow, ok := allowRaw.(tftypes.Object)
+	if !ok {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to cast 'allow' as a TF object.")
+		return
+	}
+	kubeResources, ok := allow.Attrs["kubernetes_resources"]
+	if !ok {
+		resp.Diagnostics.AddError(DefaultRoleKubeModifierErrSummary, "Failed to get 'kubernetes_resources' from TF object.")
+		return
+	}
+	resp.AttributePlan = kubeResources
+}

--- a/terraform/tfschema/types_terraform.go
+++ b/terraform/tfschema/types_terraform.go
@@ -1803,7 +1803,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Computed:      true,
 							Description:   "KubernetesResources is the Kubernetes Resources this Role grants access to.",
 							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{DefaultRoleKubeResources()},
 						},
 						"kubernetes_users": {
 							Description: "KubeUsers is an optional kubernetes users to impersonate",


### PR DESCRIPTION
![image](https://github.com/gravitational/teleport-plugins/assets/16366487/bd088878-f5f2-4626-b6d5-d6fd159cf93f)

This PR is required because relaxing the RequireReplace() causes the Kubernetes resource defaults bug to reappear.

For context:
- the kubernetes_resource field can be empty for the user
- the server and provider will set defaults
- TF will get mad if it's not aware that this can happen, we can tell TF by marking the field as "computed"
- When a field is computed, TF will store its result back into the state
- The state is then used for future reconciliations
- If you happen to change the role version, the defaults should change, but TF will not be aware and use the old defaults from the state
- You will have a new role with older defaults, causing inconsistencies and potentially granting too much access

We tried to solve this issue by marking the resource for replacement on version change, but this proved to be super disruptive. Not all resources can be deleted easily. AccessLists contain information about its members, and roles might have dependencies (you cannot delete a role if a user or an AL is referencing it, SSO are dynamic and we cannot remove them with TF).

This PR proposes a more advanced solution. Instead of using the TF state, we re-compute the defaults based on the configuration provided in the TF code. This is done with a Plan modifier.
