### PR TITLE
use the new bot API while keeping a similar behaviour

### DIFF
--- a/terraform/provider/resource_teleport_bot.go
+++ b/terraform/provider/resource_teleport_bot.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/utils"


### PR DESCRIPTION
We removed the old CreateBot RPC on master, the provider doesn't compile anymore.

This PR is a quick fix: it uses the new RPC to create the bot. The long term fix is doing a breaking change and using the new bot resource correctly (generating from protobuf/go structs instead of writing the provider manually).

I need the Terraform provider to compile on master because I want to copy it there to get rid of the `teleport-plugins` repo.