### PR TITLE
Temporarily ignore ProvisionToken.Spec.TPM

### DIFF
--- a/terraform/protoc-gen-terraform-teleport.yaml
+++ b/terraform/protoc-gen-terraform-teleport.yaml
@@ -164,6 +164,9 @@ exclude_fields:
     - "UserSpecV2.CreatedBy"
     - "UserSpecV2.Status"
 
+    # Temporary fix to release 15.2.2
+    - "ProvisionTokenV2.Spec.TPM"
+
 name_overrides:
 
 # These fields will be marked as Computed: true


### PR DESCRIPTION
The new TPM field breaks the protoc code gen. It's unclear why, likely because of the oneof. @strideynet was planning to revert the one_of anyway. In the meantime, we can disable the field to unblock the release process.