### PR TITLE
Drop swallow of `trace.BadParameter` errors in `SearchEvents`

### DIFF
--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -151,26 +151,7 @@ func (t *TeleportEventsWatcher) flipPage() bool {
 func (t *TeleportEventsWatcher) fetch(ctx context.Context) error {
 	log := logger.Get(ctx)
 	b, nextCursor, err := t.getEvents(ctx)
-	// When a trace.BadParameter error is returned, it means that the Teleport event handler
-	// protobuf version is incompatible with the Teleport Auth protobuf version.
-	// This is a fatal error and the event handler should exit because it won't be able to parse the
-	// event that is supported by the newer version of Teleport Auth but not by the
-	// older version of Teleport event handler.
-	// Teleport event handler compatibility is strictly tied to the Teleport Auth version
-	// and it should be updated to the latest version when the Teleport Auth
-	// version is updated. Event handler breaks our compatibility promise of supporting
-	// clients 1 major version behind Auth. We don't support older versions of event handler
-	// with newer versions of Teleport Auth even if they are in the same major version
-	// because we can not guarantee that the handler will be able to parse the events
-	// introduced between minor or patch versions of Teleport Auth.
-	// This is a temporary solution until we have a better way to handle this.
-	if trace.IsBadParameter(err) {
-		return trace.BadParameter(
-			"Teleport event handler version is incompatible with the Teleport Auth version. " +
-				"Please update Teleport event handler to the same version as the Teleport Auth server to resume operations. \n" +
-				authServerVersionMessage(ctx, t.client),
-		)
-	} else if err != nil {
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -359,16 +340,4 @@ func (t *TeleportEventsWatcher) UpsertLock(ctx context.Context, user string, log
 	}
 
 	return t.client.UpsertLock(ctx, lock)
-}
-
-// authServerVersionMessage returns a message to be printed with the auth server
-// and plugin versions if the auth server version is incompatible with the plugin.
-// It returns an empty string if the auth version cannot be determined.
-func authServerVersionMessage(ctx context.Context, client TeleportSearchEventsClient) string {
-	rsp, err := client.Ping(ctx)
-	if err != nil {
-		log.WithError(err).Warn("unable to get auth server version")
-		return ""
-	}
-	return fmt.Sprintf("Auth server version %v; Teleport event handler version %v", rsp.ServerVersion, Version)
 }


### PR DESCRIPTION
This PR removes a temporary error masking that causes troubles if the auth server returns a `trace.BadParameter` error if any parameter is incorrect. This error is no longer required because both server and event-handler already support the new unstructured events endpoints.