### PR TITLE
Event-Handler: Add ability to skip Teleport events

### DIFF
--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -34,6 +34,7 @@ You may specify configuration options via command line arguments, environment va
 | storage                   | Storage directory                                                                                     | FDFWD_STORAGE                   |
 | batch                     | Fetch batch size                                                                                      | FDFWD_BATCH                     |
 | types                     | Comma-separated list of event types to forward                                                        | FDFWD_TYPES                     |
+| skip-event-types              | Comma-separated list of event types to skip                                                           | FDFWD_SKIP_EVENT_TYPES              |
 | skip-session-types        | Comma-separated list of session event types to skip                                                   | FDFWD_SKIP_SESSION_TYPES        |
 | start-time                | Minimum event time (RFC3339 format)                                                                   | FDFWD_START_TIME                |
 | timeout                   | Polling timeout                                                                                       | FDFWD_TIMEOUT                   |

--- a/event-handler/cli.go
+++ b/event-handler/cli.go
@@ -123,6 +123,12 @@ type IngestConfig struct {
 	// Types are event types to log
 	Types []string `help:"Comma-separated list of event types to forward" env:"FDFWD_TYPES"`
 
+	// SkipEventTypesRaw are event types to skip
+	SkipEventTypesRaw []string `name:"skip-event-types" help:"Comma-separated list of event types to skip" env:"FDFWD_SKIP_EVENT_TYPES"`
+
+	// SkipEventTypes is a map generated from SkipEventTypesRaw
+	SkipEventTypes map[string]struct{} `kong:"-"`
+
 	// SkipSessionTypes are session event types to skip
 	SkipSessionTypesRaw []string `name:"skip-session-types" help:"Comma-separated list of session event types to skip" default:"print" env:"FDFWD_SKIP_SESSION_TYPES"`
 
@@ -226,6 +232,7 @@ func (c *StartCmdConfig) Validate() error {
 		return trace.Wrap(err)
 	}
 	c.SkipSessionTypes = lib.SliceToAnonymousMap(c.SkipSessionTypesRaw)
+	c.SkipEventTypes = lib.SliceToAnonymousMap(c.SkipEventTypesRaw)
 
 	return nil
 }
@@ -237,6 +244,7 @@ func (c *StartCmdConfig) Dump(ctx context.Context) {
 	// Log configuration variables
 	log.WithField("batch", c.BatchSize).Info("Using batch size")
 	log.WithField("types", c.Types).Info("Using type filter")
+	log.WithField("skip-event-types", c.SkipEventTypes).Info("Using type exclude filter")
 	log.WithField("types", c.SkipSessionTypes).Info("Skipping session events of type")
 	log.WithField("value", c.StartTime).Info("Using start time")
 	log.WithField("timeout", c.Timeout).Info("Using timeout")

--- a/event-handler/cli_test.go
+++ b/event-handler/cli_test.go
@@ -58,6 +58,7 @@ func TestStartCmdConfig(t *testing.T) {
 				IngestConfig: IngestConfig{
 					StorageDir:          "./storage",
 					BatchSize:           20,
+					SkipEventTypes:      map[string]struct{}{},
 					SkipSessionTypesRaw: []string{"print"},
 					SkipSessionTypes: map[string]struct{}{
 						"print": {},

--- a/event-handler/teleport_events_watcher.go
+++ b/event-handler/teleport_events_watcher.go
@@ -175,7 +175,7 @@ func (t *TeleportEventsWatcher) fetch(ctx context.Context) error {
 	}
 
 	// Zero batch
-	t.batch = make([]*TeleportEvent, len(b))
+	t.batch = make([]*TeleportEvent, 0, len(b))
 
 	// Save next cursor
 	t.nextCursor = nextCursor
@@ -193,13 +193,17 @@ func (t *TeleportEventsWatcher) fetch(ctx context.Context) error {
 	pos := 0
 
 	// Convert batch to TeleportEvent
-	for i, e := range b {
+	for _, e := range b {
+		if _, ok := t.config.SkipEventTypes[e.Type]; ok {
+			log.WithField("event", e).Debug("Skipping event")
+			continue
+		}
 		evt, err := NewTeleportEvent(e, t.cursor)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		t.batch[i] = evt
+		t.batch = append(t.batch, evt)
 	}
 
 	// If last known id is not empty, let's try to find it's pos


### PR DESCRIPTION
This PR adds the ability to skip some audit log events when pushing them to FluentD.