### PR TITLE
Bump `protoc-gen-terraform` version to v2.2.0

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -44,7 +44,7 @@ $(BUILDDIR)/terraform-provider-teleport_%: terraform-provider-teleport-v$(VERSIO
 	mv $(BUILDDIR)/$(OS)/$*/terraform-provider-teleport $@
 
 CUSTOM_IMPORTS_TMP_DIR ?= /tmp/protoc-gen-terraform/custom-imports
-PROTOC_GEN_TERRAFORM_VERSION ?= v2.1.0
+PROTOC_GEN_TERRAFORM_VERSION ?= v2.2.0
 PROTOC_GEN_TERRAFORM_EXISTS := $(shell protoc-gen-terraform version 2>&1 >/dev/null | grep 'protoc-gen-terraform $(PROTOC_GEN_TERRAFORM_VERSION)')
 
 .PHONY: gen-tfschema


### PR DESCRIPTION
After we added support for optionals, we didn't bump the version of this protoc plugin. This means that folks do not get a friendly warning that they need to upgrade their version and instead get a confusing error.

Do not merge until https://github.com/gravitational/protoc-gen-terraform/pull/43 is merged