### PR TITLE
Enables debug logging for eventhandler by config and env variable

### DIFF
--- a/event-handler/cli.go
+++ b/event-handler/cli.go
@@ -55,6 +55,9 @@ type TeleportConfig struct {
 	// TeleportIdentityFile is a path to Teleport identity file
 	TeleportIdentityFile string `help:"Teleport identity file" type:"existingfile" name:"teleport-identity" env:"FDFWD_TELEPORT_IDENTITY"`
 
+	// TeleportDebugEnabled allows for debug logging
+	TeleporDebugEnabled bool `help:"Configures debug logging on" name:"teleport-debug" env:"FDFWD_DEBUG"`
+
 	// TeleportRefreshEnabled will reload the identity file from disk on the
 	// configured interval.
 	TeleportRefreshEnabled bool `help:"Configures the identity file to be reloaded from disk at a configured interval." env:"FDFWD_TELEPORT_REFRESH_ENABLED"`
@@ -210,7 +213,7 @@ type CLI struct {
 	Config kong.ConfigFlag `help:"Path to TOML configuration file" optional:"true" short:"c" type:"existingfile" env:"FDFWD_CONFIG"`
 
 	// Debug is a debug logging mode flag
-	Debug bool `help:"Debug logging" short:"d"`
+	Debug bool `help:"Debug logging" short:"d" env:"FDFWD_DEBUG"`
 
 	// Version is the version print command
 	Version struct{} `cmd:"true" help:"Print plugin version"`

--- a/event-handler/cli_test.go
+++ b/event-handler/cli_test.go
@@ -54,6 +54,7 @@ func TestStartCmdConfig(t *testing.T) {
 					TeleportIdentityFile:    path.Join(wd, "testdata", "fake-file"),
 					TeleportRefreshEnabled:  true,
 					TeleportRefreshInterval: 2 * time.Minute,
+					TeleporDebugEnabled:     false,
 				},
 				IngestConfig: IngestConfig{
 					StorageDir:          "./storage",

--- a/event-handler/main.go
+++ b/event-handler/main.go
@@ -55,11 +55,7 @@ func main() {
 	)
 
 	if cli.Debug {
-		err := logger.Setup(logger.Config{Severity: "debug", Output: "stderr"})
-		if err != nil {
-			fmt.Println(trace.DebugReport(err))
-			os.Exit(-1)
-		}
+		enablelogdebug()
 	}
 
 	switch {
@@ -82,8 +78,24 @@ func main() {
 	}
 }
 
+// turn on log debugging
+func enablelogdebug() {
+	err := logger.Setup(logger.Config{Severity: "debug", Output: "stderr"})
+	if err != nil {
+		fmt.Println(trace.DebugReport(err))
+		os.Exit(-1)
+	}
+
+}
+
 // start spawns the main process
 func start() error {
+
+	if !cli.Debug && cli.Start.TeleportConfig.TeleporDebugEnabled {
+		enablelogdebug()
+
+	}
+
 	app, err := NewApp(&cli.Start)
 	if err != nil {
 		return trace.Wrap(err)

--- a/event-handler/main.go
+++ b/event-handler/main.go
@@ -85,7 +85,6 @@ func enablelogdebug() {
 		fmt.Println(trace.DebugReport(err))
 		os.Exit(-1)
 	}
-
 }
 
 // start spawns the main process
@@ -93,7 +92,6 @@ func start() error {
 
 	if !cli.Debug && cli.Start.TeleportConfig.TeleporDebugEnabled {
 		enablelogdebug()
-
 	}
 
 	app, err := NewApp(&cli.Start)


### PR DESCRIPTION
Provides a debug setting within the Teleport Event handler and the environment variable `FDFWD_DEBUG`.

```toml
[teleport]
addr = "teleport.example.com:443"
identity = "example"
debug = true
```

Will update docs and see about helm update after this is added.
